### PR TITLE
feat(mcp): add apply_embed_edits for crash-free edits to large procedures

### DIFF
--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -980,6 +980,58 @@ Use this tool to discover IDE APIs and understand what's available for automatio
                 }
             });
 
+            Register(new McpTool
+            {
+                Name = "apply_embed_edits",
+                Description = "Apply one or more embed-slot edits to a procedure in a SINGLE transient " +
+                    "open->write->save->close round-trip — NO interactive embeditor session stays open. " +
+                    "Prefer this over open_procedure_embed + write_embed_content for LARGE procedures where the " +
+                    "live PWEE editor is unstable under repeated interactive driving (it reuses the proven Modern " +
+                    "Embeditor save path). 'edits' is a JSON array of {\"line_number\":N,\"code\":\"...\"}: line_number " +
+                    "is the 1-based «E:N» slot start (from get_embeditor_source/search_embeditor_source), code is the " +
+                    "COMPLETE replacement for that slot (end with a trailing newline). Edits are applied bottom-to-top. " +
+                    "If ANY line_number is not a current embed-slot start, NOTHING is written. The procedure is opened, " +
+                    "written, saved and closed automatically — do NOT wrap this in open_procedure_embed / " +
+                    "save_and_close_embeditor.",
+                InputSchema = McpJsonRpc.BuildSchema(new Dictionary<string, string>
+                {
+                    { "procedure_name", "Name of the procedure to edit." },
+                    { "edits", "JSON array of edits: [{\"line_number\":123,\"code\":\"...full slot code...\\n\"}]. " +
+                               "line_number = 1-based «E:N» slot start; code = complete replacement for that slot." }
+                }, new[] { "procedure_name", "edits" }),
+                RequiresUiThread = true,
+                Handler = args =>
+                {
+                    string proc = McpJsonRpc.GetString(args, "procedure_name");
+                    if (string.IsNullOrWhiteSpace(proc)) return "Error: procedure_name is required.";
+                    string editsJson = McpJsonRpc.GetString(args, "edits");
+                    if (string.IsNullOrWhiteSpace(editsJson))
+                        return "Error: edits is required (JSON array of {line_number, code}).";
+
+                    var parsed = new List<KeyValuePair<int, string>>();
+                    try
+                    {
+                        var ser = new JavaScriptSerializer { MaxJsonLength = int.MaxValue };
+                        var arr = ser.DeserializeObject(editsJson) as object[];
+                        if (arr == null) return "Error: edits must be a JSON array of {line_number, code}.";
+                        foreach (var item in arr)
+                        {
+                            var d = item as Dictionary<string, object>;
+                            if (d == null) return "Error: each edit must be an object {line_number, code}.";
+                            int ln = 0;
+                            if (d.ContainsKey("line_number")) int.TryParse(Convert.ToString(d["line_number"]), out ln);
+                            if (ln <= 0) return "Error: every edit needs a positive line_number.";
+                            string code = (d.ContainsKey("code") && d["code"] != null) ? d["code"].ToString() : "";
+                            parsed.Add(new KeyValuePair<int, string>(ln, code));
+                        }
+                    }
+                    catch (Exception ex) { return "Error parsing edits JSON: " + ex.Message; }
+
+                    bool ok;
+                    return ModernEmbeditorSaver.ApplyLineEdits(proc, parsed, out ok);
+                }
+            });
+
             // === TXA Export/Import Tools ===
 
             Register(new McpTool

--- a/ClarionAssistant/Services/ModernEmbeditorSaver.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorSaver.cs
@@ -129,6 +129,85 @@ namespace ClarionAssistant.Services
             }
         }
 
+        /// <summary>
+        /// Apply explicit per-slot edits to a procedure in ONE transient open-&gt;write-&gt;save-&gt;close round-trip,
+        /// with NO interactive embeditor session left open. Robust for very large procedures where the live PWEE
+        /// editor is unstable under repeated interactive driving (this reuses the proven Modern Embeditor save
+        /// path: OpenAndMirror -&gt; WriteEmbedContentByLine -&gt; SaveAndCloseEmbeditor -&gt; WaitForEmbedClosed).
+        ///
+        /// Each edit is (1-based «E:N» slot-start line, COMPLETE replacement code for that slot). Every line is
+        /// validated against the freshly-opened embed structure; if ANY line is not a current embed-slot start,
+        /// NOTHING is written (the embeditor is cancelled). Writes run bottom-to-top so earlier slots' line
+        /// numbers stay valid, verbatim (no re-indent — the caller supplies fully-indented code). UI thread only.
+        /// </summary>
+        public static string ApplyLineEdits(string procName, IList<KeyValuePair<int, string>> edits, out bool ok)
+        {
+            ok = false;
+            if (string.IsNullOrWhiteSpace(procName))
+                return "Error: procedure_name is required.";
+            if (edits == null || edits.Count == 0)
+                return "Error: no edits supplied.";
+
+            var appTree = new AppTreeService();
+            // Reliably re-open the correct procedure and mirror its current source + ranges; leaves the
+            // embeditor open for us to write into (same entry point the interactive save uses).
+            string fsource, openErr;
+            List<int[]> franges;
+            if (!ModernEmbeditorLauncher.OpenAndMirror(appTree, procName, out fsource, out franges, out openErr))
+                return "Apply aborted: " + openErr;
+
+            try
+            {
+                // Valid write targets = the slot-START lines of the freshly-opened structure.
+                var slotStarts = new HashSet<int>();
+                if (franges != null)
+                    foreach (var r in franges)
+                        if (r != null && r.Length >= 1) slotStarts.Add(r[0]);
+
+                // Validate ALL edits BEFORE writing anything (all-or-nothing).
+                foreach (var e in edits)
+                {
+                    if (e.Key <= 0 || !slotStarts.Contains(e.Key))
+                    {
+                        try { appTree.CancelEmbeditor(); } catch { }
+                        return "Apply aborted: line " + e.Key + " is not a current embed-slot start in '" +
+                               procName + "'. Re-read with get_embeditor_source and retry. Nothing was written.";
+                    }
+                }
+
+                // Write changed slots bottom-to-top so earlier slots' line numbers stay valid; verbatim.
+                var errors = new List<string>();
+                foreach (var e in edits.OrderByDescending(x => x.Key))
+                {
+                    string res = appTree.WriteEmbedContentByLine(e.Key, e.Value ?? "", false);
+                    if (res != null && res.StartsWith("Error", StringComparison.OrdinalIgnoreCase))
+                        errors.Add("  • slot@line " + e.Key + ": " + res);
+                }
+
+                if (errors.Count > 0)
+                {
+                    try { appTree.CancelEmbeditor(); } catch { } // discard — persist nothing on partial failure
+                    return "Apply FAILED — nothing persisted:\r\n" + string.Join("\r\n", errors);
+                }
+
+                string saveRes = appTree.SaveAndCloseEmbeditor();
+                if (saveRes != null && saveRes.StartsWith("Error", StringComparison.OrdinalIgnoreCase))
+                    return "Apply error: " + saveRes;
+
+                if (!ModernEmbeditorLauncher.WaitForEmbedClosed(appTree, 3000))
+                    return "Apply error: '" + procName + "' was written but the embeditor did not confirm closed — " +
+                           "close it in the IDE before applying again.";
+
+                ok = true;
+                return "Applied " + edits.Count + " embed edit(s) to '" + procName + "'.";
+            }
+            catch (Exception ex)
+            {
+                try { appTree.CancelEmbeditor(); } catch { }
+                return "Apply error: " + (ex.InnerException != null ? ex.InnerException.Message : ex.Message);
+            }
+        }
+
         private static bool RangesMatch(List<int[]> a, List<int[]> b)
         {
             if (a == null || b == null || a.Count != b.Count) return false;


### PR DESCRIPTION
## What

Adds an MCP tool **`apply_embed_edits`** that applies one or more embed-slot edits to a procedure in a **single transient** `open → write → save → close` round-trip, with no interactive embeditor session left open.

## Why

Driving the classic PWEE editor interactively — repeated `open_procedure_embed` + `write_embed_content` — destabilises and crashes the IDE on **very large procedures**. Real case: a ~4,500-line `Touch_Salg` procedure in a POS app, where the interactive path crashed reliably. This tool let us apply 5 multi-line edits across that procedure with **zero crashes**.

It reuses the proven Modern Embeditor save path rather than inventing a new one:

```
ModernEmbeditorLauncher.OpenAndMirror
  → WriteEmbedContentByLine (bottom-to-top)
  → SaveAndCloseEmbeditor
  → WaitForEmbedClosed
```

## How

- **`ModernEmbeditorSaver.ApplyLineEdits(procName, edits, out ok)`**
  - Validates every edit's `line_number` against the freshly-opened embed structure **before writing anything** (all-or-nothing).
  - Writes changed slots **bottom-to-top** so earlier slots' line numbers stay valid.
  - On any failure it cancels the embeditor and persists nothing.
- **`McpToolRegistry`** registers the `apply_embed_edits` tool.
  - Input: `procedure_name` + `edits` = JSON array of `{ "line_number": N, "code": "...full slot replacement..." }`, where `N` is the 1-based `«E:N»` slot start (from `get_embeditor_source` / `search_embeditor_source`).

## Notes

- Scope is intentionally just the two service files — no version bump or deploy-script changes are included.
- Related: #44 documents a non-ASCII (UTF-8 → Windows-1252) double-encoding issue observed via this same write path (`WriteEmbedContentByLine`), which likely affects the existing interactive `write_embed_content` too. That's a separate fix; this PR only adds the tool.

Happy to adjust naming/placement to fit your conventions.
