### PR TITLE
feat(embeditor): LSP global scope via real module path + MEMBER header (closes #56)

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Services\AppTreeService.cs" />
     <Compile Include="Services\IdeReflectionService.cs" />
     <Compile Include="Services\EmbeditorCompletionService.cs" />
+    <Compile Include="Services\EmbedLspContext.cs" />
     <Compile Include="ShowModernEmbeditorCommand.cs" />
     <Compile Include="ClarionBindingAssemblyResolver.cs" />
     <Compile Include="LspAutostartCommand.cs" />

--- a/ClarionAssistant/Services/EmbedLspContext.cs
+++ b/ClarionAssistant/Services/EmbedLspContext.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Real-module LSP context for the CA Embeditor (GitHub #56 — embed global scope via a synthetic
+    /// MEMBER header + the module's REAL path).
+    ///
+    /// The embed buffer is a procedure slice with no module header, and it used to be addressed to the
+    /// LSP by a synthetic bare name (e.g. "UpdateCustomer.clw", no directory). The Clarion LSP resolves
+    /// a member module's GLOBAL scope (program globals, file/field labels, ABC classes) by following its
+    /// MEMBER('App.clw') to the parent program file on disk — roughly path.resolve(dirOfCurrentFile, arg)
+    /// + fs.existsSync. A directory-less, header-less buffer gives that resolution nothing to work from,
+    /// so program globals never resolved inside the embed.
+    ///
+    /// This context fixes both halves, WITHOUT touching the Monaco buffer itself:
+    ///   1. Address the buffer by the generated module's REAL full path — PweeEditorDetails.AppName's
+    ///      directory + PweeEditorDetails.Module — the generated .clw already on disk and in the project.
+    ///      The buffer then lives in the real project directory (redirection/libsrc/project match).
+    ///   2. Prepend the module's own MEMBER(...) line — read VERBATIM from the on-disk module so the
+    ///      exact argument form matches — to every LSP-bound copy of the buffer. MEMBER→parent resolution
+    ///      then lands on the real PROGRAM .clw and pulls in global scope.
+    ///
+    /// The prepend happens ONLY in the LSP-facing buffer (requests carry <see cref="LineOffset"/>);
+    /// the Monaco model, editable ranges, caret mirror, and save/write-back all keep their existing
+    /// 1:1 line mapping with the native document.
+    ///
+    /// Capture timing matters: PweeEditorDetails exists only while the NATIVE embeditor is open, and the
+    /// snapshot launcher cancels it before the Monaco tab is constructed — so the launcher captures this
+    /// context at mirror time and passes it into the view.
+    ///
+    /// While a context is active, the pushed buffer SHADOWS the on-disk module in the LSP under the same
+    /// path. There is no didClose in the transport, so <see cref="RevertShadow"/> pushes the on-disk
+    /// content back on tab teardown to restore the server to the truth.
+    /// </summary>
+    public sealed class EmbedLspContext
+    {
+        /// <summary>Full path of the generated module .clw on disk (dir of the .app + module name).
+        /// The embed buffer is addressed to the LSP by this path.</summary>
+        public string RealPath { get; private set; }
+
+        /// <summary>The module's own MEMBER(...) line, read verbatim from disk (or synthesized from the
+        /// .app name when the read fails). Prepended to every LSP-bound buffer.</summary>
+        public string HeaderLine { get; private set; }
+
+        /// <summary>Lines prepended to the LSP-facing buffer (the MEMBER header). Add to a Monaco line
+        /// to get the LSP line; subtract from an LSP line to get back to Monaco.</summary>
+        public int LineOffset { get { return 1; } }
+
+        private EmbedLspContext(string realPath, string headerLine)
+        {
+            RealPath = realPath;
+            HeaderLine = headerLine;
+        }
+
+        /// <summary>
+        /// Build the context from the currently-open native embeditor's PweeEditorDetails, or null when
+        /// it can't be built (no embed open, details lack AppName/Module, or the generated module isn't
+        /// on disk — e.g. never generated). Null simply means "keep the synthetic-name behavior".
+        /// MUST be called while the native embeditor is still open (the snapshot path cancels it later).
+        /// </summary>
+        public static EmbedLspContext TryCapture(AppTreeService appTree = null)
+        {
+            try
+            {
+                var pwee = (appTree ?? new AppTreeService()).GetOpenPweeDetails();
+                if (pwee == null) return null;
+                string appName = GetProp(pwee, "AppName") as string;
+                string module = GetProp(pwee, "Module") as string;
+                if (string.IsNullOrEmpty(appName) || string.IsNullOrEmpty(module)) return null;
+
+                string dir = Path.GetDirectoryName(appName);
+                if (string.IsNullOrEmpty(dir)) return null;
+                string candidate = Path.Combine(dir, Path.GetFileName(module.Trim()));
+                if (!File.Exists(candidate))
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        "[EmbedLspContext] generated module not on disk: '" + candidate + "' — keeping synthetic LSP name.");
+                    return null;
+                }
+
+                string header = ReadMemberLine(candidate)
+                    ?? "  MEMBER('" + Path.GetFileNameWithoutExtension(appName) + ".clw')";
+                System.Diagnostics.Debug.WriteLine(
+                    "[EmbedLspContext] captured: realPath='" + candidate + "', header='" + header.Trim() + "'");
+                return new EmbedLspContext(candidate, header);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[EmbedLspContext] TryCapture: " + ex.Message);
+                return null;
+            }
+        }
+
+        /// <summary>The LSP-facing copy of a Monaco buffer: the MEMBER header + the buffer. The embed
+        /// buffer is a procedure slice, so it never carries its own MEMBER/PROGRAM — but guard anyway
+        /// (a buffer that already opens with one is passed through untouched, offset stays harmless-safe
+        /// only because such a buffer never occurs in embed mode).</summary>
+        public string WrapBuffer(string buffer)
+        {
+            string b = buffer ?? "";
+            string firstLine = b;
+            int nl = b.IndexOf('\n');
+            if (nl >= 0) firstLine = b.Substring(0, nl);
+            string t = firstLine.TrimStart();
+            if (t.StartsWith("MEMBER", StringComparison.OrdinalIgnoreCase) ||
+                t.StartsWith("PROGRAM", StringComparison.OrdinalIgnoreCase))
+                return b;
+            return HeaderLine + "\r\n" + b;
+        }
+
+        /// <summary>
+        /// Un-shadow the on-disk module in the LSP. While the embeditor tab is open, every request pushes
+        /// the (wrapped) embed buffer to the server under <see cref="RealPath"/>, overriding the on-disk
+        /// file in the server's view. The transport exposes no didClose, so on tab teardown we push the
+        /// REAL on-disk content back. Safe no-op when the LSP isn't running or the file vanished.
+        /// </summary>
+        public void RevertShadow()
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(RealPath) || !File.Exists(RealPath)) return;
+                if (!SharedLspBridge.IsRunning) return;
+                SharedLspBridge.EnsureBufferSynced(RealPath, File.ReadAllText(RealPath));
+                System.Diagnostics.Debug.WriteLine("[EmbedLspContext] reverted LSP shadow for '" + RealPath + "'.");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[EmbedLspContext] RevertShadow: " + ex.Message);
+            }
+        }
+
+        /// <summary>The module's own MEMBER(...) line, verbatim from disk (skipping leading blanks and
+        /// '!' comments), or null when none precedes the first real statement.</summary>
+        private static string ReadMemberLine(string path)
+        {
+            try
+            {
+                foreach (var line in File.ReadLines(path))
+                {
+                    var t = line.Trim();
+                    if (t.StartsWith("MEMBER", StringComparison.OrdinalIgnoreCase)) return line;
+                    if (t.Length > 0 && !t.StartsWith("!")) break; // first real statement — MEMBER must precede it
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        private static object GetProp(object obj, string name)
+        {
+            if (obj == null) return null;
+            try
+            {
+                var p = obj.GetType().GetProperty(name,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                return (p != null && p.GetIndexParameters().Length == 0) ? p.GetValue(obj, null) : null;
+            }
+            catch { return null; }
+        }
+    }
+}

--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -79,7 +79,7 @@ namespace ClarionAssistant.Services
         /// </summary>
         public static List<Dictionary<string, object>> Compute(
             string lspFileName, string buffer, List<int[]> ranges, string procedureName,
-            bool embedSlotChecks = true)
+            bool embedSlotChecks = true, EmbedLspContext lspContext = null)
         {
             var markers = new List<Dictionary<string, object>>();
             if (string.IsNullOrEmpty(buffer) || ranges == null || ranges.Count == 0) return markers;
@@ -92,7 +92,11 @@ namespace ClarionAssistant.Services
                 // Route through SharedLspBridge: shared ClarionLsp when active, else the bundled LspClient.
                 if (SharedLspBridge.IsRunning && !string.IsNullOrEmpty(lspFileName))
                 {
-                    SharedLspBridge.EnsureBufferSynced(lspFileName, buffer);
+                    // #56: with a real-module context the LSP sees the MEMBER-wrapped buffer, so its line
+                    // numbers run one AHEAD of Monaco's — subtract the offset before clamping to slots.
+                    int off = (lspContext != null) ? lspContext.LineOffset : 0;
+                    SharedLspBridge.EnsureBufferSynced(lspFileName,
+                        (lspContext != null) ? lspContext.WrapBuffer(buffer) : buffer);
                     var wait = SharedLspBridge.WaitForDiagnostics(lspFileName, 1500, true);
                     List<LspClient.DiagnosticEntry> entries =
                         (wait != null && !wait.Pending && wait.Entries != null)
@@ -102,9 +106,10 @@ namespace ClarionAssistant.Services
                     foreach (var d in entries)
                     {
                         // DiagnosticEntry is 0-based; ranges are 1-based inclusive.
-                        int line1 = d.Line + 1;
+                        int line1 = d.Line + 1 - off;
+                        if (line1 < 1) continue; // marker on the injected MEMBER header — not user code
                         if (!InAnyRange(line1, ranges)) continue; // drop generated-line noise / mislocations
-                        markers.Add(Marker(line1, d.Character + 1, d.EndLine + 1, d.EndCharacter + 1,
+                        markers.Add(Marker(line1, d.Character + 1, Math.Max(line1, d.EndLine + 1 - off), d.EndCharacter + 1,
                             string.IsNullOrEmpty(d.Message) ? "Clarion diagnostic" : d.Message,
                             LspSevToMonaco(d.Severity)));
                     }

--- a/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
@@ -43,6 +43,11 @@ namespace ClarionAssistant.Services
                 // ~halving it. Idempotent, fire-and-forget.
                 try { EmbeditorCompletionService.LspStarter?.Invoke(); } catch { }
 
+                // #56: capture the real-module LSP context NOW — PweeEditorDetails only exists while the
+                // native embeditor is open, and CancelEmbeditor below tears it down.
+                EmbedLspContext lspCtx = null;
+                try { lspCtx = EmbedLspContext.TryCapture(appTree); } catch { }
+
                 // OpenAndMirror leaves the embeditor open; we made no edits, so discard/close to free the lock.
                 try { appTree.CancelEmbeditor(); } catch { }
                 WaitForEmbedClosed(appTree, 3000);
@@ -57,11 +62,13 @@ namespace ClarionAssistant.Services
                 // and the message/input state drains first — deterministically reproducing that gap.
                 var ctx = WindowsFormsSynchronizationContext.Current ?? new WindowsFormsSynchronizationContext();
                 string capProc = procName; string capSrc = source; List<int[]> capRanges = ranges; bool capDark = isDark;
+                EmbedLspContext capLspCtx = lspCtx;
                 ctx.Post(_ =>
                 {
                     try
                     {
-                        var view = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc);
+                        var view = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc,
+                            false, 0, capLspCtx);
                         WorkbenchSingleton.Workbench.ShowView(view);
                     }
                     catch (Exception ex)
@@ -133,6 +140,11 @@ namespace ClarionAssistant.Services
                 // Warm the LSP now so its background parse overlaps the WebView2/Monaco load. Fire-and-forget.
                 try { EmbeditorCompletionService.LspStarter?.Invoke(); } catch { }
 
+                // #56: capture the real-module LSP context from the live embed (it stays open in overlay
+                // mode, but capture eagerly for symmetry with the snapshot path).
+                EmbedLspContext lspCtx = null;
+                try { lspCtx = EmbedLspContext.TryCapture(appTree); } catch { }
+
                 // Read the native caret position NOW (before the embed closes under us) so Monaco lands at the
                 // embed point the developer had the cursor on — not the last-saved cursor for this procedure.
                 int nativeLine = 0;
@@ -143,6 +155,7 @@ namespace ClarionAssistant.Services
                 var ctx = WindowsFormsSynchronizationContext.Current ?? new WindowsFormsSynchronizationContext();
                 string capProc = procName; string capSrc = source; List<int[]> capRanges = ranges; bool capDark = isDark;
                 int capNativeLine = nativeLine;
+                EmbedLspContext capLspCtx = lspCtx;
                 var capHost = host; var capCover = preCover; var capEditor = appTree.GetOpenClaGenEditor();
                 ctx.Post(_ =>
                 {
@@ -155,7 +168,7 @@ namespace ClarionAssistant.Services
                             System.Diagnostics.Debug.WriteLine("[ModernEmbeditorLauncher] AttachOverlayToOpenEmbed: no ClaGenEditor host — cannot overlay.");
                             return;
                         }
-                        var overlay = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc, false, capNativeLine);
+                        var overlay = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc, false, capNativeLine, capLspCtx);
                         overlay.ShowAsEmbedOverlay(h, capEditor ?? new AppTreeService().GetOpenClaGenEditor(), capCover);
                     }
                     catch (Exception ex)

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -44,6 +44,9 @@ namespace ClarionAssistant.Terminal
         private List<string> _originalSlotTexts;     // baseline slot contents for change detection
         private readonly bool _saveEnabled;
         private readonly string _lspFileName;        // synthetic .clw URI for LSP completion/hover requests
+        // Real-module LSP context (#56): when captured, _lspFileName is the generated module's REAL path and
+        // every LSP-bound buffer is wrapped with its MEMBER header (+1 line) — Monaco itself is untouched.
+        private readonly Services.EmbedLspContext _lspContext;
 
         // LIVE-LINKED mode (ticket a5bbf005): this tab holds Clarion's native embeditor OPEN underneath the
         // floating Monaco, so save writes straight back into it (no re-open / no locator re-type). At most ONE
@@ -207,7 +210,7 @@ namespace ClarionAssistant.Terminal
             {
                 var lsp = LspClient.Active;
                 if (lsp == null) return result;
-                var resp = lsp.GetDocumentSymbols(_lspFileName, _sourceText);
+                var resp = lsp.GetDocumentSymbols(_lspFileName, LspBuffer(_sourceText));
                 object res = (resp != null && resp.ContainsKey("result")) ? resp["result"] : null;
                 CollectSymbols(res, result);
             }
@@ -955,7 +958,7 @@ namespace ClarionAssistant.Terminal
 
         public ModernEmbeditorViewContent(string title, string sourceText, List<int[]> editableRanges,
             string language = "clarion", bool isDark = true, string procedureName = null, bool liveLinked = false,
-            int initialLine = 0)
+            int initialLine = 0, Services.EmbedLspContext lspContext = null)
         {
             _title = title ?? "Embeditor";
             _sourceText = sourceText ?? "";
@@ -965,7 +968,11 @@ namespace ClarionAssistant.Terminal
             _procedureName = procedureName;
             _saveEnabled = !string.IsNullOrWhiteSpace(procedureName);
             _originalSlotTexts = ModernEmbeditorSaver.ExtractSlotTexts(_sourceText, _editableRanges);
-            _lspFileName = MakeLspFileName(procedureName);
+            // #56: prefer the real generated-module path (captured by the launcher while the native embed
+            // was open) so the LSP resolves the buffer inside the real project dir with PROGRAM scope via
+            // the prepended MEMBER header. Falls back to the classic synthetic name when not captured.
+            _lspContext = lspContext;
+            _lspFileName = (_lspContext != null) ? _lspContext.RealPath : MakeLspFileName(procedureName);
             _initialLine = initialLine;
             TitleName = "CA: " + _title;
 
@@ -2194,6 +2201,22 @@ namespace ClarionAssistant.Terminal
             catch { }
         }
 
+        // #56 helpers — the LSP-facing view of the buffer/positions. With a real-module context the
+        // LSP buffer carries a prepended MEMBER header, so LSP lines run one AHEAD of Monaco lines;
+        // without one these degrade to the classic identity mapping (±1 base conversion only).
+        private string LspBuffer(string buffer)
+        {
+            return (_lspContext != null) ? _lspContext.WrapBuffer(buffer) : buffer;
+        }
+        private int LspLine0(int monacoLine1)
+        {
+            return Math.Max(0, monacoLine1 - 1) + ((_lspContext != null) ? _lspContext.LineOffset : 0);
+        }
+        private int MonacoLine1(int lspLine0)
+        {
+            return Math.Max(1, lspLine0 + 1 - ((_lspContext != null) ? _lspContext.LineOffset : 0));
+        }
+
         private void HandleCompletion(string json)
         {
             int reqId, line, column; string buffer;
@@ -2211,7 +2234,7 @@ namespace ClarionAssistant.Terminal
                     {
                         // Pass the LIVE buffer (mirror HandleHover). Passing null made the shared server complete
                         // against an empty document → always "no suggestions" (John's test; root-caused with Bob).
-                        var comps = SharedLspBridge.GetCompletion(_lspFileName, Math.Max(0, line - 1), Math.Max(0, column - 1), 2500, buffer);
+                        var comps = SharedLspBridge.GetCompletion(_lspFileName, LspLine0(line), Math.Max(0, column - 1), 2500, LspBuffer(buffer));
                         if (comps != null)
                             foreach (var c in comps)
                                 items.Add(new Dictionary<string, object>
@@ -2252,17 +2275,29 @@ namespace ClarionAssistant.Terminal
                     EnsureLspStarted();
                     if (SharedLspBridge.IsRunning)
                     {
-                        var def = SharedLspBridge.GetDefinition(_lspFileName, Math.Max(0, line - 1), Math.Max(0, column - 1), buffer);
+                        var def = SharedLspBridge.GetDefinition(_lspFileName, LspLine0(line), Math.Max(0, column - 1), LspBuffer(buffer));
                         string targetPath; int targetLine0, targetChar0;
                         bool got = SharedLspBridge.TryGetFirstLocation(def, out targetPath, out targetLine0, out targetChar0);
                         // The embeditor's LSP document is a SYNTHETIC file (_lspFileName has no file on disk),
                         // so a SAME-FILE definition resolves to that synthetic path — NavigateToFileAndLine can't
                         // open it and returns false, which is why F12 did nothing. When the LSP resolves in-buffer
                         // (e.g. a local var) its line numbers ARE this buffer's, so reveal in-place. (task 37e2079f)
+                        // With the real-module context (#56) the same-file path is the REAL module path our buffer
+                        // shadows: LSP results are in wrapped-buffer coords (MonacoLine1 unwraps them), but the
+                        // CodeGraph fallback returns ON-DISK module lines that mean nothing in this buffer — for
+                        // routines TryResolveLocalRoutine is authoritative in-buffer, so it wins when it matches.
                         bool sameFile = got && IsSameLspFile(targetPath);
                         if (sameFile)
                         {
-                            if (_panel != null) _panel.RevealLine(targetLine0 + 1, targetChar0 + 1);
+                            int localLine;
+                            if (_lspContext != null && TryResolveLocalRoutine(buffer, line, column, out localLine))
+                            {
+                                if (_panel != null) _panel.RevealLine(localLine, 1);
+                            }
+                            else if (_panel != null)
+                            {
+                                _panel.RevealLine(MonacoLine1(targetLine0), targetChar0 + 1);
+                            }
                             navigated = _panel != null;
                         }
                         else
@@ -2353,7 +2388,7 @@ namespace ClarionAssistant.Terminal
                     EnsureLspStarted();
                     if (SharedLspBridge.IsRunning)
                     {
-                        var resp = SharedLspBridge.GetHover(_lspFileName, Math.Max(0, line - 1), Math.Max(0, column - 1), buffer);
+                        var resp = SharedLspBridge.GetHover(_lspFileName, LspLine0(line), Math.Max(0, column - 1), LspBuffer(buffer));
                         contents = ExtractHoverString(resp);
                     }
                 }
@@ -2383,7 +2418,8 @@ namespace ClarionAssistant.Terminal
                         buffer ?? _sourceText,
                         (ranges != null && ranges.Count > 0) ? ranges : _editableRanges,
                         _procedureName,
-                        embedSlotChecks: !_fileMode);   // file mode: LSP only, skip embed-slot heuristics
+                        embedSlotChecks: !_fileMode,    // file mode: LSP only, skip embed-slot heuristics
+                        lspContext: _lspContext);       // #56: wrap the LSP pass with the MEMBER header
                 }
                 catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] diagnostics: " + ex.Message); }
                 PostResponse(reqId, new Dictionary<string, object> { { "markers", markers } });
@@ -3136,6 +3172,10 @@ namespace ClarionAssistant.Terminal
             // confirm MessageBox can't get stuck behind the live WebView2 (the documented native<->WebView2 deadlock).
             bool promptSave = _fileMode && _fileDirty && _fileLiveText != null && !_disposed;
             _disposed = true;
+
+            // #56: while this tab was open, LSP requests shadowed the on-disk generated module under its
+            // real path. No didClose exists, so push the on-disk content back to un-shadow it.
+            try { if (_lspContext != null) _lspContext.RevertShadow(); } catch { }
 
             lock (_instances) { _instances.Remove(this); }
             try { _settingsReg?.Dispose(); } catch { }


### PR DESCRIPTION
## Why

Closes #56.

The CA Embeditor's buffer is a procedure slice with no module header, addressed to the LSP by a **synthetic bare name** (e.g. `file:///UpdateCustomer.clw` — no directory, no file on disk). The Clarion LSP resolves a member module's **global scope** (program globals, file/field labels, ABC class scope) by following its `MEMBER('App.clw')` line to the parent program file on disk — roughly `path.resolve(dirOfCurrentFile, arg)` + `fs.existsSync`. A directory-less, header-less buffer gives that resolution nothing to work from, so PROGRAM-scope symbols never resolved inside the embed. The C#-side CodeGraph merges papered over some of this, but the server itself was blind to global scope.

## What

Two changes when talking to the LSP, per the technique proven in [msarson/ClarionMonacoEditor](https://github.com/msarson/ClarionMonacoEditor) (see #56):

1. **Address the buffer by the generated module's REAL full path** — `PweeEditorDetails.AppName`'s directory + `PweeEditorDetails.Module`. The buffer then lives in the real project directory (exact project match, redirection/libsrc context).
2. **Prepend the module's own `MEMBER(...)` line** — read verbatim from the on-disk module — to every LSP-bound copy of the buffer. MEMBER→parent resolution lands on the real PROGRAM `.clw` and pulls in global scope.

With this, the server itself resolves program globals in embed completion/hover/definition — type-aware, no separate index to build or keep fresh.

## How it fits this codebase (two deliberate adaptations)

- **The MEMBER header is prepended ONLY to the LSP-facing buffer copies — never to the Monaco model.** Save/write-back sends Monaco line numbers straight to `WriteEmbedContentByLine`, and the caret mirror + editable-range decorations all assume a 1:1 line mapping with the native document. So `EmbedLspContext.WrapBuffer` wraps at request time, request positions shift +1 (`LspLine0`), and same-file definition / diagnostic results shift back (`MonacoLine1` / the diagnostics offset). Monaco, ranges, caret and save are untouched. (In ClarionMonacoEditor the header is visible at line 1 because its write-back maps slots by index — that isn't safe here.)
- **The context is captured at mirror time in `ModernEmbeditorLauncher`** (both the snapshot and live-overlay paths), because `PweeEditorDetails` only exists while the native embeditor is open and the snapshot path cancels it before the Monaco tab is constructed.

Details:
- New `Services/EmbedLspContext.cs` — capture (via the existing `AppTreeService.GetOpenPweeDetails()`), verbatim `MEMBER` read with synthesized fallback, buffer wrap, and teardown un-shadow.
- Same-file F12 results: in-buffer ROUTINE targets stay authoritative over the CodeGraph fallback (whose on-disk module line numbers don't map to the assembled buffer).
- Diagnostics landing on the injected header line are dropped before slot-clamping.
- **Un-shadow on close:** while a tab is open its pushed buffer shadows the on-disk module in the server's view under the same path; there's no didClose in the transport, so `Dispose` pushes the on-disk content back (`RevertShadow`).
- Falls back to the classic synthetic-name behavior whenever the context can't be captured (no embed open, module not generated yet) — zero behavior change in that case.

## Testing

- Verified live in the Clarion 11.1 IDE against a real app: PROGRAM globals (e.g. a `VCRRequest LONG,THREAD` from the generated program file) now resolve in embed completion.
- Also verified at the server level with a standalone LSP harness (initialize + `clarion/updatePaths` + didOpen of the MEMBER-wrapped buffer under the real path → completion returns the program global; the same buffer under a synthetic bare name does not).
- Interplay note from #56: upstream LSP v0.9.9+ added bare-prefix completion, so with a bundle re-pin ≥ v0.9.9 the server covers bare-prefix globals in the embed on its own — worth comparing against the CodeGraph merge path afterwards.

## Known edge

Two embeditor tabs open on procedures from the **same generated module** will alternately shadow the same real path in the server (last request wins). Same characteristic as the reference implementation; in practice each request re-pushes its own buffer first, so results stay consistent per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)