### PR TITLE
fix: update EndLineNr after embed write so Save() persists correct content

### DIFF
--- a/ClarionAssistant/Services/AppTreeService.cs
+++ b/ClarionAssistant/Services/AppTreeService.cs
@@ -1144,6 +1144,15 @@ namespace ClarionAssistant.Services
                         caretOffsetProp.SetValue(caret, startOff + indented.Length, null);
                 }
 
+                // Update EndLineNr on the CustomLine to reflect the new line count.
+                // CommonGenEditor.Save() reads document content via StartLineNr..EndLineNr
+                // (not from PweePart.Data), but PWEE does not refresh these after Document.Insert.
+                // Without this fix, Save() slices only the original single-line range and the
+                // embed appears empty on next open — even though the buffer showed the correct text.
+                var endLineNrProp = customLine.GetType().GetProperty("EndLineNr", AllInstance);
+                if (endLineNrProp != null && endLineNrProp.CanWrite)
+                    endLineNrProp.SetValue(customLine, startLine0 + newLineCount - 1, null);
+
                 // Mark the CustomLine and the editor view dirty so save-and-close persists the edit
                 var dirtyField = customLine.GetType().GetField("Dirty", AllInstance);
                 if (dirtyField != null) dirtyField.SetValue(customLine, true);


### PR DESCRIPTION
## Bug

`write_embed_content` appears to succeed but the embed is empty on next open. Verified against Clarion 11.1 and 12.

## Root cause

`CommonGenEditor.Save()` reads embed content from the document buffer using `StartLineNr..EndLineNr` on the `CustomPweeLine`:

```csharp
LineSegment lineSegment  = document.GetLineSegment(customPweeLine.StartLineNr);
LineSegment lineSegment2 = document.GetLineSegment(customPweeLine.EndLineNr);
string text = document.GetText(lineSegment.Offset, lineSegment2.Offset + lineSegment2.Length - lineSegment.Offset);
```

After `Document.Insert` grows a multi-line embed, PWEE does not refresh `EndLineNr` on the `CustomPweeLine`. So `Save()` slices only the original stale line range — discarding all inserted content. The embed visually shows the correct text while the embeditor is open, but is empty after save-close-reopen.

This regression was introduced in the polish commit (3c59a1b) when the write path changed from updating `PweePart.Data` directly to using `Document.Insert/Remove`. The TextArea buffer path is correct for visual editing, but `Save()` does not use the buffer directly — it re-reads via the CustomLine metadata.

## Fix

After inserting the new content, update `EndLineNr` on the `CustomPweeLine` to reflect the new line count so `Save()` reads the correct range.

## Testing

Tested on Clarion 11.1 — embed with multiple existing lines written successfully, content persists correctly after `save_and_close_embeditor`.