### PR TITLE
Merge mcp-extra.json sidecar into per-tab mcp-config (issue #26)

### DIFF
--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -2666,6 +2666,15 @@ namespace ClarionAssistant
             // via mcp-config — prefix is different than when loaded as a plugin.
             if (_mcpServer != null && _mcpServer.IncludeMultiTerminalChannel)
                 allowedTools += ",mcp__multiterminal-channel__*";
+            // Auto-approve user-supplied MCP servers merged in from mcp-extra.json
+            if (_mcpServer != null && _mcpServer.ExtraMcpServerNames != null)
+            {
+                foreach (var name in _mcpServer.ExtraMcpServerNames)
+                {
+                    if (!string.IsNullOrEmpty(name))
+                        allowedTools += ",mcp__" + name + "__*";
+                }
+            }
 
             string pluginArg = "";
             string pluginDir = GetClarionAssistantPluginPath();

--- a/ClarionAssistant/Services/McpServer.cs
+++ b/ClarionAssistant/Services/McpServer.cs
@@ -277,6 +277,15 @@ namespace ClarionAssistant.Services
         /// </summary>
         public bool IncludeMultiTerminalChannel { get; private set; }
 
+        /// <summary>
+        /// Names of user-supplied MCP servers merged in from
+        /// <c>%APPDATA%\ClarionAssistant\mcp-extra.json</c> by the last
+        /// GenerateMcpConfig call (Claude format). AssistantChatControl reads
+        /// this to append <c>mcp__&lt;name&gt;__*</c> patterns to --allowedTools
+        /// so the user's servers auto-approve like the built-ins.
+        /// </summary>
+        public List<string> ExtraMcpServerNames { get; private set; } = new List<string>();
+
         public string GenerateMcpConfig(McpConfigFormat format = McpConfigFormat.Claude)
         {
             // Both Claude and Copilot MCP client configs accept a `headers` map
@@ -360,6 +369,52 @@ namespace ClarionAssistant.Services
             else
             {
                 IncludeMultiTerminalChannel = false;
+            }
+
+            // Merge user-supplied MCP servers from
+            // %APPDATA%\ClarionAssistant\mcp-extra.json. Claude format only —
+            // Copilot's schema differs and needs separate handling.
+            ExtraMcpServerNames = new List<string>();
+            if (format == McpConfigFormat.Claude)
+            {
+                try
+                {
+                    string sidecar = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                        "ClarionAssistant", "mcp-extra.json");
+                    if (File.Exists(sidecar))
+                    {
+                        string raw = File.ReadAllText(sidecar);
+                        var parsed = McpJsonRpc.Deserialize(raw);
+                        object entriesObj;
+                        if (parsed != null && parsed.TryGetValue("mcpServers", out entriesObj))
+                        {
+                            var entries = entriesObj as Dictionary<string, object>;
+                            if (entries != null)
+                            {
+                                foreach (var kv in entries)
+                                {
+                                    if (string.IsNullOrEmpty(kv.Key)) continue;
+                                    if (servers.ContainsKey(kv.Key))
+                                    {
+                                        System.Diagnostics.Debug.WriteLine(
+                                            "[McpServer] mcp-extra.json: skipping reserved key '" + kv.Key + "'");
+                                        continue;
+                                    }
+                                    servers[kv.Key] = kv.Value;
+                                    ExtraMcpServerNames.Add(kv.Key);
+                                    System.Diagnostics.Debug.WriteLine(
+                                        "[McpServer] mcp-extra.json: merged server '" + kv.Key + "'");
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        "[McpServer] mcp-extra.json merge failed (ignored): " + ex.Message);
+                }
             }
 
             return McpJsonRpc.Serialize(new Dictionary<string, object>


### PR DESCRIPTION
## Summary

Implements the `mcp-extra.json` sidecar merge that the v4.6.0 release notes describe but that was never wired up in source — v4.6.0 only bumped the version manifest and README; no source-side code change accompanied it. Result: any `mcp-extra.json` placed under `%APPDATA%\ClarionAssistant\` is read by nothing today, and `--strict-mcp-config` on the in-IDE tab launch prevents Claude Code from picking it up via its own user-level config path either.

This PR makes the README accurate.

### `McpServer.GenerateMcpConfig` (Claude format only)

- Reads `%APPDATA%\ClarionAssistant\mcp-extra.json` on every call.
- Parses the top-level `mcpServers` map via the existing `McpJsonRpc.Deserialize` — no new JSON dependency.
- Merges every entry whose key doesn't collide with a built-in (`clarion-assistant`, `multiterminal`, `multiterminal-channel`). Reserved keys are silently skipped per the README contract.
- Records merged keys on a new `ExtraMcpServerNames` property for the launcher to consume.
- Malformed JSON, missing file, and IO failure are logged via `Debug.WriteLine` and ignored. A broken sidecar can never block a tab from launching.

### `AssistantChatControl` tab launch

For every merged server, appends `mcp__<name>__*` to `--allowedTools` so user-supplied tools auto-approve like the three built-ins do.

### Out of scope

Copilot format isn't touched — its MCP schema differs and warrants its own pass. The Settings → MCP "Open" button the README also describes is also a separate piece of work; users who already have an `mcp-extra.json` (e.g. created by hand or by external tooling) work without it.

## Test plan

- [x] Place an `mcp-extra.json` under `%APPDATA%\ClarionAssistant\` with a single stdio entry (e.g. `iconvectors`), open a Claude tab, run `/mcp` — server is listed alongside the three built-ins.
- [x] Reserved-key collision: add an `mcp-extra.json` entry keyed `clarion-assistant` — the addin's entry wins, sidecar entry is silently dropped (Debug log confirms skip).
- [x] Malformed sidecar (trailing comma): tab still launches with just the built-ins; Debug log captures the parse failure.
- [x] Missing sidecar: behavior identical to pre-patch (just the built-ins).
- [x] Tools from the merged server auto-approve on first use inside the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)