### PR TITLE
Add Directory.Build.props for portable ClarionRoot configuration

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -155,7 +155,7 @@
       <Link>docs\ClarionAssistant-Guide.html</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Everything32.dll">
+    <Content Include="Everything32.dll" Condition="Exists('Everything32.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -10,11 +10,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Clarion version: 10, 11, or 12 (default). Pass /p:ClarionVersion=10 to build for Clarion 10. -->
-    <ClarionVersion Condition=" '$(ClarionVersion)' == '' ">12</ClarionVersion>
-    <ClarionRoot Condition=" '$(ClarionVersion)' == '12' ">C:\Clarion12</ClarionRoot>
-    <ClarionRoot Condition=" '$(ClarionVersion)' == '11' ">C:\Clarion11-13372</ClarionRoot>
-    <ClarionRoot Condition=" '$(ClarionVersion)' == '10' ">C:\Clarion10</ClarionRoot>
+    <!-- ClarionVersion and ClarionRoot are defined in Directory.Build.props (with .user override support) -->
     <OutputPath Condition=" '$(Configuration)' == 'Debug' ">bin\Debug-C$(ClarionVersion)\</OutputPath>
     <OutputPath Condition=" '$(Configuration)' == 'Release' ">bin\Release-C$(ClarionVersion)\</OutputPath>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,9 @@
     ClarionVersion (10, 11, or 12) selects the default ClarionRoot when no .user override is present.
     Pass /p:ClarionVersion=11 to target a different version.
   -->
+  <!-- Import local developer overrides (gitignored) — must come before defaults so overrides win -->
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.props.user" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.props.user')" />
+
   <PropertyGroup>
     <ClarionVersion Condition="'$(ClarionVersion)' == ''">12</ClarionVersion>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,29 @@
+<Project>
+  <!--
+    ClarionRoot: path to the Clarion IDE installation directory.
+
+    Override options (in priority order):
+      1. Create a Directory.Build.props.user file alongside this one (gitignored) containing:
+           <Project><PropertyGroup><ClarionRoot>C:\YourClarion\bin\..</ClarionRoot></PropertyGroup></Project>
+      2. Pass on the command line: msbuild /p:ClarionRoot=C:\YourClarion
+      3. Default below (John's machine layout — change to match your install if building without a .user file)
+
+    ClarionVersion (10, 11, or 12) selects the default ClarionRoot when no .user override is present.
+    Pass /p:ClarionVersion=11 to target a different version.
+  -->
+  <PropertyGroup>
+    <ClarionVersion Condition="'$(ClarionVersion)' == ''">12</ClarionVersion>
+  </PropertyGroup>
+
+  <!-- Per-version defaults — only applied when ClarionRoot not already set by .user file or command line -->
+  <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '12'">
+    <ClarionRoot>C:\Clarion12</ClarionRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '11'">
+    <ClarionRoot>C:\Clarion11-13372</ClarionRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '10'">
+    <ClarionRoot>C:\Clarion10</ClarionRoot>
+  </PropertyGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -232,26 +232,54 @@ The installer includes 20+ Clarion-specific skills for Claude Code (installed as
 - Clarion IDE (for reference assemblies in `{Clarion}\bin\`)
 - [Inno Setup 6](https://jrsoftware.org/isdownload.php) (for building the installer)
 
+### Configuring your Clarion path
+
+The build uses `Directory.Build.props` at the repo root to locate your Clarion installation. The defaults assume John's machine layout (`C:\Clarion12`, `C:\Clarion11-13372`, `C:\Clarion10`).
+
+If your Clarion is installed elsewhere, create a `Directory.Build.props.user` file alongside `Directory.Build.props` (it is gitignored — never commit it):
+
+```xml
+<Project>
+  <!-- Replace with your actual Clarion installation path -->
+  <PropertyGroup>
+    <ClarionRoot>C:\Clarion\Clarion12</ClarionRoot>
+  </PropertyGroup>
+</Project>
+```
+
+The `.user` file overrides the defaults for all `ClarionVersion` values, so a single path entry is enough if you only build for one version. You can still pass `/p:ClarionVersion=11` on the command line to select the target version.
+
+Alternatively, pass the path directly on the command line without creating a `.user` file:
+
+```powershell
+msbuild ClarionAssistant.csproj /p:ClarionVersion=11 /p:ClarionRoot="C:\Clarion\Clarion11.1"
+```
+
 ### Build
 
 ```powershell
-# Build the addin for all Clarion versions
+# Build for a specific version (uses Directory.Build.props.user if present)
 cd ClarionAssistant
-.\deploy.ps1 -NoBuild:$false -Version all
-
-# Or build for a specific version
 msbuild ClarionAssistant.csproj /p:Configuration=Debug /p:ClarionVersion=12
+
+# Build the addin for all Clarion versions via deploy script
+.\deploy.ps1 -NoBuild:$false -Version all
 ```
+
+> **Note:** Use MSBuild directly — do **not** use `dotnet build`. WebView2 NuGet resolution fails with the .NET CLI on this .NET Framework 4.8 project.
 
 ### Deploy for Development
 
 ```powershell
-# Deploy to your local Clarion IDE (builds + copies)
+# Deploy to your local Clarion IDE (builds + copies DLLs)
 cd ClarionAssistant
 .\deploy.ps1 -Version 12
 
-# Deploy all versions
-.\deploy.ps1 -Version all
+# Deploy without rebuilding (e.g. HTML-only changes)
+.\deploy.ps1 -Version 12 -NoBuild
+
+# Kill the IDE before deploying (when DLLs are locked)
+.\deploy.ps1 -Version 12 -Kill
 ```
 
 ---


### PR DESCRIPTION
## Problem

Building from a fresh clone requires Clarion to be installed at exactly John's paths (\C:\Clarion12\, \C:\Clarion11-13372\, \C:\Clarion10\). Anyone with a different install location gets immediate compile failures because the Clarion IDE reference assemblies can't be found.

## Solution

Add a \Directory.Build.props\ at the repo root that:
- Provides per-version \ClarionRoot\ defaults matching John's layout (no behaviour change for existing builds)
- Supports a gitignored \Directory.Build.props.user\ override for developers with non-standard paths
- Removes the now-duplicate \ClarionVersion\/\ClarionRoot\ property definitions from \ClarionAssistant.csproj\

The \.user\ file pattern is well-established in MSBuild (e.g. \*.csproj.user\) — it's already gitignored via the \*.user\ rule.

Also makes the \Everything32.dll\ content copy conditional on file existence so the build doesn't hard-fail if the VoidTools SDK DLL is absent (fixed separately in #5, but belt-and-suspenders).

## README

Added a 'Configuring your Clarion path' section to the Building from Source docs explaining the \.user\ file and the command-line override alternative.

## Testing

Built successfully on a machine with Clarion at \C:\Clarion\Clarion11.1\ using \Directory.Build.props.user\ override.