### PR TITLE
deploy.ps1: auto-discover MSBuild instead of hardcoding VS2022 path

### DIFF
--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -11,9 +11,32 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Locate MSBuild.exe without hardcoding a Visual Studio version/edition.
+# Order: vswhere (covers VS 2019/2022/18+, any edition) -> common install paths.
+function Resolve-MSBuild {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $found = & $vswhere -latest -requires Microsoft.Component.MSBuild `
+                            -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+        if ($found -and (Test-Path $found)) { return $found }
+    }
+
+    # Fallback: scan known roots if vswhere is unavailable.
+    foreach ($root in @($env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+        if (-not $root) { continue }
+        $candidate = Get-ChildItem -Path (Join-Path $root "Microsoft Visual Studio") `
+                        -Filter MSBuild.exe -Recurse -ErrorAction SilentlyContinue |
+                        Where-Object { $_.FullName -match "\\Current\\Bin\\MSBuild\.exe$" } |
+                        Select-Object -First 1
+        if ($candidate) { return $candidate.FullName }
+    }
+
+    throw "MSBuild.exe not found. Install Visual Studio with the MSBuild component, or set `$MSBuild manually."
+}
+
 $ProjectDir  = $PSScriptRoot
 $ProjectFile = Join-Path $ProjectDir "ClarionAssistant.csproj"
-$MSBuild     = "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
+$MSBuild     = Resolve-MSBuild
 
 # Indexer build output (separate project, shares source files with ClarionCodeGraph)
 $IndexerDir    = "H:\DevLaptop\ClarionLSP\indexer"


### PR DESCRIPTION
## Problem

`ClarionAssistant/deploy.ps1` hardcodes the MSBuild path to VS 2022 Community:

```powershell
$MSBuild = "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
```

This breaks the deploy on any machine that doesn't have that exact edition/version — e.g. VS 2019, Professional/Enterprise editions, or the newer VS "18" line where MSBuild lives under `...\Visual Studio\18\Community\...`. The script fails immediately at the build step with a path-not-found error.

## Fix

Replace the literal path with a `Resolve-MSBuild` function that:

1. Queries `vswhere -latest -requires Microsoft.Component.MSBuild` — covers any installed VS edition/version.
2. Falls back to scanning Program Files for `Current\Bin\MSBuild.exe` if `vswhere` is unavailable.
3. Throws a clear, actionable error if MSBuild genuinely can't be found.

No behavior change on machines that already worked; it just stops assuming a single hardcoded location.

## Testing

Verified `Resolve-MSBuild` resolves correctly on a machine where the old hardcoded path does **not** exist — it located MSBuild under `...\Visual Studio\18\Community\...` via vswhere, and `deploy.ps1 -Version 12` built `ClarionAssistant.dll` with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)