### PR TITLE
Add Code Snippets (Ctrl+J) to the CA Embeditor

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -107,6 +107,7 @@
       <DependentUpon>ClassHelperControl.cs</DependentUpon>
     </Compile>
     <Compile Include="Services\ClarionClassParser.cs" />
+    <Compile Include="Services\SnippetStore.cs" />
     <Compile Include="Services\ExplorerRecentsStore.cs" />
     <Compile Include="Services\ExplorerFileClassifier.cs" />
     <Compile Include="Services\MonacoFileOpener.cs" />

--- a/ClarionAssistant/Dialogs/ClaudeChatSettingsDialog.cs
+++ b/ClarionAssistant/Dialogs/ClaudeChatSettingsDialog.cs
@@ -187,6 +187,15 @@ namespace ClarionAssistant.Dialogs
                     case "testGitHubToken":
                         HandleTestGitHubToken(json);
                         break;
+                    case "addSnippet":
+                        HandleAddSnippet(json);
+                        break;
+                    case "editSnippet":
+                        HandleEditSnippet(json);
+                        break;
+                    case "deleteSnippet":
+                        HandleDeleteSnippet(json);
+                        break;
                     case "browseClassFolder":
                         BrowseFolder("classFolder", "Select Class Output Folder", _settings.Get("Class.OutputFolder"));
                         break;
@@ -361,6 +370,107 @@ namespace ClarionAssistant.Dialogs
 
             // Send GitHub accounts (separate message — keeps setSettings clean)
             SendGitHubAccounts();
+            SendSnippets();
+        }
+
+        private void SendSnippets()
+        {
+            try
+            {
+                _webView.CoreWebView2.PostWebMessageAsString(
+                    "{\"type\":\"setSnippets\",\"snippets\":" + SnippetStore.ToJson(SnippetStore.Load()) + "}");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[SettingsDialog] SendSnippets error: " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Snippet payloads carry a multi-line Clarion code body (arbitrary quotes/backslashes/tabs), so
+        /// unlike the GitHub-account handlers above (which use the hand-rolled ExtractJsonValue on a
+        /// double-stringified "data" field), the snippet JS side sends "data" as a native nested object
+        /// and this parses the WHOLE envelope with JavaScriptSerializer — one clean JSON round-trip
+        /// instead of two layers of string-escaping that ExtractJsonValue isn't built to survive
+        /// (it doesn't decode \t or \uXXXX).
+        /// </summary>
+        private static Dictionary<string, object> ExtractSnippetData(string json)
+        {
+            try
+            {
+                var d = new System.Web.Script.Serialization.JavaScriptSerializer { MaxJsonLength = int.MaxValue }
+                    .DeserializeObject(json) as Dictionary<string, object>;
+                object data;
+                return (d != null && d.TryGetValue("data", out data)) ? data as Dictionary<string, object> : null;
+            }
+            catch { return null; }
+        }
+
+        private static string SnippetStr(Dictionary<string, object> d, string key)
+        {
+            object v;
+            return (d != null && d.TryGetValue(key, out v) && v != null) ? v.ToString() : null;
+        }
+
+        private static List<string> SnippetStrList(Dictionary<string, object> d, string key)
+        {
+            var list = new List<string>();
+            object v;
+            if (d != null && d.TryGetValue(key, out v) && v is object[])
+                foreach (var item in (object[])v) if (item != null) list.Add(item.ToString());
+            return list;
+        }
+
+        private void HandleAddSnippet(string json)
+        {
+            try
+            {
+                var data = ExtractSnippetData(json);
+                if (data == null) return;
+                var updated = SnippetStore.Add(
+                    SnippetStr(data, "trigger"), SnippetStr(data, "description"),
+                    SnippetStrList(data, "extensions"), SnippetStr(data, "body"));
+                SendSnippets();
+                Terminal.ModernEmbeditorViewContent.ApplySnippetsToAll(updated);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[SettingsDialog] AddSnippet error: " + ex.Message);
+            }
+        }
+
+        private void HandleEditSnippet(string json)
+        {
+            try
+            {
+                var data = ExtractSnippetData(json);
+                if (data == null) return;
+                var updated = SnippetStore.Update(
+                    SnippetStr(data, "id"), SnippetStr(data, "trigger"), SnippetStr(data, "description"),
+                    SnippetStrList(data, "extensions"), SnippetStr(data, "body"));
+                SendSnippets();
+                Terminal.ModernEmbeditorViewContent.ApplySnippetsToAll(updated);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[SettingsDialog] EditSnippet error: " + ex.Message);
+            }
+        }
+
+        private void HandleDeleteSnippet(string json)
+        {
+            try
+            {
+                string id = ExtractJsonValue(json, "data");
+                if (string.IsNullOrEmpty(id)) return;
+                var updated = SnippetStore.Delete(id);
+                SendSnippets();
+                Terminal.ModernEmbeditorViewContent.ApplySnippetsToAll(updated);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[SettingsDialog] DeleteSnippet error: " + ex.Message);
+            }
         }
 
         private void SendGitHubAccounts()

--- a/ClarionAssistant/Services/SnippetStore.cs
+++ b/ClarionAssistant/Services/SnippetStore.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web.Script.Serialization;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// A single Ctrl+J code snippet. Body uses Monaco snippet syntax ($1, ${1:default}, $0) plus the
+    /// CA Embeditor's own ${SELECTED} placeholder, substituted client-side with the text that was
+    /// selected when the snippet picker was triggered (see monaco-embeditor.html's snippet picker).
+    /// </summary>
+    public sealed class Snippet
+    {
+        public string Id;
+        public string Trigger;
+        public string Description;
+        public List<string> Extensions = new List<string>();  // e.g. [".clw"]; empty = applies to all extensions
+        public string Body;
+
+        public Dictionary<string, object> ToDict()
+        {
+            return new Dictionary<string, object>
+            {
+                { "id", Id }, { "trigger", Trigger }, { "description", Description ?? "" },
+                { "extensions", Extensions ?? new List<string>() }, { "body", Body ?? "" }
+            };
+        }
+
+        public static Snippet FromDict(IDictionary<string, object> d)
+        {
+            var s = new Snippet();
+            if (d == null) return s;
+            object v;
+            if (d.TryGetValue("id", out v) && v != null) s.Id = v.ToString();
+            if (d.TryGetValue("trigger", out v) && v != null) s.Trigger = v.ToString();
+            if (d.TryGetValue("description", out v) && v != null) s.Description = v.ToString();
+            if (d.TryGetValue("body", out v) && v != null) s.Body = v.ToString();
+            if (d.TryGetValue("extensions", out v) && v is object[])
+            {
+                s.Extensions = new List<string>();
+                foreach (var e in (object[])v) if (e != null) s.Extensions.Add(e.ToString());
+            }
+            return s;
+        }
+    }
+
+    /// <summary>
+    /// Global (NOT per-Clarion-version, NOT per-solution) storage for Ctrl+J code snippets:
+    /// %APPDATA%\ClarionAssistant\snippets.json. A snippet is reusable Clarion source across every
+    /// project, so — unlike ModernEmbeditorHistory's per-solution find/replace lists — there is
+    /// exactly one file for the whole install. The list is authoritative on every Save (mirrors
+    /// ModernEmbeditorHistory.Save): callers always pass the full set, so a delete sticks.
+    /// </summary>
+    public static class SnippetStore
+    {
+        private const int MaxSnippets = 500;
+        private const int MaxTriggerLength = 64;
+        private const int MaxDescriptionLength = 200;
+        private const int MaxBodyLength = 32 * 1024;
+        private const int MaxExtensions = 16;
+        private const int MaxExtensionLength = 16;
+
+        /// <summary>Load the full list from disk, tolerant of a missing/corrupt file (returns empty).</summary>
+        public static List<Snippet> Load()
+        {
+            var list = new List<Snippet>();
+            try
+            {
+                string path = FilePath();
+                if (!File.Exists(path)) return list;
+                var arr = new JavaScriptSerializer { MaxJsonLength = int.MaxValue }
+                    .DeserializeObject(File.ReadAllText(path)) as object[];
+                if (arr == null) return list;
+                foreach (var item in arr)
+                {
+                    var d = item as Dictionary<string, object>;
+                    if (d != null) list.Add(Snippet.FromDict(d));
+                }
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SnippetStore] Load: " + ex.Message); }
+            return Sanitize(list);
+        }
+
+        /// <summary>Persist the full list (authoritative — replaces the file).</summary>
+        public static void Save(List<Snippet> all)
+        {
+            var clean = Sanitize(all);
+            try
+            {
+                string dir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ClarionAssistant");
+                if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                var payload = new List<object>();
+                foreach (var s in clean) payload.Add(s.ToDict());
+                File.WriteAllText(Path.Combine(dir, "snippets.json"),
+                    new JavaScriptSerializer().Serialize(payload), Encoding.UTF8);
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SnippetStore] Save: " + ex.Message); }
+        }
+
+        public static List<Snippet> Add(string trigger, string description, List<string> extensions, string body)
+        {
+            var all = Load();
+            all.Add(new Snippet
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Trigger = trigger, Description = description,
+                Extensions = extensions ?? new List<string>(), Body = body
+            });
+            Save(all);
+            return Load();
+        }
+
+        public static List<Snippet> Update(string id, string trigger, string description, List<string> extensions, string body)
+        {
+            var all = Load();
+            foreach (var s in all)
+            {
+                if (!string.Equals(s.Id, id, StringComparison.Ordinal)) continue;
+                s.Trigger = trigger; s.Description = description;
+                s.Extensions = extensions ?? new List<string>(); s.Body = body;
+                break;
+            }
+            Save(all);
+            return Load();
+        }
+
+        public static List<Snippet> Delete(string id)
+        {
+            var all = Load();
+            all.RemoveAll(s => string.Equals(s.Id, id, StringComparison.Ordinal));
+            Save(all);
+            return Load();
+        }
+
+        /// <summary>Serialize for the JS bridge (setSource's initial payload + the applySnippets broadcast).</summary>
+        public static string ToJson(List<Snippet> list)
+        {
+            try
+            {
+                var payload = new List<object>();
+                if (list != null) foreach (var s in list) payload.Add(s.ToDict());
+                return new JavaScriptSerializer().Serialize(payload);
+            }
+            catch { return "[]"; }
+        }
+
+        private static string FilePath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "ClarionAssistant", "snippets.json");
+        }
+
+        /// <summary>
+        /// Defensive copy/clamp before persisting or handing back to the bridge: drop snippets with no
+        /// trigger, reject CR/LF in the trigger (it's used as a JS key / HTML list label, not code),
+        /// clamp lengths and counts — mirrors ModernEmbeditorSettings.SanitizeBindings so a
+        /// crafted/hand-edited snippets.json can't corrupt the file or balloon it.
+        /// </summary>
+        private static List<Snippet> Sanitize(List<Snippet> list)
+        {
+            var outp = new List<Snippet>();
+            if (list == null) return outp;
+            foreach (var s in list)
+            {
+                if (outp.Count >= MaxSnippets) break;
+                if (s == null || string.IsNullOrWhiteSpace(s.Trigger)) continue;
+                string trigger = s.Trigger.Trim();
+                if (HasCrLf(trigger)) continue;
+                if (trigger.Length > MaxTriggerLength) trigger = trigger.Substring(0, MaxTriggerLength);
+
+                string description = s.Description ?? "";
+                if (HasCrLf(description)) description = description.Replace("\r", " ").Replace("\n", " ");
+                if (description.Length > MaxDescriptionLength) description = description.Substring(0, MaxDescriptionLength);
+
+                string body = s.Body ?? "";
+                if (body.Length > MaxBodyLength) body = body.Substring(0, MaxBodyLength);
+
+                var extensions = new List<string>();
+                if (s.Extensions != null)
+                {
+                    foreach (var e in s.Extensions)
+                    {
+                        if (string.IsNullOrWhiteSpace(e) || extensions.Count >= MaxExtensions) continue;
+                        string ext = e.Trim();
+                        if (ext.Length > MaxExtensionLength || HasCrLf(ext)) continue;
+                        extensions.Add(ext);
+                    }
+                }
+
+                outp.Add(new Snippet
+                {
+                    Id = string.IsNullOrEmpty(s.Id) ? Guid.NewGuid().ToString("N") : s.Id,
+                    Trigger = trigger, Description = description, Extensions = extensions, Body = body
+                });
+            }
+            return outp;
+        }
+
+        private static bool HasCrLf(string s) { return s != null && (s.IndexOf('\r') >= 0 || s.IndexOf('\n') >= 0); }
+    }
+}

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1809,6 +1809,17 @@ namespace ClarionAssistant.Terminal
         // editors too — not just Modern Embeditor tabs.
 
         /// <summary>
+        /// Broadcast the current Ctrl+J snippet list to every open Modern Embeditor tab, so an
+        /// add/edit/delete in Settings &gt; Snippets is picked up live without reopening the tab
+        /// (mirrors ApplySettingsToAll — called by ClaudeChatSettingsDialog after each CRUD op).
+        /// </summary>
+        public static void ApplySnippetsToAll(List<Snippet> snippets)
+        {
+            string json = "{\"type\":\"applySnippets\",\"snippets\":" + SnippetStore.ToJson(snippets) + "}";
+            lock (_instances) { foreach (var inst in _instances) inst._panel?.PostJson(json); }
+        }
+
+        /// <summary>
         /// Persist the Find/Replace dropdown history (sent by JS as full arrays) and broadcast the saved
         /// lists to every open tab so all tabs converge. The incoming list is authoritative, so per-entry
         /// delete and "clear history" stick. Persist failures are logged but never block the broadcast.
@@ -2141,6 +2152,10 @@ namespace ClarionAssistant.Terminal
                 }
                 catch { }
 
+                string snippetsJson;
+                try { snippetsJson = SnippetStore.ToJson(SnippetStore.Load()); }
+                catch { snippetsJson = "[]"; }
+
                 string json = "{\"type\":\"setSource\"," +
                     "\"title\":" + JsonString(_title) + "," +
                     "\"language\":" + JsonString(_language) + "," +
@@ -2156,6 +2171,7 @@ namespace ClarionAssistant.Terminal
                     "\"cursorLine\":" + cursorLine + "," +
                     "\"cursorColumn\":" + cursorColumn + "," +
                     "\"bookmarks\":" + bookmarksJson + "," +
+                    "\"snippets\":" + snippetsJson + "," +
                     "\"sourceUrl\":\"https://" + VIRTUAL_HOST + "/source.txt\"}";
                 _panel.PostJson(json);
             }

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -466,6 +466,9 @@
     var lastFindQuery = null;     // the query that produced findResults (for Enter = next)
     var findOpts = { matchCase: false, wholeWord: false, regex: false, includeReadOnly: true };
     // Monaco's standard word-boundary separators (needed to enable whole-word matching).
+
+    // ----- Snippets (Ctrl+J) state -----
+    var snippetsList = [];        // [{id,trigger,description,extensions,body}], from setSource + applySnippets broadcast
     var WORD_SEPARATORS = "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?";
 
     // ----- Find TABS: each tab is an independent search session {query, replaceText, opts}. The live
@@ -609,6 +612,7 @@
                 editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, doSave);
                 installCommandPalette(editor); // F1 / Ctrl+Shift+P open Monaco's quick-command palette
                 installFindKeyInterceptor();   // capture-phase Ctrl+F/Ctrl+H/F3 — beats Monaco's stock widgets
+                installSnippetKeyInterceptor(); // capture-phase Ctrl+J — classic Clarion code-snippet picker
                 rebuildChordMap();             // seed the binding map from defaults (settings refine it later)
                 installKeyBindings();          // capture-phase dispatcher for all rebindable Clarion editor keys
                 installGlyphBookmarkClick();   // far-left margin click toggles a bookmark (#16)
@@ -655,6 +659,7 @@
         embedRanges = msg.editableRanges || [];
         saveEnabled = !!msg.saveEnabled;
         fileMode = !!msg.fileMode;
+        currentFilePath = msg.filePath || '';
         breakpointsEnabled = !!msg.breakpointsEnabled;   // overlay: gutter-click toggles a breakpoint (not a bookmark)
         designerEnabled = !!msg.designerEnabled;         // overlay: Ctrl+D designs structures in plain source files
         var sb = document.getElementById('saveBtn');
@@ -682,6 +687,7 @@
         if (msg.findHistory) replaceArray(findHistory, msg.findHistory);
         if (msg.replaceHistory) replaceArray(replHistory, msg.replaceHistory);
         if (msg.procHistory) replaceArray(procFindHistory, msg.procHistory);
+        if (msg.snippets) snippetsList = msg.snippets;
         // Source is transferred via the virtual-host URL to avoid huge postMessage payloads.
         fetch(msg.sourceUrl, { cache: 'no-store' })
             .then(function (r) { return r.text(); })
@@ -1006,6 +1012,7 @@
 
     function installKeyBindings() {
         document.addEventListener('keydown', function (ev) {
+            if (snippetPickerOpen) return;   // the snippet picker owns its own keydown handling while open
             if (capturingKey) { handleKeyCapture(ev); return; }
             var chord = chordFromEvent(ev);
             if (!chord) return;
@@ -2718,7 +2725,7 @@
     // Monaco's textarea handler) and stop it dead, so OUR panel opens instead. F3/Shift+F3 cycle.
     function installFindKeyInterceptor() {
         document.addEventListener('keydown', function (ev) {
-            if (capturingKey) return;   // rebind-capture in the settings panel owns the keyboard
+            if (capturingKey || snippetPickerOpen) return;   // rebind-capture / snippet picker owns the keyboard
             var ctrl = ev.ctrlKey || ev.metaKey;
             if (ctrl && (ev.keyCode === 70 || ev.key === 'f' || ev.key === 'F')) {         // Ctrl+F
                 ev.preventDefault(); ev.stopImmediatePropagation(); openFindPanel(false);
@@ -2735,6 +2742,243 @@
                 }
             }
         }, true);   // capture phase — runs ahead of Monaco's own keydown listener
+    }
+
+    // ----- Code Snippets (Ctrl+J) picker -----
+    // Classic-Clarion-style Ctrl+J: a dedicated modal picker (NOT folded into the LSP completion
+    // provider), filterable by trigger/description, scoped to the active file's extension. Modeled
+    // on showTemplatePicker's overlay (dynamically-built DOM, centered, native <select> for
+    // keyboard nav) rather than the docked Find panel, since this is a one-shot pick-and-insert.
+    var snippetPickerOpen = false;
+    var currentFilePath = '';   // set from setSource's msg.filePath; used to scope snippets by extension
+
+    function installSnippetKeyInterceptor() {
+        document.addEventListener('keydown', function (ev) {
+            if (capturingKey || snippetPickerOpen) return;   // picker owns its own keydown once open
+            var ctrl = ev.ctrlKey || ev.metaKey;
+            if (ctrl && (ev.keyCode === 74 || ev.key === 'j' || ev.key === 'J')) {   // Ctrl+J
+                ev.preventDefault(); ev.stopImmediatePropagation(); openSnippetPicker();
+            }
+        }, true);   // capture phase — runs ahead of Monaco's own keydown listener
+    }
+
+    // In procedure/embed mode there's no real file path (a PWEE procedure always generates into a
+    // .clw), so extension scoping falls back to .clw; file mode uses the real path's extension.
+    function activeSnippetExtension() {
+        if (fileMode && currentFilePath) {
+            var m = /\.[^.\\\/]+$/.exec(currentFilePath);
+            if (m) return m[0].toLowerCase();
+        }
+        return '.clw';
+    }
+
+    function openSnippetPicker() {
+        if (snippetPickerOpen) return;
+        var ed = activeEd();
+        if (!ed) return;
+        var sel = ed.getSelection();
+        var selText = (sel && !sel.isEmpty()) ? ed.getModel().getValueInRange(sel) : '';
+        var ext = activeSnippetExtension();
+
+        var old = document.getElementById('snippetPicker');
+        if (old) old.remove();
+        snippetPickerOpen = true;
+
+        var ov = document.createElement('div');
+        ov.id = 'snippetPicker';
+        ov.style.cssText = 'position:fixed;inset:0;z-index:1001;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;';
+        var panel = document.createElement('div');
+        panel.style.cssText = 'background:#2d2d30;color:#eee;padding:14px 16px;border-radius:8px;font-family:Segoe UI,sans-serif;box-shadow:0 4px 24px rgba(0,0,0,.5);min-width:380px;';
+        var selPreview = selText ? (selText.length > 30 ? selText.substring(0, 30) + '…' : selText) : '';
+        panel.innerHTML =
+            '<div style="font-size:14px;margin-bottom:8px;">Insert Snippet' +
+            (selPreview ? ' — selection: "' + escHtml(selPreview) + '"' : '') + '</div>' +
+            '<input id="snippetFilter" type="text" placeholder="Filter by trigger or description..." ' +
+            'style="width:100%;box-sizing:border-box;font-family:Segoe UI,sans-serif;background:#1e1e1e;color:#eee;border:1px solid #555;padding:5px 8px;margin-bottom:6px;">' +
+            '<select id="snippetListBox" size="10" style="width:100%;font-family:Consolas,monospace;font-size:12px;background:#1e1e1e;color:#eee;border:1px solid #555;padding:2px;"></select>' +
+            '<div id="snippetEmptyMsg" style="opacity:.6;font-size:11px;margin-top:6px;display:none;">No snippets match' +
+            (ext ? ' for ' + escHtml(ext) : '') + '.</div>' +
+            '<div style="opacity:.6;font-size:11px;margin-top:6px;">↑↓ to navigate · Enter to insert · Esc to cancel</div>';
+        ov.appendChild(panel);
+        document.body.appendChild(ov);
+
+        var filterInput = document.getElementById('snippetFilter');
+        var listBox = document.getElementById('snippetListBox');
+        var emptyMsg = document.getElementById('snippetEmptyMsg');
+
+        function appliesToExt(s) {
+            return !s.extensions || !s.extensions.length || s.extensions.indexOf(ext) !== -1;
+        }
+        function renderList() {
+            var q = (filterInput.value || '').toLowerCase();
+            var prevId = listBox.value;
+            listBox.innerHTML = '';
+            var any = false, restoredIdx = -1;
+            for (var i = 0; i < snippetsList.length; i++) {
+                var s = snippetsList[i];
+                if (!appliesToExt(s)) continue;
+                var hay = (s.trigger + ' ' + (s.description || '')).toLowerCase();
+                if (q && hay.indexOf(q) === -1) continue;
+                var o = document.createElement('option');
+                o.value = s.id;
+                o.textContent = s.trigger + (s.description ? '  — ' + s.description : '');
+                listBox.appendChild(o);
+                if (s.id === prevId) restoredIdx = listBox.options.length - 1;
+                any = true;
+            }
+            emptyMsg.style.display = any ? 'none' : '';
+            listBox.selectedIndex = restoredIdx >= 0 ? restoredIdx : (any ? 0 : -1);
+        }
+        // Exposed so the applySnippets broadcast handler can refresh a picker left open while
+        // Settings > Snippets is edited from another window.
+        window.renderSnippetPickerList = renderList;
+
+        function close() {
+            snippetPickerOpen = false;
+            if (window.renderSnippetPickerList === renderList) delete window.renderSnippetPickerList;
+            ov.remove();
+            try { ed.focus(); } catch (e) { }
+        }
+
+        function accept() {
+            var id = listBox.value;
+            if (!id) return;
+            var snip = null;
+            for (var i = 0; i < snippetsList.length; i++) if (snippetsList[i].id === id) { snip = snippetsList[i]; break; }
+            if (!snip) return;
+            close();
+            insertSnippetBody(ed, snip.body || '', selText);
+        }
+
+        filterInput.addEventListener('input', renderList);
+        listBox.ondblclick = accept;
+        ov.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter') { e.preventDefault(); accept(); }
+            else if (e.key === 'Escape') { e.preventDefault(); close(); }
+            else if (e.key === 'ArrowDown') { e.preventDefault(); if (listBox.selectedIndex < listBox.options.length - 1) listBox.selectedIndex++; }
+            else if (e.key === 'ArrowUp') { e.preventDefault(); if (listBox.selectedIndex > 0) listBox.selectedIndex--; }
+        });
+
+        renderList();
+        filterInput.focus();
+    }
+
+    // Home-grown tab-stop engine. Monaco's own snippet controller (editor.action.insertSnippet) is
+    // deliberately NOT used here — same reason the Data-pad drop site avoids it (see "dropIntoEditor
+    // snippet-expands the text" above): its internal edits aren't recognized by installReadOnlyGuard
+    // as a single legal executeEdits() operation, so the guard silently undoes them inside embed
+    // slots. Every other programmatic edit in this file goes through executeEdits() (cmdComment,
+    // cmdDuplicateLineAbove, the Data-pad drop, Find/Replace...) — snippets follow the same path and
+    // roll their own minimal $0 / $N / ${N} / ${N:default} parsing + Tab/Shift+Tab cycling.
+    function parseSnippetBody(body) {
+        var text = '', stops = [], i = 0;
+        while (i < body.length) {
+            var c = body[i];
+            if (c === '\\' && body[i + 1] === '$') { text += '$'; i += 2; continue; }
+            if (c === '$') {
+                var rest = body.slice(i);
+                var m = /^\$(\d+)/.exec(rest);
+                if (m) { stops.push({ index: parseInt(m[1], 10), start: text.length, end: text.length }); i += m[0].length; continue; }
+                m = /^\$\{(\d+)(?::([^}]*))?\}/.exec(rest);
+                if (m) {
+                    var def = m[2] || '';
+                    stops.push({ index: parseInt(m[1], 10), start: text.length, end: text.length + def.length });
+                    text += def; i += m[0].length; continue;
+                }
+            }
+            text += c; i++;
+        }
+        return { text: text, stops: stops };
+    }
+
+    // Substitutes ${SELECTED} in the snippet body: with the text that was selected when Ctrl+J was
+    // pressed, or — if nothing was selected — with a new editable tab-stop (so the snippet never
+    // inserts a blank hole). A literal '$' inside the selected text is escaped so parseSnippetBody
+    // doesn't mistake it for the start of another tab-stop.
+    function insertSnippetBody(ed, body, selText) {
+        var subst;
+        if (selText) {
+            var escaped = selText.replace(/\$/g, function () { return '\\$'; });
+            subst = body.split('${SELECTED}').join(escaped);
+        } else {
+            var maxIdx = 0, re = /\$\{?(\d+)/g, m;
+            while ((m = re.exec(body))) { var n = parseInt(m[1], 10); if (n > maxIdx) maxIdx = n; }
+            subst = body.split('${SELECTED}').join('${' + (maxIdx + 1) + ':seleccionar}');
+        }
+
+        var model = ed.getModel();
+        var range = ed.getSelection() || ed.getModel().getFullModelRange();
+
+        // Match the classic Clarion Ctrl+J behavior: every line after the first inherits the leading
+        // whitespace of the line the snippet was triggered on, so nested body text (LOOP/IF blocks
+        // etc.) lands aligned instead of jammed at column 1. No control character needed in the body —
+        // this is automatic, same as VS Code's own snippet indentation.
+        var baseIndent = /^[ \t]*/.exec(model.getLineContent(range.startLineNumber))[0];
+        if (baseIndent) subst = subst.split('\n').map(function (line, i) { return i === 0 ? line : baseIndent + line; }).join('\n');
+
+        var parsed = parseSnippetBody(subst);
+        var startOffset = model.getOffsetAt({ lineNumber: range.startLineNumber, column: range.startColumn });
+
+        ed.executeEdits('snippet-picker', [{ range: range, text: parsed.text, forceMoveMarkers: true }]);
+
+        var numbered = parsed.stops.filter(function (s) { return s.index > 0; })
+            .sort(function (a, b) { return a.index - b.index; });
+        var zero = parsed.stops.filter(function (s) { return s.index === 0; })[0];
+        var target = numbered.length ? numbered[0] : zero;
+        var endOfInsert = model.getPositionAt(startOffset + parsed.text.length);
+        if (target) {
+            var sp = model.getPositionAt(startOffset + target.start), ep = model.getPositionAt(startOffset + target.end);
+            ed.setSelection(new monaco.Range(sp.lineNumber, sp.column, ep.lineNumber, ep.column));
+        } else {
+            ed.setSelection(new monaco.Range(endOfInsert.lineNumber, endOfInsert.column, endOfInsert.lineNumber, endOfInsert.column));
+        }
+        ed.revealPositionInCenterIfOutsideViewport(ed.getPosition());
+        ed.focus();
+
+        installSnippetTabCycling(ed, model, startOffset, numbered, zero);
+    }
+
+    // Tracks the remaining tab-stops as live decorations (so they shift correctly as the user types
+    // into an earlier stop) and lets Tab/Shift+Tab cycle between them, gated by a per-editor context
+    // key so Tab still indents normally once no snippet is in progress.
+    var _snippetTabState = null;
+    function installSnippetTabCycling(ed, model, startOffset, numbered, zero) {
+        clearSnippetTabState();
+        var all = numbered.concat(zero ? [zero] : []);
+        if (all.length < 2) return;   // nothing left to Tab to
+        var decoIds = model.deltaDecorations([], all.map(function (s) {
+            var sp = model.getPositionAt(startOffset + s.start), ep = model.getPositionAt(startOffset + s.end);
+            return {
+                range: new monaco.Range(sp.lineNumber, sp.column, ep.lineNumber, ep.column),
+                options: { stickiness: monaco.editor.TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges }
+            };
+        }));
+        if (!ed.__snippetTabKey) {
+            ed.__snippetTabKey = ed.createContextKey('caSnippetTabActive', false);
+            var nav = function (dir) { return function () { jumpSnippetStop(dir); }; };
+            ed.addCommand(monaco.KeyCode.Tab, nav(1), 'caSnippetTabActive');
+            ed.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Tab, nav(-1), 'caSnippetTabActive');
+            ed.onDidBlurEditorWidget(clearSnippetTabState);
+        }
+        _snippetTabState = { ed: ed, model: model, decoIds: decoIds, idx: 0, key: ed.__snippetTabKey };
+        ed.__snippetTabKey.set(true);
+    }
+
+    function jumpSnippetStop(dir) {
+        var st = _snippetTabState;
+        if (!st) return;
+        st.idx = (st.idx + dir + st.decoIds.length) % st.decoIds.length;
+        var r = st.model.getDecorationRange(st.decoIds[st.idx]);
+        if (!r) { clearSnippetTabState(); return; }
+        st.ed.setSelection(r);
+        st.ed.revealPositionInCenterIfOutsideViewport(r.getStartPosition());
+    }
+
+    function clearSnippetTabState() {
+        if (!_snippetTabState) return;
+        try { _snippetTabState.model.deltaDecorations(_snippetTabState.decoIds, []); } catch (e) { }
+        try { _snippetTabState.key.set(false); } catch (e) { }
+        _snippetTabState = null;
     }
 
     // Single-line non-empty editor selection text, else '' (used to seed a search from Ctrl+F).
@@ -3376,6 +3620,9 @@
                 if (fh && !fh.classList.contains('hidden')) showFindHist();
                 var rh = document.getElementById('replHist');
                 if (rh && !rh.classList.contains('hidden')) showReplHist();
+            } else if (msg.type === 'applySnippets') {
+                snippetsList = msg.snippets || [];
+                if (snippetPickerOpen) renderSnippetPickerList();   // keep an open picker live if Settings was edited concurrently
             }
         });
     }

--- a/ClarionAssistant/Terminal/settings.html
+++ b/ClarionAssistant/Terminal/settings.html
@@ -314,6 +314,7 @@
     <div class="nav-item" onclick="showPage('data')">Data</div>
     <div class="nav-item" onclick="showPage('classes')">Classes</div>
     <div class="nav-item" onclick="showPage('github')">Source Control</div>
+    <div class="nav-item" onclick="showPage('snippets')">Snippets</div>
     <div class="nav-item" onclick="showPage('mcp')">MCP Server</div>
     <div class="nav-item" onclick="showPage('acknowledgments')">Acknowledgments</div>
     <div class="nav-item" onclick="showPage('about')">About</div>
@@ -589,6 +590,27 @@
       <!-- Add/Edit form is now in the ghFormOverlay modal -->
     </div>
 
+    <!-- Snippets -->
+    <div class="page" id="page-snippets">
+      <h2>Code Snippets</h2>
+      <div class="field-desc" style="margin-bottom:12px">Ctrl+J in the CA Embeditor opens a picker with these snippets. Bodies use Monaco snippet syntax (<code>$1</code>, <code>${1:default}</code>, <code>$0</code>) plus <code>${SELECTED}</code>, which is replaced with whatever text was selected when Ctrl+J was pressed.</div>
+
+      <table style="width:100%;border-collapse:collapse;margin-bottom:10px" id="snippetTable">
+        <thead>
+          <tr>
+            <th style="text-align:left;font-size:11px;font-weight:600;color:var(--section-fg);padding:6px 8px;border-bottom:1px solid var(--input-border)">TRIGGER</th>
+            <th style="text-align:left;font-size:11px;font-weight:600;color:var(--section-fg);padding:6px 8px;border-bottom:1px solid var(--input-border)">DESCRIPTION</th>
+            <th style="text-align:left;font-size:11px;font-weight:600;color:var(--section-fg);padding:6px 8px;border-bottom:1px solid var(--input-border);width:120px">EXTENSIONS</th>
+            <th style="width:120px;text-align:right;font-size:11px;font-weight:600;color:var(--section-fg);padding:6px 8px;border-bottom:1px solid var(--input-border)"></th>
+          </tr>
+        </thead>
+        <tbody id="snippetBody"></tbody>
+      </table>
+      <div id="snippetEmpty" style="color:var(--desc-fg);font-size:12px;font-style:italic;padding:8px 0;display:none">No snippets configured.</div>
+
+      <button class="btn" onclick="showSnippetForm()" style="margin-top:4px">+ Add Snippet</button>
+    </div>
+
     <!-- MCP Server -->
     <div class="page" id="page-mcp">
       <h2>MCP Server</h2>
@@ -811,6 +833,54 @@
         <button class="btn" onclick="cancelGhForm()">Cancel</button>
         <button class="btn" id="ghTestBtn" onclick="testGhToken()">Test</button>
         <span id="ghTestResult" style="font-size:12px;margin-left:4px"></span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="overlay" id="snippetFormOverlay" onclick="if(event.target===this)cancelSnippetForm()">
+  <div class="overlay-panel" style="width:520px;max-height:640px">
+    <div class="overlay-header">
+      <h3 id="snippetFormTitle">Add Snippet</h3>
+      <button class="overlay-close" onclick="cancelSnippetForm()">&times;</button>
+    </div>
+    <div class="overlay-body">
+      <input type="hidden" id="snippetFormId" value="">
+      <div class="field">
+        <div class="field-label">Trigger</div>
+        <input type="text" id="snippetTrigger" placeholder="e.g. loopventas">
+      </div>
+      <div class="field">
+        <div class="field-label">Description</div>
+        <input type="text" id="snippetDescription" placeholder="e.g. Standard loop over the Ventas file">
+      </div>
+      <div class="field">
+        <div class="field-label">Extensions</div>
+        <div style="display:flex;gap:14px;flex-wrap:wrap">
+          <label class="check-row" style="margin-bottom:0"><input type="checkbox" class="snippetExt" value=".clw">.clw</label>
+          <label class="check-row" style="margin-bottom:0"><input type="checkbox" class="snippetExt" value=".tpl">.tpl</label>
+          <label class="check-row" style="margin-bottom:0"><input type="checkbox" class="snippetExt" value=".tpw">.tpw</label>
+        </div>
+        <div class="field-desc">Leave all unchecked to make this snippet available for every file type.</div>
+      </div>
+      <div class="field">
+        <div class="field-label">Body</div>
+        <textarea id="snippetBodyField" rows="10" placeholder="$1, ${1:default}, $0 for tab-stops; ${SELECTED} for the text selected when Ctrl+J was pressed"
+          style="width:100%;font-family:Cascadia Mono,Consolas,monospace;font-size:12px;background:var(--input-bg);color:var(--input-fg);border:1px solid var(--input-border);padding:8px;border-radius:4px;resize:vertical"></textarea>
+        <div style="padding:8px 10px;background:rgba(116,199,236,0.08);border:1px solid rgba(116,199,236,0.35);border-radius:4px;margin-top:6px;font-size:11px;line-height:1.6">
+          <b>Placeholders</b> (indentation is automatic — every line after the first matches the line Ctrl+J was pressed on):
+          <table style="margin-top:4px;border-collapse:collapse">
+            <tr><td style="font-family:Consolas,monospace;padding:1px 10px 1px 0;white-space:nowrap">${SELECTED}</td><td style="color:var(--section-fg)">Text selected when Ctrl+J was pressed; becomes a fillable tab-stop if nothing was selected.</td></tr>
+            <tr><td style="font-family:Consolas,monospace;padding:1px 10px 1px 0;white-space:nowrap">$1 $2 ...</td><td style="color:var(--section-fg)">Tab-stops. Tab/Shift+Tab cycles through them in order after insertion.</td></tr>
+            <tr><td style="font-family:Consolas,monospace;padding:1px 10px 1px 0;white-space:nowrap">${1:texto}</td><td style="color:var(--section-fg)">Tab-stop pre-filled with default text (here, "texto").</td></tr>
+            <tr><td style="font-family:Consolas,monospace;padding:1px 10px 1px 0;white-space:nowrap">$0</td><td style="color:var(--section-fg)">Final cursor position, visited last (after every numbered tab-stop).</td></tr>
+            <tr><td style="font-family:Consolas,monospace;padding:1px 10px 1px 0;white-space:nowrap">\$</td><td style="color:var(--section-fg)">Literal dollar sign (escapes the tab-stop syntax above).</td></tr>
+          </table>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;margin-top:12px">
+        <button class="btn" style="background:var(--accent);color:#fff;border-color:var(--accent)" onclick="saveSnippet()">Save</button>
+        <button class="btn" onclick="cancelSnippetForm()">Cancel</button>
       </div>
     </div>
   </div>
@@ -1506,6 +1576,84 @@
     }
   }
 
+  // ----- Code Snippets (Ctrl+J) -----
+  var snippetsData = [];
+
+  function renderSnippets() {
+    var tbody = document.getElementById('snippetBody');
+    var empty = document.getElementById('snippetEmpty');
+    if (snippetsData.length === 0) {
+      tbody.innerHTML = '';
+      empty.style.display = 'block';
+      return;
+    }
+    empty.style.display = 'none';
+    var html = '';
+    for (var i = 0; i < snippetsData.length; i++) {
+      var s = snippetsData[i];
+      var exts = (s.extensions && s.extensions.length) ? s.extensions.join(', ') : 'all';
+      html += '<tr>'
+        + '<td style="padding:6px 8px;border-bottom:1px solid var(--input-border);font-size:13px;font-family:Consolas,monospace">' + esc(s.trigger) + '</td>'
+        + '<td style="padding:6px 8px;border-bottom:1px solid var(--input-border);font-size:13px;color:var(--section-fg)">' + esc(s.description) + '</td>'
+        + '<td style="padding:6px 8px;border-bottom:1px solid var(--input-border);font-size:12px;color:var(--section-fg)">' + esc(exts) + '</td>'
+        + '<td style="padding:6px 8px;border-bottom:1px solid var(--input-border);text-align:right">'
+        + '<button class="btn btn-sm" onclick="editSnippet(\'' + esc(s.id) + '\')" style="margin-right:4px">Edit</button>'
+        + '<button class="btn btn-sm" onclick="deleteSnippet(\'' + esc(s.id) + '\')">Delete</button>'
+        + '</td></tr>';
+    }
+    tbody.innerHTML = html;
+  }
+
+  function showSnippetForm(id) {
+    var overlay = document.getElementById('snippetFormOverlay');
+    overlay.classList.add('visible');
+    var checks = document.querySelectorAll('.snippetExt');
+    if (id) {
+      var snip = null;
+      for (var i = 0; i < snippetsData.length; i++) { if (snippetsData[i].id === id) { snip = snippetsData[i]; break; } }
+      if (!snip) return;
+      document.getElementById('snippetFormTitle').textContent = 'Edit Snippet';
+      document.getElementById('snippetFormId').value = snip.id;
+      document.getElementById('snippetTrigger').value = snip.trigger || '';
+      document.getElementById('snippetDescription').value = snip.description || '';
+      document.getElementById('snippetBodyField').value = snip.body || '';
+      var exts = snip.extensions || [];
+      for (var j = 0; j < checks.length; j++) checks[j].checked = exts.indexOf(checks[j].value) !== -1;
+    } else {
+      document.getElementById('snippetFormTitle').textContent = 'Add Snippet';
+      document.getElementById('snippetFormId').value = '';
+      document.getElementById('snippetTrigger').value = '';
+      document.getElementById('snippetDescription').value = '';
+      document.getElementById('snippetBodyField').value = '';
+      for (var k = 0; k < checks.length; k++) checks[k].checked = false;
+    }
+  }
+
+  function editSnippet(id) { showSnippetForm(id); }
+
+  function cancelSnippetForm() {
+    document.getElementById('snippetFormOverlay').classList.remove('visible');
+  }
+
+  function saveSnippet() {
+    var id = document.getElementById('snippetFormId').value;
+    var trigger = document.getElementById('snippetTrigger').value.trim();
+    var description = document.getElementById('snippetDescription').value.trim();
+    var body = document.getElementById('snippetBodyField').value;
+    if (!trigger) { document.getElementById('snippetTrigger').focus(); return; }
+    var extensions = [];
+    var checks = document.querySelectorAll('.snippetExt');
+    for (var i = 0; i < checks.length; i++) if (checks[i].checked) extensions.push(checks[i].value);
+    var data = { id: id, trigger: trigger, description: description, extensions: extensions, body: body };
+    send(id ? 'editSnippet' : 'addSnippet', data);
+    cancelSnippetForm();
+  }
+
+  function deleteSnippet(id) {
+    if (!confirm('Delete this snippet?')) return;
+    send('deleteSnippet', id);
+  }
+
   function testGhToken() {
     var token = document.getElementById('ghToken').value;
     var id = document.getElementById('ghFormId').value;
@@ -1785,6 +1933,11 @@
     if (msg.type === 'setGitHubAccounts') {
       ghAccounts = msg.accounts || [];
       renderGhAccounts();
+    }
+
+    if (msg.type === 'setSnippets') {
+      snippetsData = msg.snippets || [];
+      renderSnippets();
     }
 
     if (msg.type === 'testGitHubResult') {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Ask it to write Clarion code, explain procedures, refactor classes, build COM co
 - **Monaco source editor** &mdash; the default editor for Clarion `.clw`/`.inc` source: syntax highlighting, folding, F12/Ctrl+Click go-to-definition, inline diagnostics, and completion (toggleable under Options &rarr; Clarion Assistant &rarr; Editor Surfaces)
 - **Smart Formatter (Ctrl+I)** &mdash; reformats Clarion code with structure indentation and aligned declarations; configurable
 - **CA Embeditor** &mdash; right-click any procedure in the app tree to open its embed code directly in a fast Monaco/WebView2 editor; open multiple procedures as tabs
+- **Code Snippets (Ctrl+J)** &mdash; classic Clarion template-picker parity: insert reusable code with tab-stops and a `${SELECTED}` placeholder, managed from Settings &rarr; Snippets
 - **CA Explorer** &mdash; docked pad showing the active CA Embeditor tab's Local, Module &amp; Global Data, Declared Tables, Other Files, and their Keys, Columns, and Relations; drag a field to the editor or Window designer, copy/paste variables native-style, and a Cheat Sheet tab of editor shortcuts
 - **Evaluate Code** &mdash; interactive code review for entire apps, procedures, open files, or selected code
 - **Diff viewer** &mdash; Monaco-based side-by-side diffs with syntax highlighting
@@ -59,6 +60,15 @@ Clarion source files (`.clw`, `.inc`) open by default in a Monaco-powered editor
 ### Smart Formatter (Ctrl+I)
 
 Press **Ctrl+I** in the Monaco source editor or CA Embeditor to reformat Clarion code &mdash; consistent indentation for structures (IF/LOOP/CASE/ACCEPT) and aligned data declarations. As-you-type aids apply light formatting while you write, and the formatter's behavior is configurable.
+
+### Code Snippets (Ctrl+J)
+
+Press **Ctrl+J** in the CA Embeditor to open a code-snippet picker &mdash; the same shortcut as the classic Clarion text editor's template picker, filterable by trigger/description and scoped to the active file's extension.
+
+- **Managed from Settings &rarr; Snippets** &mdash; add/edit/delete snippets (trigger, description, extensions, body); stored globally in `%APPDATA%\ClarionAssistant\snippets.json`.
+- **Tab-stops** &mdash; bodies use VS Code-style snippet syntax (`$1`, `${1:default}`, `$0`); **Tab**/**Shift+Tab** cycles between stops after insertion.
+- **`${SELECTED}`** &mdash; substituted with the text selected when Ctrl+J was pressed, or left as a fillable tab-stop if nothing was selected.
+- **Auto-indent** &mdash; continuation lines match the indentation of the line Ctrl+J was triggered on.
 
 ### CA Embeditor &mdash; right-click a procedure to open it instantly
 

--- a/docs/ClarionAssistant-Guide.html
+++ b/docs/ClarionAssistant-Guide.html
@@ -440,6 +440,7 @@
     <h3>What's New</h3>
     <a href="#whats-new">Release Notes</a>
     <a href="#whats-new-50" class="sub">v5.1</a>
+    <a href="#whats-new-snippets" class="sub">Code Snippets (Ctrl+J)</a>
     <a href="#whats-new-sidecar" class="sub">Custom MCP Servers</a>
     <a href="#whats-new-codex" class="sub">Codex Backend</a>
     <a href="#whats-new-selfheal" class="sub">Codex Config Self-Heal</a>
@@ -467,6 +468,7 @@
     <a href="#ca-embeditor">Overview</a>
     <a href="#ca-embeditor-open" class="sub">Opening a Procedure</a>
     <a href="#ca-monaco-editor" class="sub">Monaco Source Editor</a>
+    <a href="#ca-snippets" class="sub">Code Snippets (Ctrl+J)</a>
     <a href="#ca-data-pad" class="sub">CA Explorer</a>
 
     <h3>Class Helper</h3>
@@ -534,6 +536,36 @@
     and a Smart Formatter &mdash; see <a href="#ca-embeditor">CA Embeditor &amp; CA Explorer</a> for the
     full walkthrough.
   </p>
+
+  <h3 id="whats-new-snippets">Code Snippets in the CA Embeditor <span style="font-weight:400;font-size:0.85em;color:var(--text-light)">(issue #49)</span></h3>
+
+  <p>
+    The CA Embeditor now has a Ctrl+J code-snippet picker, matching the classic Clarion text
+    editor's Ctrl+J template picker &mdash; see
+    <a href="#ca-snippets">Code Snippets (Ctrl+J)</a> for the full walkthrough.
+  </p>
+
+  <ul>
+    <li>
+      <strong>Settings &rarr; Snippets</strong> &mdash; add, edit, and delete snippets from a page in
+      the Clarion Assistant Settings dialog. Snippets are stored globally
+      (<code>%APPDATA%\ClarionAssistant\snippets.json</code>) and available across every solution.
+    </li>
+    <li>
+      <strong>Tab-stops</strong> &mdash; snippet bodies use the same tab-stop syntax as VS Code user
+      snippets (<code>$1</code>, <code>${1:default}</code>, <code>$0</code>); after inserting,
+      <kbd>Tab</kbd> / <kbd>Shift</kbd>+<kbd>Tab</kbd> cycles between the remaining stops.
+    </li>
+    <li>
+      <strong><code>${SELECTED}</code></strong> &mdash; a Clarion Assistant-specific placeholder
+      substituted with whatever text was selected when Ctrl+J was pressed (or left as a fillable
+      tab-stop when nothing was selected).
+    </li>
+    <li>
+      <strong>Extension scoping</strong> &mdash; a snippet can be restricted to specific file
+      extensions (e.g. only <code>.clw</code>), or left available everywhere.
+    </li>
+  </ul>
 
   <div class="section-intro">
     <p>
@@ -1466,6 +1498,49 @@
     declarations, and normalized code statements. As-you-type aids apply light formatting while you
     write. The formatter's behavior is configurable from its settings panel.
   </p>
+
+  <h3 id="ca-snippets">Code Snippets (Ctrl+J)</h3>
+
+  <p>
+    Press <kbd>Ctrl</kbd>+<kbd>J</kbd> in the CA Embeditor to open the code-snippet picker &mdash;
+    the same shortcut as the classic Clarion text editor's template picker, reimplemented on
+    Monaco's snippet engine. It's a dedicated picker (not folded into regular autocomplete): type
+    to filter by trigger or description, use <kbd>&uarr;</kbd>/<kbd>&darr;</kbd> to pick a row, and
+    <kbd>Enter</kbd> to insert (<kbd>Esc</kbd> to cancel).
+  </p>
+
+  <ul>
+    <li>
+      <strong>Managed from Settings</strong> &mdash; open <strong>Clarion Assistant &rarr;
+      Settings &rarr; Snippets</strong> to add, edit, or delete snippets. Each has a trigger, an
+      optional description, an optional list of file extensions it applies to (blank = all), and a
+      body.
+    </li>
+    <li>
+      <strong>Tab-stops</strong> &mdash; the body uses the same placeholder syntax as VS Code user
+      snippets: <code>$1</code>, <code>$2</code>&hellip; number the stops, <code>${1:texto}</code>
+      pre-fills a stop with default text, and <code>$0</code> is the final cursor position (visited
+      last). After inserting, press <kbd>Tab</kbd> to jump to the next stop and
+      <kbd>Shift</kbd>+<kbd>Tab</kbd> to go back.
+    </li>
+    <li>
+      <strong><code>${SELECTED}</code></strong> &mdash; select some text before pressing
+      <kbd>Ctrl</kbd>+<kbd>J</kbd> and any <code>${SELECTED}</code> in the chosen snippet's body is
+      replaced with it (handy for wrapping an existing variable or file name in a template, e.g. a
+      standard <code>SET</code>/<code>LOOP</code> block). If nothing is selected,
+      <code>${SELECTED}</code> becomes an ordinary fillable tab-stop instead of inserting blank.
+    </li>
+    <li>
+      <strong>Auto-indent</strong> &mdash; every line of the snippet after the first automatically
+      picks up the indentation of the line Ctrl+J was pressed on, so multi-line bodies (a
+      <code>LOOP</code>/<code>END</code> block, for example) land aligned with the surrounding code.
+    </li>
+    <li>
+      <strong>Scoped to the file type</strong> &mdash; a snippet restricted to specific extensions
+      only shows up while editing a matching file; leave the extension list empty to make it
+      available everywhere.
+    </li>
+  </ul>
 
   <h3 id="ca-data-pad">CA Explorer</h3>
 


### PR DESCRIPTION
## Summary
- Replicates the classic Clarion text editor's Ctrl+J template picker on the Monaco-based CA Embeditor, using Monaco snippet syntax for tab-stops.
- Ctrl+J opens a dedicated filterable picker (not folded into the LSP completion provider), scoped to the active file's extension.
- Snippet bodies support `$1` / `${1:default}` / `$0` tab-stops plus a custom `${SELECTED}` placeholder that's substituted with whatever text was selected when Ctrl+J was pressed (falls back to a fillable tab-stop when nothing was selected). Continuation lines auto-indent to match the line Ctrl+J was triggered on.
- New "Snippets" page in Settings (table + add/edit/delete modal, mirrors the existing GitHub Accounts page) backed by a new `SnippetStore` — global JSON storage at `%APPDATA%\ClarionAssistant\snippets.json`. Changes broadcast live to every open embeditor tab.
- Snippet insertion goes through `executeEdits` with a small home-grown tab-stop engine rather than Monaco's native `editor.action.insertSnippet` — that action's edits aren't recognized by `installReadOnlyGuard` as a legal single edit inside embed slots (same reason the Data-pad drop path already avoids it), so it silently gets undone there.

Closes #49.

## Test plan
- [x] Manually verified in a running Clarion 11 IDE: create/edit/delete snippets in Settings > Snippets.
- [x] Ctrl+J in the CA Embeditor (procedure/embed mode) opens the picker, filters live, inserts with tab-stops and `${SELECTED}` substitution working with and without an active selection.
- [x] Tab/Shift+Tab cycles between remaining tab-stops after insertion.
- [x] Continuation-line indentation matches the trigger line.
- [x] Editing snippets in Settings while an embeditor tab is open updates that tab's picker live (broadcast).
- [x] Extension filtering (`.clw`-only snippet doesn't show while editing a `.tpl`, etc.).
- [ ] Reviewer: exercise Ctrl+F/Ctrl+H/F12/Ctrl+D still work normally and don't fire while the snippet picker is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)