### PR TITLE
Add Red File redirection when Running Indexer

### DIFF
--- a/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
@@ -16,7 +16,7 @@ namespace ClarionCodeGraph.Graph
         private readonly CodeGraphDatabase _db;
         private readonly SolutionParser _slnParser;
         private readonly ProjectParser _projParser;
-        private readonly SourceResolver _resolver;
+        private SourceResolver _resolver;
         private readonly ClarionParser _clarionParser;
 
         public event Action<string> OnProgress;
@@ -51,6 +51,10 @@ namespace ClarionCodeGraph.Graph
             ReportProgress("Parsing solution file...");
             var projects = _slnParser.Parse(slnPath);
             result.ProjectCount = projects.Count;
+
+            // Load redirection file so SourceResolver can find files in Compile\, Classes\, etc.
+            string slnDir = Path.GetDirectoryName(slnPath);
+            _resolver = new SourceResolver(TryLoadRedFile(slnDir));
 
             // For full re-index, wipe everything and start fresh
             if (!incremental)
@@ -1259,6 +1263,24 @@ namespace ClarionCodeGraph.Graph
             }
             catch { }
             return false;
+        }
+
+        private ClarionAssistant.Services.RedFileService TryLoadRedFile(string slnDir)
+        {
+            try
+            {
+                string[] redFiles = Directory.GetFiles(slnDir, "*.red", SearchOption.TopDirectoryOnly);
+                if (redFiles.Length == 0) return null;
+
+                var svc = new ClarionAssistant.Services.RedFileService();
+                var macros = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["THISDIR"] = slnDir
+                };
+                ReportProgress(string.Format("Using redirection file: {0}", Path.GetFileName(redFiles[0])));
+                return svc.Load(redFiles[0], macros) ? svc : null;
+            }
+            catch { return null; }
         }
 
         private void ReportProgress(string message)

--- a/ClarionAssistant/CodeGraph/Parsing/SourceResolver.cs
+++ b/ClarionAssistant/CodeGraph/Parsing/SourceResolver.cs
@@ -1,15 +1,25 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using ClarionAssistant.Services;
 
 namespace ClarionCodeGraph.Parsing
 {
     /// <summary>
     /// Locates actual .clw/.inc source files on disk.
-    /// For v1, uses the .\source\ subfolder convention.
+    /// Searches .\source\, project root, then falls back to the .red redirection paths.
     /// </summary>
     public class SourceResolver
     {
+        private readonly RedFileService _redService;
+
+        public SourceResolver() { }
+
+        public SourceResolver(RedFileService redService)
+        {
+            _redService = redService;
+        }
+
         /// <summary>
         /// Given a project directory and a list of source file names from the .cwproj,
         /// resolves each to its full path by searching known locations.
@@ -34,10 +44,7 @@ namespace ClarionCodeGraph.Parsing
 
         private string FindFile(string projectDir, string fileName)
         {
-            // Search order:
             // 1. .\source\ subfolder (primary convention)
-            // 2. Project root directory (fallback)
-
             string sourcePath = Path.Combine(projectDir, "source", fileName);
             if (File.Exists(sourcePath))
                 return sourcePath;
@@ -47,9 +54,18 @@ namespace ClarionCodeGraph.Parsing
             if (File.Exists(sourcePathAlt))
                 return sourcePathAlt;
 
+            // 2. Project root directory
             string rootPath = Path.Combine(projectDir, fileName);
             if (File.Exists(rootPath))
                 return rootPath;
+
+            // 3. Redirection file search paths (Clarion .red — e.g. %THISDIR%\Compile)
+            if (_redService != null)
+            {
+                string resolved = _redService.ResolveFrom(fileName, projectDir, "Common", "Debug", "Release");
+                if (resolved != null)
+                    return resolved;
+            }
 
             return null;
         }

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionBuild>518</VersionBuild>
-    <FullVersion>5.0.518</FullVersion>
-    <AssemblyFullVersion>5.0.518.0</AssemblyFullVersion>
+    <VersionBuild>520</VersionBuild>
+    <FullVersion>5.0.520</FullVersion>
+    <AssemblyFullVersion>5.0.520.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Closes #36 
indexer was not picking up that my redirect moved all my .clw and .inc to a subfolder /compile 

Asked claude to bring in the Resolver Process which was already built but not called. 

Use what ever is useful to you