### PR TITLE
Auto-trigger completion on ':' as well as '.'

### DIFF
--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -2269,7 +2269,7 @@
     // LSP-backed completion + hover, routed through the C# host to the Clarion language server.
     function registerClarionProviders() {
         monaco.languages.registerCompletionItemProvider('clarion', {
-            triggerCharacters: ['.'],
+            triggerCharacters: ['.', ':'],
             provideCompletionItems: function (model, position) {
                 // Completion replace-range = the trailing identifier chars only, breaking on ':' and '.'.
                 // We intentionally do NOT use getWordUntilPosition here: the Clarion wordPattern keeps ':'


### PR DESCRIPTION
Small quality-of-life fix for the Monaco embeditor.

The completion provider only auto-triggered on `.`, but the Clarion language server advertises **both `.` and `:`** as completion trigger characters (`triggerCharacters: [".", ":"]`). Clarion uses `:` for prefixed field access (e.g. `PRE:Field`), so typing the prefix separator should pop completion the same way `.` does.

**Change:** one line in `ClarionAssistant/Terminal/monaco-embeditor.html` — adds `:` to the provider's `triggerCharacters`. Behaviour for `.` is unchanged; this just aligns the client with the server's already-advertised triggers.

Figured it's a nice quick win to land before any new LSP work. Happy to adjust.