### PR TITLE
fix(embeditor): navigate Monaco overlay to native caret position on attach

### DIFF
--- a/ClarionAssistant/Services/EmbeditorCompletionService.cs
+++ b/ClarionAssistant/Services/EmbeditorCompletionService.cs
@@ -101,6 +101,18 @@ namespace ClarionAssistant.Services
             return true;
         }
 
+        /// <summary>Return the 1-based line the native embeditor caret is on, or 0 on failure.</summary>
+        public static int GetNativeCaretLine()
+        {
+            try
+            {
+                var control = GetActiveEmbeditorControl(new StringBuilder());
+                if (control == null) return 0;
+                return control.ActiveTextAreaControl.Caret.Line + 1; // ICSharpCode caret is 0-based
+            }
+            catch { return 0; }
+        }
+
         /// <summary>
         /// Reflection-based locate of the embeditor's ICSharpCode TextEditorControl,
         /// then a typed cast. Mirrors AppTreeService.GetClaGenEditor()'s search.

--- a/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
@@ -133,10 +133,16 @@ namespace ClarionAssistant.Services
                 // Warm the LSP now so its background parse overlaps the WebView2/Monaco load. Fire-and-forget.
                 try { EmbeditorCompletionService.LspStarter?.Invoke(); } catch { }
 
+                // Read the native caret position NOW (before the embed closes under us) so Monaco lands at the
+                // embed point the developer had the cursor on — not the last-saved cursor for this procedure.
+                int nativeLine = 0;
+                try { nativeLine = EmbeditorCompletionService.GetNativeCaretLine(); } catch { }
+
                 // Freeze-safe tail — dock on a settled turn. Keep WebView2 async init off any reentrant stack. The
                 // pre-cover is already up over the host; ShowAsEmbedOverlay ADOPTS it (no second cover, no gap).
                 var ctx = WindowsFormsSynchronizationContext.Current ?? new WindowsFormsSynchronizationContext();
                 string capProc = procName; string capSrc = source; List<int[]> capRanges = ranges; bool capDark = isDark;
+                int capNativeLine = nativeLine;
                 var capHost = host; var capCover = preCover; var capEditor = appTree.GetOpenClaGenEditor();
                 ctx.Post(_ =>
                 {
@@ -149,7 +155,7 @@ namespace ClarionAssistant.Services
                             System.Diagnostics.Debug.WriteLine("[ModernEmbeditorLauncher] AttachOverlayToOpenEmbed: no ClaGenEditor host — cannot overlay.");
                             return;
                         }
-                        var overlay = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc, false);
+                        var overlay = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc, false, capNativeLine);
                         overlay.ShowAsEmbedOverlay(h, capEditor ?? new AppTreeService().GetOpenClaGenEditor(), capCover);
                     }
                     catch (Exception ex)

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -949,8 +949,13 @@ namespace ClarionAssistant.Terminal
             catch { }
         }
 
+        // When set (> 0), overrides the saved cursor position on first open — used by AttachOverlayToOpenEmbed
+        // to land Monaco at the embed point the developer had the native caret on when the overlay fired.
+        private int _initialLine;
+
         public ModernEmbeditorViewContent(string title, string sourceText, List<int[]> editableRanges,
-            string language = "clarion", bool isDark = true, string procedureName = null, bool liveLinked = false)
+            string language = "clarion", bool isDark = true, string procedureName = null, bool liveLinked = false,
+            int initialLine = 0)
         {
             _title = title ?? "Embeditor";
             _sourceText = sourceText ?? "";
@@ -961,6 +966,7 @@ namespace ClarionAssistant.Terminal
             _saveEnabled = !string.IsNullOrWhiteSpace(procedureName);
             _originalSlotTexts = ModernEmbeditorSaver.ExtractSlotTexts(_sourceText, _editableRanges);
             _lspFileName = MakeLspFileName(procedureName);
+            _initialLine = initialLine;
             TitleName = "CA: " + _title;
 
             // Reusable Monaco surface; we are its host (IMonacoEditorHost). It self-inits on HandleCreated.
@@ -2982,6 +2988,10 @@ namespace ClarionAssistant.Terminal
                     bookmarksJson = ModernEmbeditorState.BookmarksJson(bms);
                 }
                 catch { }
+
+                // Native-caret override: when the overlay attached to an already-open native embed, land Monaco
+                // at the embed point the developer was on — not the last-saved cursor for this procedure.
+                if (_initialLine > 0) { cursorLine = _initialLine; cursorColumn = 1; _initialLine = 0; }
 
                 string snippetsJson;
                 try { snippetsJson = SnippetStore.ToJson(SnippetStore.Load()); }


### PR DESCRIPTION
## Problem

When the CA Monaco overlay fires via the poll-detect path (ticket 4d16b53a), it was opening Monaco at the last *saved* cursor for that procedure instead of the embed point the developer had the cursor on in the native Clarion embeditor. Net result: click embed point X → Monaco opens at line 1 (or wherever the cursor was last session).

## Root cause

`AttachOverlayToOpenEmbed` never read the native caret position. `SendSource()` only restores from `ModernEmbeditorState` (persisted state), with no override path for the "just-opened from native" case.

## Fix

- `EmbeditorCompletionService.GetNativeCaretLine()` — reads `TextEditorControl.ActiveTextAreaControl.Caret.Line` (0-based → 1-based).
- `ModernEmbeditorLauncher.AttachOverlayToOpenEmbed` — reads the native caret before the deferred `ctx.Post` (the embed is still open at that point) and captures it for the overlay constructor.
- `ModernEmbeditorViewContent` — new `int initialLine = 0` constructor parameter; `SendSource()` overrides `cursorLine` with it once on first paint, then clears it so subsequent navigations are unaffected.

## Test

1. Open a procedure in the native Clarion embeditor (via Clarion's "Embeditor Source" menu).
2. Click on an embed point that is NOT at line 1.
3. The CA Monaco overlay should open with the cursor/view centred on that embed point, not at the top of the file.