### PR TITLE
fix(formatter): keyword-named data labels no longer open phantom structures

### DIFF
--- a/ClarionAssistant/Terminal/clarion-formatter.js
+++ b/ClarionAssistant/Terminal/clarion-formatter.js
@@ -107,12 +107,22 @@
     // The structure/keyword driving a line (uppercased) or ''. If the line begins (column 1) with a
     // non-keyword identifier followed by whitespace, that's a LABEL and the keyword is the next token;
     // otherwise the first token itself is the keyword (handles unlabeled structures like "MENUBAR,USE").
+    // A column-1 token that MATCHES a data-structure keyword but is really a LABEL: it is followed
+    // by whitespace + another identifier (the type), e.g. ABC's "Toolbar ToolbarClass" / "Menu x".
+    // A genuine unlabeled structure header (MENUBAR,USE / TOOLBAR / TOOLBAR,AT()) is followed by a
+    // comma or nothing — never a second identifier — so this stays false for those. Restricted to
+    // DATASTRUCT keywords so statement/control keywords (IF x, LOOP i) are unaffected. Without this,
+    // ABC's "Toolbar ToolbarClass" opens a phantom TOOLBAR structure that never closes, cascading
+    // every following ROUTINE/statement out to the data column (GitHub: keyword-named data labels).
+    function labelLikeStructKeyword(firstTok, code) {
+        return DATASTRUCT_SET[firstTok] && /^[A-Za-z_][A-Za-z0-9_:.]*\s+[A-Za-z_]/.test(code);
+    }
     function structureWord(raw) {
         var code = stripComment(raw);
         var m = /^\s*([A-Za-z_][A-Za-z0-9_:.]*)/.exec(code);
         if (!m) return '';
         var firstTok = m[1].toUpperCase();
-        if (startsInCol1(raw) && !KEYWORD_SET[firstTok]) {
+        if (startsInCol1(raw) && (!KEYWORD_SET[firstTok] || labelLikeStructKeyword(firstTok, code))) {
             var lm = /^([A-Za-z_][A-Za-z0-9_:.]*)\s+(.*)$/.exec(code);
             return lm ? leadingKeyword(lm[2]) : '';   // label + keyword, or label-only
         }
@@ -126,7 +136,10 @@
     function isDataDecl(raw) {
         if (!startsInCol1(raw)) return false;
         var code = stripComment(raw), first = leadingKeyword(code);
-        if (!first || KEYWORD_SET[first]) return false;
+        if (!first) return false;
+        // A keyword-led line is not a declaration UNLESS it's a struct-keyword-spelled LABEL
+        // followed by a type (ABC's "Toolbar ToolbarClass") — that IS a decl.
+        if (KEYWORD_SET[first] && !labelLikeStructKeyword(first, code)) return false;
         var sp = splitLabel(rtrim(code));
         if (!sp) return false;
         var r = sp.rest.charAt(0);

--- a/ClarionAssistant/Terminal/test/clarion-formatter.test.js
+++ b/ClarionAssistant/Terminal/test/clarion-formatter.test.js
@@ -332,5 +332,53 @@ console.log('\nC#/JS formatter-key list parity:');
     }
 })();
 
+// ---- Keyword-named data labels (ABC "Toolbar ToolbarClass") ----
+// A column-1 LABEL spelled like a data-structure keyword (Toolbar/Menu/Sheet/Tab/Option/Menubar/
+// Form/Report) must be read as a label+type declaration, NOT an unlabeled structure header. Before
+// the fix, "Toolbar ToolbarClass" opened a phantom TOOLBAR structure that never closed, cascading
+// every following ROUTINE and statement out to the data column.
+console.log('\nKeyword-named data labels (label + type, not a structure):');
+(function () {
+    var o = { alignAssignments: false, keywordCase: 'asis', otherNameCase: 'asis' };
+    function fmt(src) { return F.formatClarion(src, o).text.replace(/\r\n/g, '\n').split('\n'); }
+    function lead(l) { return /^ */.exec(l)[0].length; }
+
+    // The exact ABC shape: Toolbar object declaration, procedure CODE, then a ROUTINE with DATA/CODE.
+    var src = ['Main PROCEDURE', 'LocVar LONG', 'Toolbar ToolbarClass', '  CODE',
+        '  LocVar = 1', '', 'MyRtn ROUTINE', '  DATA', 'V LONG', '  CODE', '  V = 2'].join('\n');
+    var out = fmt(src);
+    // The routine's statement (last line) must sit at one tab (4), not blown out to the data column.
+    ok('routine body at one tab after keyword-named label', lead(out[out.length - 1]) === 4,
+        'lead=' + lead(out[out.length - 1]) + '\n      ' + JSON.stringify(out));
+    // The label itself must be preserved as-declared (not uppercased to TOOLBAR by keyword casing).
+    ok('"Toolbar" label preserved (not cased to TOOLBAR)',
+        out.some(function (l) { return /^Toolbar\s+ToolbarClass/.test(l); }), JSON.stringify(out));
+
+    // Structure balance via the classifier: opensId per opened structure, cat==='close' per END.
+    function structDepth(srcLines) {
+        var cls = F._internal.classify(srcLines, F.DEFAULTS, 0);
+        var depth = 0, opened = 0;
+        cls.recs.forEach(function (r) {
+            if (r.opensId) { depth++; opened++; }
+            else if (r.cat === 'close') depth--;
+        });
+        return { finalDepth: depth, opened: opened };
+    }
+    // The Toolbar-label case must open NOTHING (that was the bug — a phantom TOOLBAR structure).
+    var td = structDepth(['Main PROCEDURE', 'Toolbar ToolbarClass', '  CODE', '  x = 1']);
+    ok('"Toolbar ToolbarClass" opens no structure', td.opened === 0 && td.finalDepth === 0, JSON.stringify(td));
+    // A genuinely LABELED structure whose label is spelled like a keyword still opens AND closes.
+    var gd = structDepth(['Main PROCEDURE', 'Group GROUP', 'F1 LONG', 'END', 'After LONG', '  CODE', '  x = 1']);
+    ok('"Group GROUP" opens exactly one structure', gd.opened === 1, JSON.stringify(gd));
+    ok('"Group GROUP" structure closes (depth 0)', gd.finalDepth === 0, JSON.stringify(gd));
+    // Real unlabeled structure headers (comma-attributes) are unaffected: still open and close.
+    var wd = structDepth(['Main PROCEDURE', 'Win WINDOW,AT(0,0,80,80)', 'MENUBAR,USE(?m)', 'ITEM(\'E&xit\'),USE(?x)', 'END', 'END', '  CODE', '  x = 1']);
+    ok('unlabeled WINDOW+MENUBAR open and close (depth 0)', wd.finalDepth === 0 && wd.opened >= 2, JSON.stringify(wd));
+
+    // Control keywords followed by an identifier (IF X, LOOP I) are never mistaken for declarations.
+    var c = fmt(['Main PROCEDURE', 'X LONG', '  CODE', '  IF X = 1', '    DoIt()', '  END'].join('\n'));
+    ok('IF X not treated as a declaration', lead(c[3]) === 4, 'IF lead=' + lead(c[3]) + '\n      ' + JSON.stringify(c));
+})();
+
 console.log('\n' + pass + ' passed, ' + fail + ' failed.');
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Problem

Formatting (Ctrl+I) a routine inside an ABC window procedure blows the whole `CODE` body out to the data column (~col 40):

```
SendSignedPing                          ROUTINE
                                        DATA
TestVar                                 LONG
                                        CODE
                                        GLO:gAPIBaseURL = 'https://localhost:7208'
                                        lAccount        = 9999
```

## Root cause

The Smart Formatter keeps a stack of open structures; `ROUTINE`/`DATA`/`CODE` scope transitions only fire when that stack is empty. A column-1 data **label** spelled like a data-structure keyword — most commonly ABC's generated `Toolbar ToolbarClass`, but also `Menu`/`Sheet`/`Tab`/`Option`/`Menubar`/`Form`/`Report` — was read by `structureWord()`/`isDataDecl()` as an **unlabeled structure header**. It opened a `TOOLBAR` structure that never gets an `END`, so the stack stayed open and every following `ROUTINE` and statement cascaded to the data column. It also mis-uppercased the label (`Toolbar` → `TOOLBAR`).

This affects essentially every ABC window procedure that has routines.

Diagnosed by tracing the structure stack over a real 9.2k-line generated `.clw`: at the routine, stack depth was `1`, held open by `line 48: Toolbar ToolbarClass`.

## Fix

A column-1 keyword-spelled token followed by whitespace + another identifier (the type) is a **label**, not a structure header (`Toolbar ToolbarClass`). Genuine unlabeled structures are followed by a comma or nothing (`TOOLBAR,AT(...)`), so they're unaffected; a truly labelled structure whose label matches a keyword (`Group GROUP`) still opens and closes. Restricted to data-structure keywords, so statement/control keywords (`IF X`, `LOOP I`) are untouched.

4-line change across two helpers (`labelLikeStructKeyword` guard added to `structureWord` and `isDataDecl`).

## Tests

`node ClarionAssistant/Terminal/test/clarion-formatter.test.js` → **71 passed, 0 failed** (7 new). New cases: the Toolbar-label cascade (routine body back at one tab), label preserved (not cased), `Toolbar ToolbarClass` opens no structure, `Group GROUP` still balances, real unlabeled `WINDOW`+`MENUBAR` still open/close, and `IF X` not read as a declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)