### PR TITLE
Harden pwsh launch path + shared Copilot dir (follow-up to #20)

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Dialogs\DiagnosticsForm.cs" />
     <Compile Include="Services\ClaudeProcessManager.cs" />
     <Compile Include="Services\CopilotProcessManager.cs" />
+    <Compile Include="Services\PwshCommandQuoter.cs" />
     <Compile Include="TaskLifecycleBoard\TaskLifecycleBoardForm.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <!-- CodeGraph engine (self-contained, no external dependencies) -->

--- a/ClarionAssistant/ClaudeChatControl.cs
+++ b/ClarionAssistant/ClaudeChatControl.cs
@@ -2432,14 +2432,32 @@ namespace ClarionAssistant
                 }
 
                 string colorfgbg = _isDarkTheme ? "$env:COLORFGBG='15;0'" : "$env:COLORFGBG='0;15'";
-                string claudeBase = _settings.GetDefaultClaudeCommand();
-                // If the command is bare "claude", resolve to full path so it works
-                // even when the CLI isn't on the inherited PATH
-                if (claudeBase == "claude")
+                // Build the base invocation from the user-selected Claude command.
+                // For bare "claude", resolve to the full path; for anything else,
+                // tokenize and quote so shell metacharacters in settings can't
+                // chain additional commands into the pwsh -Command payload.
+                string claudeCmdRaw = _settings.GetDefaultClaudeCommand();
+                string claudeBase;
+                if (claudeCmdRaw == "claude")
                 {
                     string resolved = Services.ClaudeProcessManager.FindClaudePathStatic();
-                    if (resolved != null)
-                        claudeBase = "& '" + resolved.Replace("'", "''") + "'";
+                    claudeBase = resolved != null
+                        ? "& " + Services.PwshCommandQuoter.QuoteLiteral(resolved)
+                        : "claude";
+                }
+                else
+                {
+                    try
+                    {
+                        claudeBase = Services.PwshCommandQuoter.BuildInvocation(claudeCmdRaw);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        UpdateStatus("Claude launch aborted: " + ex.Message);
+                        tab.AssistantLaunched = false;
+                        tab.AssistantBackend = null;
+                        return;
+                    }
                 }
                 // Set CA tab ID so the statusline script can write per-tab status
                 string tabEnv = $"$env:CLARIONASSISTANT_TAB='{tab.Id}'";
@@ -2559,16 +2577,55 @@ namespace ClarionAssistant
                 string safeInstrDir = (instructionsDir ?? "").Replace("'", "''");
                 string safeMcpConfig = (mcpConfig ?? "").Replace("'", "''");
 
-                string copilotBase = _settings.GetDefaultCopilotCommand();
-                if (copilotBase == "copilot")
+                // Build the base invocation from the user-selected Copilot command.
+                // For bare "copilot", resolve to the full path; for anything else,
+                // tokenize and quote so shell metacharacters in settings can't
+                // chain additional commands into the pwsh -Command payload.
+                string copilotCmdRaw = _settings.GetDefaultCopilotCommand();
+                string copilotBase;
+                if (copilotCmdRaw == "copilot")
                 {
                     string resolved = Services.CopilotProcessManager.FindCopilotPathStatic();
-                    if (resolved != null)
-                        copilotBase = "& '" + resolved.Replace("'", "''") + "'";
+                    copilotBase = resolved != null
+                        ? "& " + Services.PwshCommandQuoter.QuoteLiteral(resolved)
+                        : "copilot";
+                }
+                else
+                {
+                    try
+                    {
+                        copilotBase = Services.PwshCommandQuoter.BuildInvocation(copilotCmdRaw);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        UpdateStatus("Copilot launch aborted: " + ex.Message);
+                        tab.AssistantLaunched = false;
+                        tab.AssistantBackend = null;
+                        try { if (tab.Terminal != null) tab.Terminal.Dispose(); } catch { }
+                        tab.Terminal = null;
+                        return;
+                    }
                 }
 
-                string extraFlags = _settings.Get("Copilot.ExtraFlags") ?? "";
-                if (!string.IsNullOrEmpty(extraFlags)) extraFlags = " " + extraFlags.Trim();
+                // Copilot.ExtraFlags is user-controllable; tokenize + quote each
+                // token so a settings value like "--verbose; Remove-Item ..." can't
+                // break out of the pwsh payload.
+                string extraFlagsRaw = _settings.Get("Copilot.ExtraFlags") ?? "";
+                string extraFlags;
+                try
+                {
+                    string built = Services.PwshCommandQuoter.BuildFlags(extraFlagsRaw);
+                    extraFlags = string.IsNullOrEmpty(built) ? string.Empty : " " + built;
+                }
+                catch (ArgumentException ex)
+                {
+                    UpdateStatus("Copilot launch aborted: " + ex.Message);
+                    tab.AssistantLaunched = false;
+                    tab.AssistantBackend = null;
+                    try { if (tab.Terminal != null) tab.Terminal.Dispose(); } catch { }
+                    tab.Terminal = null;
+                    return;
+                }
 
                 string copilotModelVal = (_settings.Get("Copilot.Model") ?? "").Trim();
                 string modelFlag = string.IsNullOrEmpty(copilotModelVal)

--- a/ClarionAssistant/ClaudeChatControl.cs
+++ b/ClarionAssistant/ClaudeChatControl.cs
@@ -2560,7 +2560,7 @@ namespace ClarionAssistant
                     ? tab.WorkingDirectory
                     : GetWorkingDirectory();
 
-                string copilotHome = GetCopilotHomeDir(tab);
+                string copilotHome = GetCopilotHomeDir();
                 string mcpConfig = null;
                 try
                 {
@@ -2636,6 +2636,10 @@ namespace ClarionAssistant
                 string permissionFlags = string.Equals(permissionMode, "allow", StringComparison.OrdinalIgnoreCase)
                     ? " --allow-all-tools"
                     : string.Empty;
+                // The '@' prefix on the path tells Copilot CLI to load the MCP
+                // config from a file rather than parse the argument as inline
+                // JSON. Copilot's own docs are quiet on this sigil; keep this
+                // comment if a future CLI upgrade changes the convention.
                 string mcpConfigArg = string.IsNullOrEmpty(safeMcpConfig)
                     ? string.Empty
                     : $" --additional-mcp-config '@{safeMcpConfig}'";
@@ -2643,6 +2647,11 @@ namespace ClarionAssistant
                 // Copilot CLI picks up custom instructions via COPILOT_CUSTOM_INSTRUCTIONS_DIRS.
                 // For MCP, pass the generated config explicitly because `--config-dir`/COPILOT_HOME
                 // did not reliably surface the clarion-assistant server in practice.
+                //
+                // Note on the `--add-dir` below: Copilot's CWD already covers workDir
+                // via the preceding `cd`, but `--add-dir` additionally puts the path
+                // on Copilot's allowed-paths list for cross-directory tool operations.
+                // The two are intentionally both set, not redundant.
                 string cmd =
                     $"cd '{safeWorkDir}'; " +
                     "$env:CLARION_ASSISTANT_EMBEDDED='1'; " +
@@ -2989,13 +2998,30 @@ namespace ClarionAssistant
             return requirePwsh ? null : "powershell.exe";
         }
 
-        private static string GetCopilotHomeDir(TerminalTab tab)
+        private static string GetCopilotHomeDir()
         {
-            string dir = Path.Combine(
+            // Shared across all tabs — the mcp-config.json and instructions/AGENTS.md
+            // we write here are launch-identical per-tab, so an earlier per-tab layout
+            // just accumulated orphan directories. Keep it flat.
+            string root = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "ClarionAssistant", "copilot", "tab-" + tab.Id);
-            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-            return dir;
+                "ClarionAssistant", "copilot");
+            if (!Directory.Exists(root)) Directory.CreateDirectory(root);
+
+            // One-shot cleanup of the legacy per-tab layout. Best-effort; ignore
+            // failures (another process might be using a dir, or ACLs might
+            // block removal — not worth blocking the launch over).
+            try
+            {
+                foreach (string legacy in Directory.GetDirectories(root, "tab-*"))
+                {
+                    try { Directory.Delete(legacy, recursive: true); }
+                    catch { }
+                }
+            }
+            catch { }
+
+            return root;
         }
 
         private static string DeployCopilotInstructions(string copilotHome)

--- a/ClarionAssistant/Services/PwshCommandQuoter.cs
+++ b/ClarionAssistant/Services/PwshCommandQuoter.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Builds safe pwsh `-Command` payloads from user-configurable settings.
+    /// The launch path composes a single PowerShell command line that is then
+    /// passed as the `-Command` argument to pwsh.exe. Any user-controlled
+    /// string concatenated into that payload must be tokenized and wrapped
+    /// so shell metacharacters cannot escape into the enclosing context.
+    ///
+    /// Why this class exists: settings values (Claude.Commands, Copilot.Commands,
+    /// Copilot.ExtraFlags) flow from the user's settings.txt into the pwsh
+    /// `-Command` string. Without tokenize-and-quote, a value like
+    /// <c>--verbose; Remove-Item C:\ -Recurse</c> would chain commands.
+    /// </summary>
+    public static class PwshCommandQuoter
+    {
+        /// <summary>
+        /// Wrap a literal string for use inside a pwsh single-quoted literal.
+        /// Doubles any embedded single quote per PowerShell rules.
+        /// Does NOT validate content — caller must ensure no stray <c>"</c>.
+        /// </summary>
+        public static string QuoteLiteral(string s)
+        {
+            return "'" + (s ?? "").Replace("'", "''") + "'";
+        }
+
+        /// <summary>
+        /// Tokenize a user-configured command line (e.g. <c>copilot --allow-all-tools</c>
+        /// or <c>"C:\\Program Files\\gh\\gh.exe" copilot</c>) and rebuild it as
+        /// a pwsh invocation using the call operator <c>&amp;</c> so the first
+        /// token is treated as an executable even when it's a quoted path.
+        /// Each token is wrapped in a pwsh single-quoted literal.
+        /// Throws <see cref="ArgumentException"/> if any token contains a
+        /// double quote (those would escape the outer CreateProcess-parsed
+        /// <c>-Command "..."</c> context and cannot be represented safely here).
+        /// </summary>
+        public static string BuildInvocation(string userCommand)
+        {
+            var tokens = Tokenize(userCommand);
+            if (tokens.Count == 0) return string.Empty;
+            ValidateTokens(tokens, "command");
+            var sb = new StringBuilder();
+            sb.Append("& ");
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                sb.Append(QuoteLiteral(tokens[i]));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Tokenize a user-configured flag string (e.g. <c>--verbose --log-level debug</c>)
+        /// and rebuild it as space-separated pwsh single-quoted literals. No
+        /// call operator is prefixed — the caller appends this to an existing
+        /// invocation. Empty / whitespace-only input returns an empty string.
+        /// </summary>
+        public static string BuildFlags(string userFlags)
+        {
+            var tokens = Tokenize(userFlags);
+            if (tokens.Count == 0) return string.Empty;
+            ValidateTokens(tokens, "flag");
+            var sb = new StringBuilder();
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                if (i > 0) sb.Append(' ');
+                sb.Append(QuoteLiteral(tokens[i]));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Basic shell-style tokenizer: splits on whitespace, honors paired
+        /// single and double quotes as token delimiters (their content is
+        /// preserved, the delimiters are consumed). Does not support escape
+        /// sequences — a literal quote character inside a token is not
+        /// representable and must be handled by the caller's validation.
+        /// </summary>
+        public static List<string> Tokenize(string input)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(input)) return result;
+
+            var cur = new StringBuilder();
+            char? quote = null;
+            foreach (char c in input)
+            {
+                if (quote.HasValue)
+                {
+                    if (c == quote.Value) { quote = null; }
+                    else { cur.Append(c); }
+                }
+                else if (c == '\'' || c == '"')
+                {
+                    quote = c;
+                }
+                else if (char.IsWhiteSpace(c))
+                {
+                    if (cur.Length > 0)
+                    {
+                        result.Add(cur.ToString());
+                        cur.Clear();
+                    }
+                }
+                else
+                {
+                    cur.Append(c);
+                }
+            }
+            if (cur.Length > 0) result.Add(cur.ToString());
+            return result;
+        }
+
+        private static void ValidateTokens(List<string> tokens, string kind)
+        {
+            foreach (string t in tokens)
+            {
+                if (t.IndexOf('"') >= 0)
+                {
+                    throw new ArgumentException(
+                        "Settings " + kind + " token contains a literal double-quote character, " +
+                        "which cannot be safely represented inside the pwsh -Command payload: [" + t + "]");
+                }
+            }
+        }
+    }
+}

--- a/ClarionAssistant/Services/SettingsService.cs
+++ b/ClarionAssistant/Services/SettingsService.cs
@@ -27,6 +27,18 @@ namespace ClarionAssistant.Services
         public void Set(string key, string value)
         {
             if (string.IsNullOrEmpty(key)) return;
+            // Reject CR/LF in values: the file format is line-based (key=value\n),
+            // so a value containing a newline would smuggle an additional key on
+            // reload (e.g. sneaking Copilot.PermissionMode=allow onto disk via a
+            // crafted ExtraFlags value).
+            if (value != null && (value.IndexOf('\r') >= 0 || value.IndexOf('\n') >= 0))
+                throw new ArgumentException(
+                    "Setting values cannot contain newline characters.", "value");
+            // Reject CR/LF in keys too, for symmetry and to prevent a crafted
+            // key from escaping onto its own line.
+            if (key.IndexOf('\r') >= 0 || key.IndexOf('\n') >= 0 || key.IndexOf('=') >= 0)
+                throw new ArgumentException(
+                    "Setting keys cannot contain newline or '=' characters.", "key");
             _settings[key] = value ?? "";
             Save();
         }


### PR DESCRIPTION
## Summary

Follow-up hotfix to #20. Two commits, landing the items I flagged during review of the Copilot backend PR.

### Commit 1 — Security hardening
- Adds `Services/PwshCommandQuoter.cs` with tokenize-and-quote helpers (`QuoteLiteral`, `BuildInvocation`, `BuildFlags`, `Tokenize`). Honors paired `'`/`"` as delimiters; rejects tokens containing `"` (those would escape the outer CreateProcess-parsed `-Command "..."` context).
- Applies the quoter to both `LaunchClaudeForTab.claudeBase` and `LaunchCopilotForTab.copilotBase` + `Copilot.ExtraFlags`. A settings value like `--verbose; Remove-Item C:\ -Recurse -Force` no longer chains arbitrary pwsh. On validation failure the launch aborts cleanly with a status-bar message.
- `SettingsService.Set` now rejects `\r`/`\n` in values and `\r`/`\n`/`=` in keys — the file format is line-based (`key=value\n`), so an embedded newline would smuggle a second key on the next save (e.g. sneaking `Copilot.PermissionMode=allow` via a crafted `ExtraFlags` value).

Threat model: exploiting any of these paths requires local write to `%AppData%\ClarionAssistant\settings.txt`. Not remotely reachable. Same shape existed on the Claude side pre-#20; we harden both.

### Commit 2 — Cleanup
- Collapsed `%AppData%\ClarionAssistant\copilot\tab-<id>\` into a single shared `copilot\` directory. Contents (mcp-config.json + instructions/AGENTS.md) were launch-identical per tab; the per-tab layout just accumulated orphan dirs on every IDE restart.
- Legacy `tab-*` dirs swept on first call, best-effort.
- Two clarifying comments in `LaunchCopilotForTab`: the `'@<path>'` sigil on `--additional-mcp-config` means "load from file" (undocumented in Copilot CLI README); the `cd` + `--add-dir` pair is intentional (CWD vs allowed-paths list), not redundant.

## Test plan

- [x] Build passes under MSBuild Debug-C12
- [x] Manual smoke test: Claude tab launches, Copilot tab launches, MCP tool round-trip works (confirmed via `query_docs` on Claude side, Copilot side round-trips errors through MCP correctly)
- [x] Settings dialog Save path unaffected (existing settings.txt parses clean, 26 rows)
- [ ] `Copilot.ExtraFlags = "--verbose; Remove-Item C:\ -Recurse"` — quoter now tokenizes+quotes; attempt doesn't chain (not needed to execute since we reject by design)

## Out of scope (separate follow-ups)

- MCP HTTP server `Access-Control-Allow-Origin: *` with no auth token — widest blast radius item, pre-existing, deserves its own PR
- `ClaudeChatControl` → `AssistantChatControl` rename
- Extract shared launch scaffolding between Claude/Copilot launch methods before adding a 3rd backend
- Merge `Terminal/AGENTS.md` with `Terminal/clarion-assistant-prompt.md` so the two don't drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)