### PR TITLE
Fix clean-checkout build: PS 5.1 script encoding + indexer SQLite reference

### DIFF
--- a/ClarionAssistant/Update-Version.ps1
+++ b/ClarionAssistant/Update-Version.ps1
@@ -1,4 +1,4 @@
-# Update-Version.ps1
+﻿# Update-Version.ps1
 # Pre-build hook called by ClarionAssistant.csproj.
 # 1. Reads Version.props
 # 2. Increments VersionBuild by 1 (unless -NoIncrement is passed)

--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -1,4 +1,4 @@
-# ClarionAssistant Deploy Script
+﻿# ClarionAssistant Deploy Script
 # Builds and deploys the addin for Clarion 10, 11, 12, or all.
 # Usage: .\deploy.ps1 [-Version 10|11|12|all] [-NoBuild] [-Kill]
 

--- a/ClarionAssistant/indexer/ClarionIndexer.csproj
+++ b/ClarionAssistant/indexer/ClarionIndexer.csproj
@@ -44,10 +44,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <!-- Resolve the NuGet global-packages folder portably (no per-machine user path). -->
+  <!-- SQLite (FTS5): use the vendored DLLs the main addin ships in ..\lib\sqlite-fts5,
+       instead of the unpublished stub.system.data.sqlite.core.netframework NuGet package
+       (not restorable on a clean checkout). Keeps the indexer self-contained per #30. -->
   <PropertyGroup>
-    <NuGetPackagesRoot Condition=" '$(NuGetPackagesRoot)' == '' ">$(USERPROFILE)\.nuget\packages</NuGetPackagesRoot>
-    <SqliteCorePkg>$(NuGetPackagesRoot)\stub.system.data.sqlite.core.netframework\1.0.118</SqliteCorePkg>
+    <SqliteVendored>$(MSBuildProjectDirectory)\..\lib\sqlite-fts5</SqliteVendored>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -55,7 +56,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Data.SQLite">
-      <HintPath>$(SqliteCorePkg)\lib\net40\System.Data.SQLite.dll</HintPath>
+      <HintPath>$(SqliteVendored)\System.Data.SQLite.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -82,6 +83,6 @@
   <!-- Copy x86 SQLite.Interop.dll to output directory after build -->
   <Target Name="CopySQLiteInterop" AfterTargets="Build">
     <MakeDir Directories="$(OutputPath)x86" />
-    <Copy SourceFiles="$(SqliteCorePkg)\build\net40\x86\SQLite.Interop.dll" DestinationFolder="$(OutputPath)x86" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(SqliteVendored)\SQLite.Interop.dll" DestinationFolder="$(OutputPath)x86" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
+++ b/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Re-pin the bundled Clarion LSP server to a tagged release of msarson/Clarion-Extension
     and rebuild it with our CodeGraph overlay, instead of hand-maintaining a drifting snapshot.


### PR DESCRIPTION
Two fixes that block building/deploying from a fresh clone on **Windows PowerShell 5.1** (the in-box shell) — hit while building v5.2 from source on a machine without PowerShell 7. Both are in the contributor-onboarding spirit of #30/#40.

## 1. `.ps1` scripts break under Windows PowerShell 5.1 (missing BOM)
`deploy.ps1`, `lsp-server-sync/Sync-LspServer.ps1`, and `Update-Version.ps1` are UTF-8 **without a BOM** and contain em-dashes (`—`). Windows PowerShell 5.1 reads a BOM-less `.ps1` as the ANSI code page, so each em-dash (`E2 80 94`) decodes into `â€"` — the stray `"` opens a phantom string and cascades into `missing )` / `missing }` parse errors, and the script won't run at all. PowerShell 7 defaults to UTF-8 so the author never sees it.

**Fix:** add a UTF-8 BOM to the three scripts. Minimal and encoding-preserving; PS7 is unaffected.
_(Alternative if you'd rather avoid a BOM: replace the em-dashes with ASCII `-` so the scripts are pure ASCII. Happy to switch this PR to that approach.)_

## 2. Indexer references an unpublished stub NuGet package
`indexer/ClarionIndexer.csproj` resolves `System.Data.SQLite` via a HintPath into `stub.system.data.sqlite.core.netframework\1.0.118`, which isn't in the NuGet cache and has no `PackageReference` to restore — so the indexer fails to compile on a clean checkout (`CS0234`/`CS0246`).

**Fix:** point the reference and the `CopySQLiteInterop` target at the vendored DLLs the main addin already ships in `ClarionAssistant\lib\sqlite-fts5\` (`System.Data.SQLite.dll` + x86 `SQLite.Interop.dll`), making the indexer self-contained — the actual goal of #30.

## Verification
With both fixes, `deploy.ps1 -Version all` builds the addin (C10/C11/C12) **and** the indexer, and deploys cleanly to all three installs on a PS 5.1 box. No functional/runtime code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)