### PR TITLE
Add GitHub Copilot CLI as alternative AI backend

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -192,6 +192,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2">
       <Version>1.0.3800.47</Version>
+      <GeneratePathProperty>true</GeneratePathProperty>
     </PackageReference>
   </ItemGroup>
   <Target Name="ValidateClarionReferences" BeforeTargets="ResolveReferences">

--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -52,6 +52,16 @@
       <HintPath>$(ClarionRoot)\bin\ICSharpCode.SharpDevelop.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <!-- Old-style csproj + PackageReference is inconsistent under dotnet/msbuild for this project.
+         Add explicit WebView2 references so compile-time assemblies are always resolved after restore. -->
+    <Reference Include="Microsoft.Web.WebView2.Core">
+      <HintPath>$(PkgMicrosoft_Web_WebView2)\lib\net462\Microsoft.Web.WebView2.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Web.WebView2.WinForms">
+      <HintPath>$(PkgMicrosoft_Web_WebView2)\lib\net462\Microsoft.Web.WebView2.WinForms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AgentPanelPad.cs" />
@@ -108,6 +118,7 @@
     <Compile Include="Terminal\LspStatusBar.cs" />
     <Compile Include="Dialogs\DiagnosticsForm.cs" />
     <Compile Include="Services\ClaudeProcessManager.cs" />
+    <Compile Include="Services\CopilotProcessManager.cs" />
     <Compile Include="TaskLifecycleBoard\TaskLifecycleBoardForm.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <!-- CodeGraph engine (self-contained, no external dependencies) -->
@@ -161,6 +172,9 @@
     <Content Include="Terminal\clarion-assistant-prompt.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Terminal\AGENTS.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Terminal\ca-statusline.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -180,5 +194,13 @@
       <Version>1.0.3800.47</Version>
     </PackageReference>
   </ItemGroup>
+  <Target Name="ValidateClarionReferences" BeforeTargets="ResolveReferences">
+    <Error Condition="'$(ClarionRoot)' == ''"
+           Text="ClarionRoot is not set. Create Directory.Build.props.user or pass /p:ClarionRoot=C:\Path\To\Clarion." />
+    <Error Condition="!Exists('$(ClarionRoot)\bin\ICSharpCode.Core.dll')"
+           Text="Missing Clarion dependency: $(ClarionRoot)\bin\ICSharpCode.Core.dll. Set ClarionRoot to your Clarion installation folder." />
+    <Error Condition="!Exists('$(ClarionRoot)\bin\ICSharpCode.SharpDevelop.dll')"
+           Text="Missing Clarion dependency: $(ClarionRoot)\bin\ICSharpCode.SharpDevelop.dll. Set ClarionRoot to your Clarion installation folder." />
+  </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/ClarionAssistant/ClaudeChatControl.cs
+++ b/ClarionAssistant/ClaudeChatControl.cs
@@ -937,6 +937,7 @@ namespace ClarionAssistant
             {
                 var tab = _tabManager?.ActiveTab;
                 if (tab == null || tab.IsHome || !tab.ClaudeLaunched || tab.Renderer == null) return;
+                if (!string.Equals(tab.AssistantBackend, "Claude", StringComparison.OrdinalIgnoreCase)) return;
 
                 string filePath = Path.Combine(Path.GetTempPath(), "ca-statusline-" + tab.Id + ".json");
                 if (!File.Exists(filePath)) return;
@@ -2332,7 +2333,7 @@ namespace ClarionAssistant
             tab.Renderer.SetFontSize(GetFontSize());
             tab.Renderer.SetFontFamily(GetFontFamily());
             tab.Renderer.FontSizeChangedByUser += OnFontSizeChangedByWheel;
-            LaunchClaudeForTab(tab);
+            LaunchAssistantForTab(tab);
             tab.Renderer.Focus();
         }
 
@@ -2341,11 +2342,21 @@ namespace ClarionAssistant
             _settings.Set("Claude.FontSize", size.ToString());
         }
 
+        private void LaunchAssistantForTab(TerminalTab tab)
+        {
+            string backend = _settings.Get("Assistant.Backend") ?? "Claude";
+            if (string.Equals(backend, "Copilot", StringComparison.OrdinalIgnoreCase))
+                LaunchCopilotForTab(tab);
+            else
+                LaunchClaudeForTab(tab);
+        }
+
         private void LaunchClaudeForTab(TerminalTab tab)
         {
             System.Diagnostics.Debug.WriteLine("[LaunchClaude] ENTER tab=" + tab.Id + ", ClaudeLaunched=" + tab.ClaudeLaunched);
             if (tab.ClaudeLaunched) return;
             tab.ClaudeLaunched = true;
+            tab.AssistantBackend = "Claude";
 
             try
             {
@@ -2497,6 +2508,107 @@ namespace ClarionAssistant
             }
         }
 
+        private void LaunchCopilotForTab(TerminalTab tab)
+        {
+            System.Diagnostics.Debug.WriteLine("[LaunchCopilot] ENTER tab=" + tab.Id + ", ClaudeLaunched=" + tab.ClaudeLaunched);
+            if (tab.ClaudeLaunched) return;
+            tab.ClaudeLaunched = true;
+            tab.AssistantBackend = "Copilot";
+
+            try
+            {
+                tab.Terminal = new ConPtyTerminal();
+                tab.Terminal.DataReceived += data => OnTabTerminalDataReceived(tab, data);
+                tab.Terminal.ProcessExited += (s, ev) => OnTabTerminalProcessExited(tab);
+
+                string pwsh = FindPowerShell(requirePwsh: true);
+                if (string.IsNullOrEmpty(pwsh) || !File.Exists(pwsh))
+                {
+                    UpdateStatus("Copilot requires pwsh.exe");
+                    try
+                    {
+                        MessageBox.Show("GitHub Copilot CLI integration requires PowerShell 7 (pwsh.exe).\n\nInstall PowerShell 7 and try again.",
+                            "Copilot CLI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
+                    catch { }
+                    tab.ClaudeLaunched = false;
+                    return;
+                }
+
+                string workDir = !string.IsNullOrEmpty(tab.WorkingDirectory) && Directory.Exists(tab.WorkingDirectory)
+                    ? tab.WorkingDirectory
+                    : GetWorkingDirectory();
+
+                string copilotHome = GetCopilotHomeDir(tab);
+                string mcpConfig = null;
+                try
+                {
+                    if (_mcpServer != null)
+                        mcpConfig = _mcpServer.WriteMcpConfigFile(copilotHome, Services.McpServer.McpConfigFormat.Copilot);
+                }
+                catch { }
+
+                string instructionsDir = DeployCopilotInstructions(copilotHome);
+
+                string envSetup = "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; [Console]::InputEncoding = [System.Text.Encoding]::UTF8; ";
+                string safeWorkDir = workDir.Replace("'", "''");
+                string safeCopilotHome = copilotHome.Replace("'", "''");
+                string safeInstrDir = (instructionsDir ?? "").Replace("'", "''");
+                string safeMcpConfig = (mcpConfig ?? "").Replace("'", "''");
+
+                string copilotBase = _settings.GetDefaultCopilotCommand();
+                if (copilotBase == "copilot")
+                {
+                    string resolved = Services.CopilotProcessManager.FindCopilotPathStatic();
+                    if (resolved != null)
+                        copilotBase = "& '" + resolved.Replace("'", "''") + "'";
+                }
+
+                string extraFlags = _settings.Get("Copilot.ExtraFlags") ?? "";
+                if (!string.IsNullOrEmpty(extraFlags)) extraFlags = " " + extraFlags.Trim();
+
+                string copilotModelVal = (_settings.Get("Copilot.Model") ?? "").Trim();
+                string modelFlag = string.IsNullOrEmpty(copilotModelVal)
+                    ? string.Empty
+                    : $" --model '{copilotModelVal.Replace("'", "''")}'";
+
+                string permissionMode = (_settings.Get("Copilot.PermissionMode") ?? "prompt").Trim();
+                string permissionFlags = string.Equals(permissionMode, "allow", StringComparison.OrdinalIgnoreCase)
+                    ? " --allow-all-tools"
+                    : string.Empty;
+                string mcpConfigArg = string.IsNullOrEmpty(safeMcpConfig)
+                    ? string.Empty
+                    : $" --additional-mcp-config '@{safeMcpConfig}'";
+
+                // Copilot CLI picks up custom instructions via COPILOT_CUSTOM_INSTRUCTIONS_DIRS.
+                // For MCP, pass the generated config explicitly because `--config-dir`/COPILOT_HOME
+                // did not reliably surface the clarion-assistant server in practice.
+                string cmd =
+                    $"cd '{safeWorkDir}'; " +
+                    "$env:CLARION_ASSISTANT_EMBEDDED='1'; " +
+                    $"$env:COPILOT_HOME='{safeCopilotHome}'; " +
+                    (string.IsNullOrEmpty(safeInstrDir) ? "" : $"$env:COPILOT_CUSTOM_INSTRUCTIONS_DIRS='{safeInstrDir}'; ") +
+                    copilotBase +
+                    $" --config-dir '{safeCopilotHome}'" +
+                    mcpConfigArg +
+                    $" --add-dir '{safeWorkDir}'" +
+                    modelFlag +
+                    permissionFlags +
+                    extraFlags;
+
+                string commandLine = $"\"{pwsh}\" -NoLogo -ExecutionPolicy Bypass -NoExit -Command \"{envSetup}{cmd}\"";
+
+                System.Diagnostics.Debug.WriteLine("[LaunchCopilot] mcpConfig=" + (mcpConfig ?? "(none)") + ", home=" + copilotHome);
+                System.Diagnostics.Debug.WriteLine("[LaunchCopilot] cols=" + tab.Renderer.VisibleCols + ", rows=" + tab.Renderer.VisibleRows);
+                tab.Terminal.Start(tab.Renderer.VisibleCols, tab.Renderer.VisibleRows, commandLine, workDir);
+                UpdateStatus("MCP: port " + (_mcpServer?.Port ?? 0) + " | Copilot CLI running");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[LaunchCopilot] EXCEPTION: " + ex);
+            }
+        }
+
         private void OnTabRendererDataReceived(TerminalTab tab, byte[] data)
         {
             if (tab.Terminal != null && tab.Terminal.IsRunning)
@@ -2566,10 +2678,13 @@ namespace ClarionAssistant
                 catch { }
             }
 
+            string label = string.Equals(tab.AssistantBackend, "Copilot", StringComparison.OrdinalIgnoreCase)
+                ? "Copilot CLI exited"
+                : "Claude Code exited";
             if (InvokeRequired)
-                BeginInvoke((Action)(() => UpdateStatus("Claude Code exited")));
+                BeginInvoke((Action)(() => UpdateStatus(label)));
             else
-                UpdateStatus("Claude Code exited");
+                UpdateStatus(label);
         }
 
         private void OnWorkWithSolution()
@@ -2766,13 +2881,81 @@ namespace ClarionAssistant
             return greeting;
         }
 
-        private string FindPowerShell()
+        private string FindPowerShell(bool requirePwsh = false)
         {
-            string pwsh7 = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-                "PowerShell", "7", "pwsh.exe");
-            if (File.Exists(pwsh7)) return pwsh7;
-            return "powershell.exe";
+            // Clarion loads this addin as an x86 process, so SpecialFolder.ProgramFiles can
+            // resolve to "C:\Program Files (x86)" even when pwsh is installed in the 64-bit path.
+            // Check both standard locations and then fall back to PATH resolution.
+            var candidates = new System.Collections.Generic.List<string>();
+
+            string programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            if (!string.IsNullOrEmpty(programFiles))
+                candidates.Add(Path.Combine(programFiles, "PowerShell", "7", "pwsh.exe"));
+
+            string programW6432 = Environment.GetEnvironmentVariable("ProgramW6432");
+            if (!string.IsNullOrEmpty(programW6432))
+                candidates.Add(Path.Combine(programW6432, "PowerShell", "7", "pwsh.exe"));
+
+            string programFilesEnv = Environment.GetEnvironmentVariable("ProgramFiles");
+            if (!string.IsNullOrEmpty(programFilesEnv))
+                candidates.Add(Path.Combine(programFilesEnv, "PowerShell", "7", "pwsh.exe"));
+
+            foreach (string candidate in candidates)
+            {
+                if (!string.IsNullOrEmpty(candidate) && File.Exists(candidate))
+                    return candidate;
+            }
+
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "where",
+                    Arguments = "pwsh",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true
+                };
+                using (var proc = Process.Start(psi))
+                {
+                    string output = proc.StandardOutput.ReadLine();
+                    proc.WaitForExit(3000);
+                    if (!string.IsNullOrEmpty(output) && File.Exists(output))
+                        return output;
+                }
+            }
+            catch { }
+
+            return requirePwsh ? null : "powershell.exe";
+        }
+
+        private static string GetCopilotHomeDir(TerminalTab tab)
+        {
+            string dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "ClarionAssistant", "copilot", "tab-" + tab.Id);
+            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        private static string DeployCopilotInstructions(string copilotHome)
+        {
+            try
+            {
+                string assemblyDir = Path.GetDirectoryName(
+                    System.Reflection.Assembly.GetExecutingAssembly().Location);
+                string source = Path.Combine(assemblyDir, "Terminal", "AGENTS.md");
+                if (!File.Exists(source)) return null;
+
+                string instrDir = Path.Combine(copilotHome, "instructions");
+                if (!Directory.Exists(instrDir)) Directory.CreateDirectory(instrDir);
+
+                string dest = Path.Combine(instrDir, "AGENTS.md");
+                File.Copy(source, dest, true);
+                return instrDir;
+            }
+            catch { }
+            return null;
         }
 
         private static string GetClarionAssistantPluginPath()

--- a/ClarionAssistant/ClaudeChatControl.cs
+++ b/ClarionAssistant/ClaudeChatControl.cs
@@ -936,7 +936,7 @@ namespace ClarionAssistant
             try
             {
                 var tab = _tabManager?.ActiveTab;
-                if (tab == null || tab.IsHome || !tab.ClaudeLaunched || tab.Renderer == null) return;
+                if (tab == null || tab.IsHome || !tab.AssistantLaunched || tab.Renderer == null) return;
                 if (!string.Equals(tab.AssistantBackend, "Claude", StringComparison.OrdinalIgnoreCase)) return;
 
                 string filePath = Path.Combine(Path.GetTempPath(), "ca-statusline-" + tab.Id + ".json");
@@ -2353,9 +2353,9 @@ namespace ClarionAssistant
 
         private void LaunchClaudeForTab(TerminalTab tab)
         {
-            System.Diagnostics.Debug.WriteLine("[LaunchClaude] ENTER tab=" + tab.Id + ", ClaudeLaunched=" + tab.ClaudeLaunched);
-            if (tab.ClaudeLaunched) return;
-            tab.ClaudeLaunched = true;
+            System.Diagnostics.Debug.WriteLine("[LaunchClaude] ENTER tab=" + tab.Id + ", AssistantLaunched=" + tab.AssistantLaunched);
+            if (tab.AssistantLaunched) return;
+            tab.AssistantLaunched = true;
             tab.AssistantBackend = "Claude";
 
             try
@@ -2510,9 +2510,9 @@ namespace ClarionAssistant
 
         private void LaunchCopilotForTab(TerminalTab tab)
         {
-            System.Diagnostics.Debug.WriteLine("[LaunchCopilot] ENTER tab=" + tab.Id + ", ClaudeLaunched=" + tab.ClaudeLaunched);
-            if (tab.ClaudeLaunched) return;
-            tab.ClaudeLaunched = true;
+            System.Diagnostics.Debug.WriteLine("[LaunchCopilot] ENTER tab=" + tab.Id + ", AssistantLaunched=" + tab.AssistantLaunched);
+            if (tab.AssistantLaunched) return;
+            tab.AssistantLaunched = true;
             tab.AssistantBackend = "Copilot";
 
             try
@@ -2531,7 +2531,10 @@ namespace ClarionAssistant
                             "Copilot CLI", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
                     catch { }
-                    tab.ClaudeLaunched = false;
+                    tab.AssistantLaunched = false;
+                    tab.AssistantBackend = null;
+                    try { if (tab.Terminal != null) tab.Terminal.Dispose(); } catch { }
+                    tab.Terminal = null;
                     return;
                 }
 
@@ -2633,7 +2636,7 @@ namespace ClarionAssistant
                 try
                 {
                     // Skip early output — Claude Code takes several seconds to initialize
-                    if (!tab.ClaudeLaunched) { /* terminal not ready yet */ }
+                    if (!tab.AssistantLaunched) { /* terminal not ready yet */ }
                     else
                     {
                         string text = Encoding.UTF8.GetString(data);
@@ -2670,7 +2673,7 @@ namespace ClarionAssistant
 
         private void OnTabTerminalProcessExited(TerminalTab tab)
         {
-            tab.ClaudeLaunched = false;
+            tab.AssistantLaunched = false;
 
             if (_knowledgeService != null && tab.SessionId > 0)
             {

--- a/ClarionAssistant/Dialogs/ClaudeChatSettingsDialog.cs
+++ b/ClarionAssistant/Dialogs/ClaudeChatSettingsDialog.cs
@@ -243,6 +243,22 @@ namespace ClarionAssistant.Dialogs
             }
             cmdsSb.Append("]");
 
+            // Copilot commands
+            var copilotCommands = _settings.GetCopilotCommands();
+            var copSb = new StringBuilder("[");
+            for (int ci = 0; ci < copilotCommands.Count; ci++)
+            {
+                if (ci > 0) copSb.Append(",");
+                copSb.AppendFormat("{{\"command\":\"{0}\",\"isDefault\":{1}}}",
+                    EscapeJson(copilotCommands[ci].Key), copilotCommands[ci].Value ? "true" : "false");
+            }
+            copSb.Append("]");
+
+            string backend = _settings.Get("Assistant.Backend") ?? "Claude";
+            string copilotModel = _settings.Get("Copilot.Model") ?? "";
+            string copilotPermMode = _settings.Get("Copilot.PermissionMode") ?? "prompt";
+            string copilotExtraFlags = _settings.Get("Copilot.ExtraFlags") ?? "";
+
             var ver = Assembly.GetExecutingAssembly().GetName().Version;
             string displayVersion = ver.Major + "." + ver.Minor;
 
@@ -254,6 +270,7 @@ namespace ClarionAssistant.Dialogs
                 + ",\"model\":\"" + EscapeJson(model) + "\""
                 + ",\"workingDir\":\"" + EscapeJson(workingDir) + "\""
                 + ",\"comFolder\":\"" + EscapeJson(comFolder) + "\""
+                + ",\"assistantBackend\":\"" + EscapeJson(backend) + "\""
                 + ",\"autoUpdate\":" + (autoUpdate ? "true" : "false")
                 + ",\"mtAvailable\":" + (mtAvailable ? "true" : "false")
                 + ",\"mtEnabled\":" + (mtOn ? "true" : "false")
@@ -261,6 +278,11 @@ namespace ClarionAssistant.Dialogs
                 + ",\"libStatus\":\"" + EscapeJson(libStatus) + "\""
                 + ",\"docPaths\":" + docPathsSb
                 + ",\"commands\":" + cmdsSb
+                + ",\"claudeCommands\":" + cmdsSb
+                + ",\"copilotCommands\":" + copSb
+                + ",\"copilotModel\":\"" + EscapeJson(copilotModel) + "\""
+                + ",\"copilotPermissionMode\":\"" + EscapeJson(copilotPermMode) + "\""
+                + ",\"copilotExtraFlags\":\"" + EscapeJson(copilotExtraFlags) + "\""
                 + ",\"classOutputFolder\":\"" + EscapeJson(_settings.Get("Class.OutputFolder") ?? "") + "\""
                 + ",\"classModels\":" + BuildClassModelsJson()
                 + "}}";
@@ -492,6 +514,11 @@ namespace ClarionAssistant.Dialogs
             bool mtEnabled = ExtractJsonValue(data, "mtEnabled") == "true";
             string agentName = ExtractJsonValue(data, "agentName") ?? "ClarionIDE";
 
+            string backend = ExtractJsonValue(data, "assistantBackend") ?? (_settings.Get("Assistant.Backend") ?? "Claude");
+            string copilotModel = ExtractJsonValue(data, "copilotModel") ?? (_settings.Get("Copilot.Model") ?? "");
+            string copilotPermMode = ExtractJsonValue(data, "copilotPermissionMode") ?? (_settings.Get("Copilot.PermissionMode") ?? "prompt");
+            string copilotExtraFlags = ExtractJsonValue(data, "copilotExtraFlags") ?? (_settings.Get("Copilot.ExtraFlags") ?? "");
+
             // Save
             _settings.Set("Theme", theme);
             _settings.Set("Claude.FontFamily", fontFamily);
@@ -503,34 +530,25 @@ namespace ClarionAssistant.Dialogs
             _settings.Set("MultiTerminal.Enabled", mtEnabled.ToString().ToLower());
             _settings.Set("MultiTerminal.AgentName", agentName);
 
+            _settings.Set("Assistant.Backend", backend);
+            _settings.Set("Copilot.Model", copilotModel);
+            _settings.Set("Copilot.PermissionMode", copilotPermMode);
+            _settings.Set("Copilot.ExtraFlags", copilotExtraFlags);
+
             // Class output folder
             string classOutputFolder = ExtractJsonValue(data, "classOutputFolder") ?? "";
             if (!string.IsNullOrEmpty(classOutputFolder))
                 _settings.Set("Class.OutputFolder", classOutputFolder);
 
             // Claude commands
-            string commandsJson = ExtractJsonArray(data, "commands");
-            if (commandsJson != null)
-            {
-                var cmds = new List<KeyValuePair<string, bool>>();
-                // Parse array of {command:"...", isDefault:true/false}
-                int cpos = 0;
-                while (cpos < commandsJson.Length)
-                {
-                    int objStart = commandsJson.IndexOf('{', cpos);
-                    if (objStart < 0) break;
-                    int objEnd = commandsJson.IndexOf('}', objStart);
-                    if (objEnd < 0) break;
-                    string obj = commandsJson.Substring(objStart, objEnd - objStart + 1);
-                    string cmd = ExtractJsonValue(obj, "command");
-                    bool isDef = ExtractJsonValue(obj, "isDefault") == "true";
-                    if (!string.IsNullOrEmpty(cmd))
-                        cmds.Add(new KeyValuePair<string, bool>(cmd, isDef));
-                    cpos = objEnd + 1;
-                }
-                if (cmds.Count > 0)
-                    _settings.SetClaudeCommands(cmds);
-            }
+            // Commands (both backends)
+            var claudeCmds = ParseCommandsArray(ExtractJsonArray(data, "claudeCommands") ?? ExtractJsonArray(data, "commands"));
+            if (claudeCmds != null && claudeCmds.Count > 0)
+                _settings.SetClaudeCommands(claudeCmds);
+
+            var copilotCmds = ParseCommandsArray(ExtractJsonArray(data, "copilotCommands"));
+            if (copilotCmds != null && copilotCmds.Count > 0)
+                _settings.SetCopilotCommands(copilotCmds);
 
             // Doc paths — extract JSON array, detect new paths, trigger ingestion
             string oldPathsStr = _settings.Get("DocGraph.Paths") ?? "";
@@ -571,6 +589,27 @@ namespace ClarionAssistant.Dialogs
 
             SettingsSaved?.Invoke(this);
             Close();
+        }
+
+        private static List<KeyValuePair<string, bool>> ParseCommandsArray(string commandsJson)
+        {
+            if (string.IsNullOrEmpty(commandsJson)) return null;
+            var cmds = new List<KeyValuePair<string, bool>>();
+            int cpos = 0;
+            while (cpos < commandsJson.Length)
+            {
+                int objStart = commandsJson.IndexOf('{', cpos);
+                if (objStart < 0) break;
+                int objEnd = commandsJson.IndexOf('}', objStart);
+                if (objEnd < 0) break;
+                string obj = commandsJson.Substring(objStart, objEnd - objStart + 1);
+                string cmd = ExtractJsonValue(obj, "command");
+                bool isDef = ExtractJsonValue(obj, "isDefault") == "true";
+                if (!string.IsNullOrEmpty(cmd))
+                    cmds.Add(new KeyValuePair<string, bool>(cmd, isDef));
+                cpos = objEnd + 1;
+            }
+            return cmds;
         }
 
         private void BrowseFolder(string target, string description, string initialPath)

--- a/ClarionAssistant/Services/CopilotProcessManager.cs
+++ b/ClarionAssistant/Services/CopilotProcessManager.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Minimal helper for resolving the GitHub Copilot CLI executable.
+    /// Intended for terminal-based launch (ConPTY) where we want a concrete path
+    /// when the user configured a bare "copilot" command.
+    /// </summary>
+    public static class CopilotProcessManager
+    {
+        public static string FindCopilotPathStatic() => FindCopilotPath();
+
+        private static string FindCopilotPath()
+        {
+            string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+            // 1. WinGet link (common for Windows installs)
+            try
+            {
+                string wingetLink = Path.Combine(localAppData, "Microsoft", "WinGet", "Links", "copilot.exe");
+                if (File.Exists(wingetLink)) return wingetLink;
+            }
+            catch { }
+
+            // 2. PATH via where.exe
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "where",
+                    Arguments = "copilot",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true
+                };
+                using (var proc = Process.Start(psi))
+                {
+                    string output = proc.StandardOutput.ReadLine();
+                    proc.WaitForExit(3000);
+                    if (!string.IsNullOrEmpty(output) && File.Exists(output))
+                        return output;
+                }
+            }
+            catch { }
+
+            return null;
+        }
+    }
+}

--- a/ClarionAssistant/Services/McpServer.cs
+++ b/ClarionAssistant/Services/McpServer.cs
@@ -122,20 +122,11 @@ namespace ClarionAssistant.Services
 
         public string GenerateMcpConfig(McpConfigFormat format = McpConfigFormat.Claude)
         {
-            // Build tool list from all registered tools (Claude: autoApprove; Copilot: tools allowlist)
-            var toolNames = new List<string>();
-            foreach (var tool in _toolRegistry.GetToolDefinitions())
-            {
-                var name = tool.ContainsKey("name") ? tool["name"] as string : null;
-                if (!string.IsNullOrEmpty(name))
-                    toolNames.Add("mcp__clarion-assistant__" + name);
-            }
-
             var servers = new Dictionary<string, object>();
             if (format == McpConfigFormat.Copilot)
             {
                 // Copilot MCP schema requires per-server tools allowlist.
-                // Start with tools:["*"] (decided) to avoid name/namespace mismatches early on.
+                // Use ["*"] to avoid name/namespace mismatches with the mcp__clarion-assistant__ prefix.
                 servers["clarion-assistant"] = new Dictionary<string, object>
                 {
                     { "type", "http" },
@@ -145,6 +136,13 @@ namespace ClarionAssistant.Services
             }
             else
             {
+                var toolNames = new List<string>();
+                foreach (var tool in _toolRegistry.GetToolDefinitions())
+                {
+                    var name = tool.ContainsKey("name") ? tool["name"] as string : null;
+                    if (!string.IsNullOrEmpty(name))
+                        toolNames.Add("mcp__clarion-assistant__" + name);
+                }
                 servers["clarion-assistant"] = new Dictionary<string, object>
                 {
                     { "type", "http" },

--- a/ClarionAssistant/Services/McpServer.cs
+++ b/ClarionAssistant/Services/McpServer.cs
@@ -106,6 +106,12 @@ namespace ClarionAssistant.Services
         public bool IncludeMultiTerminal { get; set; }
         public string MultiTerminalMcpPath { get; set; }
 
+        public enum McpConfigFormat
+        {
+            Claude,
+            Copilot
+        }
+
         /// <summary>
         /// True if the multiterminal-channel plugin .mjs file is present on disk.
         /// Set by GenerateMcpConfig when it successfully resolves the path.
@@ -114,9 +120,9 @@ namespace ClarionAssistant.Services
         /// </summary>
         public bool IncludeMultiTerminalChannel { get; private set; }
 
-        public string GenerateMcpConfig()
+        public string GenerateMcpConfig(McpConfigFormat format = McpConfigFormat.Claude)
         {
-            // Build auto-approve list from all registered tools
+            // Build tool list from all registered tools (Claude: autoApprove; Copilot: tools allowlist)
             var toolNames = new List<string>();
             foreach (var tool in _toolRegistry.GetToolDefinitions())
             {
@@ -125,27 +131,39 @@ namespace ClarionAssistant.Services
                     toolNames.Add("mcp__clarion-assistant__" + name);
             }
 
-            var servers = new Dictionary<string, object>
+            var servers = new Dictionary<string, object>();
+            if (format == McpConfigFormat.Copilot)
             {
-                { "clarion-assistant", new Dictionary<string, object>
-                    {
-                        { "type", "http" },
-                        { "url", string.Format("http://localhost:{0}/mcp", _port) },
-                        { "autoApprove", toolNames.ToArray() }
-                    }
-                }
-            };
+                // Copilot MCP schema requires per-server tools allowlist.
+                // Start with tools:["*"] (decided) to avoid name/namespace mismatches early on.
+                servers["clarion-assistant"] = new Dictionary<string, object>
+                {
+                    { "type", "http" },
+                    { "url", string.Format("http://localhost:{0}/mcp", _port) },
+                    { "tools", new string[] { "*" } }
+                };
+            }
+            else
+            {
+                servers["clarion-assistant"] = new Dictionary<string, object>
+                {
+                    { "type", "http" },
+                    { "url", string.Format("http://localhost:{0}/mcp", _port) },
+                    { "autoApprove", toolNames.ToArray() }
+                };
+            }
 
-            // Conditionally add MultiTerminal
-            if (IncludeMultiTerminal && !string.IsNullOrEmpty(MultiTerminalMcpPath)
+            // Conditionally add MultiTerminal (Claude-only for now)
+            if (format == McpConfigFormat.Claude && IncludeMultiTerminal && !string.IsNullOrEmpty(MultiTerminalMcpPath)
                 && File.Exists(MultiTerminalMcpPath))
             {
-                servers["multiterminal"] = new Dictionary<string, object>
+                var mt = new Dictionary<string, object>
                 {
                     { "type", "stdio" },
                     { "command", "node" },
                     { "args", new string[] { MultiTerminalMcpPath } }
                 };
+                servers["multiterminal"] = mt;
             }
 
             // Add the multiterminal-channel MCP server so the embedded Claude receives
@@ -153,7 +171,7 @@ namespace ClarionAssistant.Services
             // and MULTITERMINAL_DOC_ID are exported from LaunchClaudeForTab per tab and
             // inherited by this stdio subprocess. --strict-mcp-config blocks user-level
             // mcpServers entries, so we must include the channel server here explicitly.
-            string channelPath = ResolveMultiTerminalChannelPath();
+            string channelPath = (format == McpConfigFormat.Claude) ? ResolveMultiTerminalChannelPath() : null;
             if (channelPath != null)
             {
                 servers["multiterminal-channel"] = new Dictionary<string, object>
@@ -215,7 +233,17 @@ namespace ClarionAssistant.Services
             if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
 
             string configPath = Path.Combine(dir, "mcp-config.json");
-            File.WriteAllText(configPath, GenerateMcpConfig());
+            File.WriteAllText(configPath, GenerateMcpConfig(McpConfigFormat.Claude));
+            return configPath;
+        }
+
+        public string WriteMcpConfigFile(string directory, McpConfigFormat format)
+        {
+            if (string.IsNullOrEmpty(directory)) throw new ArgumentNullException("directory");
+            if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
+
+            string configPath = Path.Combine(directory, "mcp-config.json");
+            File.WriteAllText(configPath, GenerateMcpConfig(format));
             return configPath;
         }
 

--- a/ClarionAssistant/Services/SettingsService.cs
+++ b/ClarionAssistant/Services/SettingsService.cs
@@ -129,5 +129,66 @@ namespace ClarionAssistant.Services
                 if (kv.Value) return kv.Key;
             return commands.Count > 0 ? commands[0].Key : "claude";
         }
+
+        // ── Copilot Commands ─────────────────────────────────────
+
+        /// <summary>
+        /// Returns the list of configured Copilot launch commands.
+        /// Format in settings.txt: Copilot.Commands = command1|0;command2|1
+        /// where |1 = default.
+        /// </summary>
+        public List<KeyValuePair<string, bool>> GetCopilotCommands()
+        {
+            var result = new List<KeyValuePair<string, bool>>();
+            string raw = Get("Copilot.Commands");
+            if (!string.IsNullOrEmpty(raw))
+            {
+                foreach (string entry in raw.Split(';'))
+                {
+                    if (string.IsNullOrWhiteSpace(entry)) continue;
+                    int pipe = entry.LastIndexOf('|');
+                    if (pipe > 0)
+                    {
+                        string cmd = entry.Substring(0, pipe);
+                        bool isDefault = entry.Substring(pipe + 1) == "1";
+                        result.Add(new KeyValuePair<string, bool>(cmd, isDefault));
+                    }
+                    else
+                    {
+                        result.Add(new KeyValuePair<string, bool>(entry.Trim(), false));
+                    }
+                }
+            }
+
+            if (result.Count == 0)
+            {
+                result.Add(new KeyValuePair<string, bool>("copilot", true));
+                result.Add(new KeyValuePair<string, bool>("gh copilot", false));
+                result.Add(new KeyValuePair<string, bool>("copilot --allow-all-tools", false));
+            }
+
+            return result;
+        }
+
+        public void SetCopilotCommands(List<KeyValuePair<string, bool>> commands)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < commands.Count; i++)
+            {
+                if (i > 0) sb.Append(';');
+                sb.Append(commands[i].Key);
+                sb.Append('|');
+                sb.Append(commands[i].Value ? "1" : "0");
+            }
+            Set("Copilot.Commands", sb.ToString());
+        }
+
+        public string GetDefaultCopilotCommand()
+        {
+            var commands = GetCopilotCommands();
+            foreach (var kv in commands)
+                if (kv.Value) return kv.Key;
+            return commands.Count > 0 ? commands[0].Key : "copilot";
+        }
     }
 }

--- a/ClarionAssistant/Terminal/AGENTS.md
+++ b/ClarionAssistant/Terminal/AGENTS.md
@@ -1,0 +1,19 @@
+# Clarion Assistant (Copilot Instructions)
+
+You are running **inside the Clarion IDE** as an embedded assistant.
+
+## Key behaviors
+- Prefer using the provided MCP tools to interact with the IDE (open files, edit text, list procedures, analyze classes, etc.).
+- Keep responses concise and action-oriented.
+- When the user asks to open/show a file, navigate there rather than describing it.
+
+## Clarion quick reference
+- Comments start with `!`
+- Variables: `Name TYPE` (e.g., `MyVar LONG`)
+- Procedures: `ProcName PROCEDURE(params)`
+- Strings are fixed-length by default: `STRING(100)`
+
+## Domain focus
+- Clarion source code: `.clw`, `.inc`, `.app`, `.txa`
+- Clarion IDE addins (SharpDevelop-based)
+- COM controls for Clarion (Registration-Free COM), typically targeting .NET Framework 4.8

--- a/ClarionAssistant/Terminal/TerminalTab.cs
+++ b/ClarionAssistant/Terminal/TerminalTab.cs
@@ -43,6 +43,12 @@ namespace ClarionAssistant.Terminal
         /// <summary>Whether Claude Code has been launched in this tab.</summary>
         public bool ClaudeLaunched { get; set; }
 
+        /// <summary>
+        /// Backend used for this tab's terminal session (e.g., "Claude" or "Copilot").
+        /// Stored per-tab so existing tabs keep correct exit/status behavior even if settings change.
+        /// </summary>
+        public string AssistantBackend { get; set; }
+
         /// <summary>Skill command to auto-run after Claude starts (e.g. "/ClarionCOM").</summary>
         public string StartupCommand { get; set; }
 

--- a/ClarionAssistant/Terminal/TerminalTab.cs
+++ b/ClarionAssistant/Terminal/TerminalTab.cs
@@ -40,8 +40,8 @@ namespace ClarionAssistant.Terminal
         /// <summary>Knowledge service session ID.</summary>
         public int SessionId { get; set; }
 
-        /// <summary>Whether Claude Code has been launched in this tab.</summary>
-        public bool ClaudeLaunched { get; set; }
+        /// <summary>Whether an AI assistant has been launched in this tab.</summary>
+        public bool AssistantLaunched { get; set; }
 
         /// <summary>
         /// Backend used for this tab's terminal session (e.g., "Claude" or "Copilot").

--- a/ClarionAssistant/Terminal/settings.html
+++ b/ClarionAssistant/Terminal/settings.html
@@ -371,14 +371,39 @@
     <div class="page" id="page-general">
       <h2>General</h2>
 
-      <div class="field">
+      <div class="field" id="claudeModelField">
         <div class="field-label">Claude Model</div>
         <select id="model">
           <option value="sonnet">Sonnet</option>
           <option value="opus">Opus</option>
           <option value="haiku">Haiku</option>
         </select>
-        <div class="field-desc">Model used for new chat sessions.</div>
+        <div class="field-desc">Model used for new Claude sessions.</div>
+      </div>
+
+      <div class="field" id="copilotModelField" style="display:none">
+        <div class="field-label">Copilot Model</div>
+        <select id="copilotModel">
+          <option value="">(default)</option>
+          <optgroup label="GPT">
+            <option value="gpt-5.4">GPT-5.4</option>
+            <option value="gpt-5.4-mini">GPT-5.4 mini</option>
+            <option value="gpt-5.3-codex">GPT-5.3 Codex</option>
+            <option value="gpt-5.2-codex">GPT-5.2 Codex</option>
+            <option value="gpt-5.2">GPT-5.2</option>
+            <option value="gpt-5-mini">GPT-5 mini</option>
+            <option value="gpt-4.1">GPT-4.1</option>
+          </optgroup>
+          <optgroup label="Claude">
+            <option value="claude-sonnet-4.6">Claude Sonnet 4.6</option>
+            <option value="claude-sonnet-4.5">Claude Sonnet 4.5</option>
+            <option value="claude-haiku-4.5">Claude Haiku 4.5</option>
+            <option value="claude-opus-4.6">Claude Opus 4.6</option>
+            <option value="claude-opus-4.5">Claude Opus 4.5</option>
+            <option value="claude-sonnet-4">Claude Sonnet 4</option>
+          </optgroup>
+        </select>
+        <div class="field-desc">Model passed via <code>--model</code> to Copilot CLI.</div>
       </div>
 
       <div class="field">
@@ -441,8 +466,17 @@
     <div class="page" id="page-launch">
       <h2>Launch</h2>
 
-      <h3>Claude Commands</h3>
-      <div class="field-desc" style="margin-bottom:8px">Configure launch commands for Claude Code terminal sessions.</div>
+      <div class="field">
+        <div class="field-label">Assistant Backend</div>
+        <select id="assistantBackend" onchange="onBackendChanged()" style="width:240px">
+          <option value="Claude">Claude</option>
+          <option value="Copilot">Copilot</option>
+        </select>
+        <div class="field-desc">Select which CLI is launched for new terminal sessions.</div>
+      </div>
+
+      <h3 id="cmdTitle">Commands</h3>
+      <div class="field-desc" id="cmdDesc" style="margin-bottom:8px">Configure launch commands for terminal sessions.</div>
       <div class="cmd-table-wrap">
         <table class="cmd-table" id="cmdTable">
           <thead><tr><th>Command</th><th style="text-align:center;width:60px">Default</th></tr></thead>
@@ -456,22 +490,41 @@
         <button class="btn btn-sm" onclick="cmdSetDefault()">Set Default</button>
       </div>
 
-      <h3>Auto-Update</h3>
-      <div class="check-row">
-        <input type="checkbox" id="autoUpdate">
-        <label for="autoUpdate">Run <code>claude update</code> before launching</label>
-      </div>
-      <div class="field-desc" style="margin-top:4px">When enabled, checks for Claude Code updates each time a new terminal session starts.</div>
+      <div id="claudeOnly">
+        <h3>Auto-Update</h3>
+        <div class="check-row">
+          <input type="checkbox" id="autoUpdate">
+          <label for="autoUpdate">Run <code>claude update</code> before launching</label>
+        </div>
+        <div class="field-desc" style="margin-top:4px">When enabled, checks for Claude Code updates each time a new terminal session starts.</div>
 
-      <h3>MultiTerminal</h3>
-      <div class="check-row">
-        <input type="checkbox" id="mtEnabled">
-        <label for="mtEnabled">Enable MultiTerminal connection</label>
-        <span id="mtStatus" class="status status-success" style="margin-left:8px">Detected</span>
+        <h3>MultiTerminal</h3>
+        <div class="check-row">
+          <input type="checkbox" id="mtEnabled">
+          <label for="mtEnabled">Enable MultiTerminal connection</label>
+          <span id="mtStatus" class="status status-success" style="margin-left:8px">Detected</span>
+        </div>
+        <div class="field">
+          <div class="field-label">Agent Name</div>
+          <input type="text" id="agentName" value="ClarionIDE" style="width:200px">
+        </div>
       </div>
-      <div class="field">
-        <div class="field-label">Agent Name</div>
-        <input type="text" id="agentName" value="ClarionIDE" style="width:200px">
+
+      <div id="copilotOnly" style="display:none">
+        <h3>Copilot</h3>
+        <div class="field">
+          <div class="field-label">Permission Mode</div>
+          <select id="copilotPermissionMode" style="width:240px">
+            <option value="prompt">Prompt</option>
+            <option value="allow">Allow Tools</option>
+          </select>
+          <div class="field-desc">`Prompt` asks before tool use. `Allow Tools` passes `--allow-all-tools` for automatic tool approval.</div>
+        </div>
+        <div class="field">
+          <div class="field-label">Extra Flags</div>
+          <input type="text" id="copilotExtraFlags" placeholder="e.g. --verbose">
+          <div class="field-desc">Optional additional flags appended to the Copilot command.</div>
+        </div>
       </div>
     </div>
 
@@ -908,10 +961,42 @@
       send('deleteClassModel', name);
   }
 
-  // ── Claude Commands ──────────────────────────────
-  var _commands = [];   // [{command:'...', isDefault:true/false}, ...]
+  // ── Commands (per backend) ───────────────────────
+  var _assistantBackend = 'Claude';
+  var _claudeCommands = [];   // [{command:'...', isDefault:true/false}, ...]
+  var _copilotCommands = [];  // [{command:'...', isDefault:true/false}, ...]
+  var _commands = [];         // active pointer
   var _cmdSelectedIdx = -1;
   var _cmdEditIdx = -1; // -1 = adding new, >=0 = editing existing
+
+  function onBackendChanged() {
+    setBackend(document.getElementById('assistantBackend').value);
+  }
+
+  function setBackend(backend) {
+    _assistantBackend = backend || 'Claude';
+    var sel = document.getElementById('assistantBackend');
+    if (sel) sel.value = _assistantBackend;
+
+    var claudeOnly = document.getElementById('claudeOnly');
+    var copilotOnly = document.getElementById('copilotOnly');
+    if (claudeOnly) claudeOnly.style.display = (_assistantBackend === 'Claude') ? 'block' : 'none';
+    if (copilotOnly) copilotOnly.style.display = (_assistantBackend === 'Copilot') ? 'block' : 'none';
+
+    var claudeModelField = document.getElementById('claudeModelField');
+    var copilotModelField = document.getElementById('copilotModelField');
+    if (claudeModelField) claudeModelField.style.display = (_assistantBackend === 'Claude') ? 'block' : 'none';
+    if (copilotModelField) copilotModelField.style.display = (_assistantBackend === 'Copilot') ? 'block' : 'none';
+
+    var title = document.getElementById('cmdTitle');
+    var desc = document.getElementById('cmdDesc');
+    if (title) title.textContent = _assistantBackend + ' Commands';
+    if (desc) desc.textContent = 'Configure launch commands for ' + _assistantBackend + ' terminal sessions.';
+
+    _commands = (_assistantBackend === 'Copilot') ? _copilotCommands : _claudeCommands;
+    _cmdSelectedIdx = _commands.length > 0 ? 0 : -1;
+    renderCommands();
+  }
 
   function renderCommands() {
     var tbody = document.getElementById('cmdBody');
@@ -1116,11 +1201,17 @@
       model: document.getElementById('model').value,
       workingDir: document.getElementById('workingDir').value,
       comFolder: document.getElementById('comFolder').value,
+      assistantBackend: _assistantBackend,
       autoUpdate: document.getElementById('autoUpdate').checked,
       mtEnabled: document.getElementById('mtEnabled').checked,
       agentName: document.getElementById('agentName').value,
       docPaths: currentSettings.docPaths || [],
-      commands: _commands,
+      commands: _claudeCommands,
+      claudeCommands: _claudeCommands,
+      copilotCommands: _copilotCommands,
+      copilotModel: (document.getElementById('copilotModel') || {}).value || '',
+      copilotPermissionMode: (document.getElementById('copilotPermissionMode') || {}).value || 'prompt',
+      copilotExtraFlags: (document.getElementById('copilotExtraFlags') || {}).value || '',
       classOutputFolder: document.getElementById('classOutputFolder').value
     };
     send('save', data);
@@ -1181,10 +1272,16 @@
       // Doc paths
       renderDocPaths(s.docPaths || []);
 
-      // Claude Commands
-      _commands = s.commands || [];
-      _cmdSelectedIdx = _commands.length > 0 ? 0 : -1;
-      renderCommands();
+      // Backend + commands
+      _claudeCommands = s.claudeCommands || s.commands || [];
+      _copilotCommands = s.copilotCommands || [];
+      if (document.getElementById('copilotModel'))
+        document.getElementById('copilotModel').value = s.copilotModel || '';
+      if (document.getElementById('copilotPermissionMode'))
+        document.getElementById('copilotPermissionMode').value = s.copilotPermissionMode || 'prompt';
+      if (document.getElementById('copilotExtraFlags'))
+        document.getElementById('copilotExtraFlags').value = s.copilotExtraFlags || '';
+      setBackend(s.assistantBackend || 'Claude');
 
       // Class Models
       _classModels = s.classModels || [];

--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -17,14 +17,29 @@ $MSBuild     = "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\
 
 # Indexer build output (separate project, shares source files with ClarionCodeGraph)
 $IndexerDir    = "H:\DevLaptop\ClarionLSP\indexer"
-$IndexerFile   = Join-Path $IndexerDir "ClarionIndexer.csproj"
-$IndexerOutput = Join-Path $IndexerDir "bin\Debug"
+$IndexerFile   = "$IndexerDir\ClarionIndexer.csproj"
+$IndexerOutput = "$IndexerDir\bin\Debug"
 
 # Version-specific config
 $Versions = @{
-    "12" = @{ Root = "C:\Clarion12";        Output = "bin\Debug-C12" }
-    "11" = @{ Root = "C:\Clarion11-13372";  Output = "bin\Debug-C11" }
-    "10" = @{ Root = @("C:\Clarion10", "C:\Clarion10v8"); Output = "bin\Debug-C10" }
+    "12" = @{ Root = "C:\Clarion12";                           Output = "bin\Debug-C12" }
+    "11" = @{ Root = @("d:\Clarion11.1EE", "C:\Clarion11-13372"); Output = "bin\Debug-C11" }
+    "10" = @{ Root = @("C:\Clarion10", "C:\Clarion10v8");    Output = "bin\Debug-C10" }
+}
+
+function Resolve-BuildOutputDir {
+    param(
+        [string]$ProjectDir,
+        [string]$PreferredOutput
+    )
+
+    $preferred = Join-Path $ProjectDir $PreferredOutput
+    if (Test-Path $preferred) { return $preferred }
+
+    $fallback = Join-Path $ProjectDir "bin\Debug-C"
+    if (Test-Path $fallback) { return $fallback }
+
+    return $preferred
 }
 
 # Which versions to process
@@ -79,11 +94,16 @@ if (-not $NoBuild) {
         Write-Host "Build succeeded for Clarion $ver." -ForegroundColor Green
     }
 
-    Write-Host ""
-    Write-Host "Building indexer..." -ForegroundColor Cyan
-    & $MSBuild $IndexerFile /p:Configuration=Debug /v:minimal
-    if ($LASTEXITCODE -ne 0) { Write-Host "Indexer build failed." -ForegroundColor Red; exit 1 }
-    Write-Host "Indexer build succeeded." -ForegroundColor Green
+    if (Test-Path $IndexerFile) {
+        Write-Host ""
+        Write-Host "Building indexer..." -ForegroundColor Cyan
+        & $MSBuild $IndexerFile /p:Configuration=Debug /v:minimal
+        if ($LASTEXITCODE -ne 0) { Write-Host "Indexer build failed." -ForegroundColor Red; exit 1 }
+        Write-Host "Indexer build succeeded." -ForegroundColor Green
+    } else {
+        Write-Host ""
+        Write-Host "Skipping indexer build (project not found: $IndexerFile)" -ForegroundColor Yellow
+    }
 }
 
 # --- Kill Clarion IDE if requested ---
@@ -99,7 +119,7 @@ if ($Kill) {
 # --- Deploy each version ---
 foreach ($ver in $TargetVersions) {
     $cfg         = $Versions[$ver]
-    $BuildOutput = Join-Path $ProjectDir $cfg.Output
+    $BuildOutput = Resolve-BuildOutputDir -ProjectDir $ProjectDir -PreferredOutput $cfg.Output
 
     # Support single root or array of roots
     $Roots = @($cfg.Root) | ForEach-Object { $_ }
@@ -157,29 +177,33 @@ foreach ($ver in $TargetVersions) {
             "x86"
         )
 
-        foreach ($item in $IndexerItems) {
-            $src = Join-Path $IndexerOutput $item
-            $dst = Join-Path $DeployDir $item
+        if (Test-Path $IndexerOutput) {
+            foreach ($item in $IndexerItems) {
+                $src = "$IndexerOutput\$item"
+                $dst = Join-Path $DeployDir $item
 
-            if (-not (Test-Path $src)) {
-                Write-Host "  SKIP  $item (not found in indexer output)" -ForegroundColor DarkGray
-                continue
-            }
-
-            try {
-                if (Test-Path $src -PathType Container) {
-                    if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
-                    Copy-Item $src $dst -Recurse -Force
-                } else {
-                    Copy-Item $src $dst -Force
+                if (-not (Test-Path $src)) {
+                    Write-Host "  SKIP  $item (not found in indexer output)" -ForegroundColor DarkGray
+                    continue
                 }
-                Write-Host "  OK    $item (indexer)" -ForegroundColor Green
-                $copied++
+
+                try {
+                    if (Test-Path $src -PathType Container) {
+                        if (Test-Path $dst) { Remove-Item $dst -Recurse -Force }
+                        Copy-Item $src $dst -Recurse -Force
+                    } else {
+                        Copy-Item $src $dst -Force
+                    }
+                    Write-Host "  OK    $item (indexer)" -ForegroundColor Green
+                    $copied++
+                }
+                catch {
+                    Write-Host "  FAIL  $item - $($_.Exception.Message)" -ForegroundColor Red
+                    $failed++
+                }
             }
-            catch {
-                Write-Host "  FAIL  $item - $($_.Exception.Message)" -ForegroundColor Red
-                $failed++
-            }
+        } else {
+            Write-Host "  SKIP  indexer output (not found: $IndexerOutput)" -ForegroundColor DarkGray
         }
 
         # --- Deploy SQLite FTS5 DLLs (after indexer, so correct version wins) ---
@@ -211,42 +235,47 @@ foreach ($ver in $TargetVersions) {
         # --- Deploy LSP Server ---
         $LspDestDir = Join-Path $DeployDir "lsp-server"
 
-        # Copy compiled server JS + common shared code
-        foreach ($outDir in @("out\server", "out\common")) {
-            $LspOutSrc = Join-Path $LspSourceDir $outDir
-            if (Test-Path $LspOutSrc) {
-                $LspOutDst = Join-Path $LspDestDir $outDir
-                if (Test-Path $LspOutDst) { Remove-Item $LspOutDst -Recurse -Force }
-                New-Item -Path $LspOutDst -ItemType Directory -Force | Out-Null
-                Copy-Item "$LspOutSrc\*" $LspOutDst -Recurse -Force
-                Write-Host "  OK    lsp-server\$outDir" -ForegroundColor Green
-                $copied++
+        if (Test-Path $LspSourceDir) {
+            # Copy compiled server JS + common shared code
+            foreach ($outDir in @("out\server", "out\common")) {
+                $LspOutSrc = "$LspSourceDir\$outDir"
+                if (Test-Path $LspOutSrc) {
+                    $LspOutDst = Join-Path $LspDestDir $outDir
+                    if (Test-Path $LspOutDst) { Remove-Item $LspOutDst -Recurse -Force }
+                    New-Item -Path $LspOutDst -ItemType Directory -Force | Out-Null
+                    Copy-Item "$LspOutSrc\*" $LspOutDst -Recurse -Force
+                    Write-Host "  OK    lsp-server\$outDir" -ForegroundColor Green
+                    $copied++
+                }
             }
-        }
-        if (-not (Test-Path (Join-Path $LspSourceDir "out\server"))) {
-            Write-Host "  SKIP  lsp-server (ClarionLSP not found)" -ForegroundColor DarkGray
-        }
 
-        # Copy bundled node.exe (so end users don't need Node.js installed)
-        $NodeExeSrc = "C:\Program Files\nodejs\node.exe"
-        if (Test-Path $NodeExeSrc) {
-            Copy-Item $NodeExeSrc (Join-Path $LspDestDir "node.exe") -Force
-            Write-Host "  OK    lsp-server\node.exe" -ForegroundColor Green
-            $copied++
+            if (-not (Test-Path "$LspSourceDir\out\server")) {
+                Write-Host "  SKIP  lsp-server (ClarionLSP build output not found)" -ForegroundColor DarkGray
+            }
+
+            # Copy bundled node.exe (so end users don't need Node.js installed)
+            $NodeExeSrc = "C:\Program Files\nodejs\node.exe"
+            if (Test-Path $NodeExeSrc) {
+                Copy-Item $NodeExeSrc (Join-Path $LspDestDir "node.exe") -Force
+                Write-Host "  OK    lsp-server\node.exe" -ForegroundColor Green
+                $copied++
+            } else {
+                Write-Host "  SKIP  node.exe (not found at $NodeExeSrc)" -ForegroundColor DarkGray
+            }
+
+            # Copy required node_modules
+            foreach ($mod in $LspNodeModules) {
+                $modSrc = "$LspSourceDir\node_modules\$mod"
+                $modDst = Join-Path $LspDestDir "node_modules\$mod"
+                if (Test-Path $modSrc) {
+                    if (Test-Path $modDst) { Remove-Item $modDst -Recurse -Force }
+                    Copy-Item $modSrc $modDst -Recurse -Force
+                    Write-Host "  OK    lsp-server\node_modules\$mod" -ForegroundColor Green
+                    $copied++
+                }
+            }
         } else {
-            Write-Host "  SKIP  node.exe (not found at $NodeExeSrc)" -ForegroundColor DarkGray
-        }
-
-        # Copy required node_modules
-        foreach ($mod in $LspNodeModules) {
-            $modSrc = Join-Path $LspSourceDir "node_modules\$mod"
-            $modDst = Join-Path $LspDestDir "node_modules\$mod"
-            if (Test-Path $modSrc) {
-                if (Test-Path $modDst) { Remove-Item $modDst -Recurse -Force }
-                Copy-Item $modSrc $modDst -Recurse -Force
-                Write-Host "  OK    lsp-server\node_modules\$mod" -ForegroundColor Green
-                $copied++
-            }
+            Write-Host "  SKIP  lsp-server (ClarionLSP not found)" -ForegroundColor DarkGray
         }
 
         # --- Version summary ---

--- a/Directory.Build.props.user.example
+++ b/Directory.Build.props.user.example
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <!-- Point this to your local Clarion installation root, the folder that contains bin\ICSharpCode.Core.dll -->
+    <ClarionRoot>C:\Clarion12</ClarionRoot>
+
+    <!-- Optional: override when targeting a different Clarion version -->
+    <ClarionVersion>12</ClarionVersion>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/peterparker57/ClarionAssistant/releases/latest"><img src="https://img.shields.io/github/v/release/peterparker57/ClarionAssistant?include_prereleases&label=download&style=for-the-badge" alt="Download"></a>
   <img src="https://img.shields.io/badge/Clarion-10%20%7C%2011%20%7C%2012-blue?style=for-the-badge" alt="Clarion 10 | 11 | 12">
-  <img src="https://img.shields.io/badge/version-4.1-green?style=for-the-badge" alt="v4.1">
+  <img src="https://img.shields.io/badge/version-4.2-green?style=for-the-badge" alt="v4.2">
 </p>
 
 ---
@@ -39,6 +39,24 @@ Ask it to write Clarion code, explain procedures, refactor classes, build COM co
 - **Diff viewer** &mdash; Monaco-based side-by-side diffs with syntax highlighting
 - **Knowledge system** &mdash; persistent cross-session memory for decisions, patterns, and gotchas
 - **Zoom persistence** &mdash; Ctrl+mousewheel zoom is saved and restored across sessions
+
+---
+
+## What's New in v4.2
+
+### GitHub Copilot CLI Backend
+- **New Assistant Backend setting** (Settings → Launch) — switch between Claude Code and GitHub Copilot CLI per terminal session
+- **Copilot Commands** — configurable launch commands for Copilot (same Add/Edit/Delete/Set Default UI as Claude commands), with defaults: `copilot`, `gh copilot`, `copilot --allow-all-tools`
+- **Copilot Model selector** (Settings → General) — dropdown with all available Copilot models grouped by provider (GPT-5.x, Claude 4.x); model is passed via `--model` flag at launch
+- **Permission Mode** — choose between `Prompt` (default) or `Allow Tools` (`--allow-all-tools`)
+- **Extra Flags** — optional additional flags appended to the Copilot command
+- **MCP integration** — Clarion Assistant MCP server auto-configured for Copilot with `tools: ["*"]` format; custom instructions deployed via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`
+- **Per-tab backend tracking** — each tab remembers its backend (`AssistantBackend` property) so status bar and exit handling work correctly even if the setting changes mid-session
+
+### Build improvements
+- Explicit WebView2 assembly references in `.csproj` to fix compile-time resolution under MSBuild
+- `ValidateClarionReferences` MSBuild target for clearer error messages when `ClarionRoot` is not set
+- `deploy.ps1` now skips the indexer build gracefully when the project is not present, and supports `d:\Clarion11.1EE` as the primary Clarion 11 path
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Ask it to write Clarion code, explain procedures, refactor classes, build COM co
 ### Build improvements
 - Explicit WebView2 assembly references in `.csproj` to fix compile-time resolution under MSBuild
 - `ValidateClarionReferences` MSBuild target for clearer error messages when `ClarionRoot` is not set
-- `deploy.ps1` now skips the indexer build gracefully when the project is not present, and supports `d:\Clarion11.1EE` as the primary Clarion 11 path
+- `deploy.ps1` now skips the indexer build gracefully when the project is not present
 
 ---
 


### PR DESCRIPTION
This adds GitHub Copilot CLI as a second AI backend alongside Claude Code, selectable per terminal session.

## What's new

- `Assistant.Backend` setting (Claude / Copilot) in Settings → Launch
- Copilot Commands — same Add/Edit/Delete UI as Claude commands; defaults: `copilot`, `gh copilot`, `copilot --allow-all-tools`
- Model selector for Copilot — dropdown passed via `--model` flag
- Permission Mode — Prompt or Allow Tools (`--allow-all-tools`)
- MCP auto-configured for Copilot with `tools: ["*"]` format
- Per-tab backend tracking so status bar works correctly when backend changes mid-session

## How to test

- Switch backend to Copilot in Settings → Launch, open a new tab — Copilot CLI should start
- MCP tools should work from within the Copilot session
- Claude backend should be unaffected