### PR TITLE
feat(editor): signature help (parameter hints) in the Monaco embeditor + source editor

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Services\AppTreeService.cs" />
     <Compile Include="Services\IdeReflectionService.cs" />
     <Compile Include="Services\EmbeditorCompletionService.cs" />
+    <Compile Include="Services\EmbedLspContext.cs" />
     <Compile Include="ShowModernEmbeditorCommand.cs" />
     <Compile Include="ClarionBindingAssemblyResolver.cs" />
     <Compile Include="LspAutostartCommand.cs" />

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -483,6 +483,26 @@ namespace ClarionAssistant
             });
         }
 
+        // LSP signature help — parameter hints when typing '(' or ',' at a call site. Same
+        // position/buffer contract as OnHover; the page hides the widget on a null reply.
+        void IMonacoEditorHost.OnSignatureHelp(MonacoEditorControl editor, string rawJson)
+        {
+            int reqId, line, col; string buffer;
+            if (!ParseLspRequest(rawJson, out reqId, out line, out col, out buffer)) return;
+            System.Threading.Tasks.Task.Run(() =>
+            {
+                Dictionary<string, object> help = null;
+                try
+                {
+                    EnsureLsp();
+                    if (SharedLspBridge.IsRunning)
+                        help = SharedLspBridge.GetSignatureHelp(_filePath, Math.Max(0, line - 1), Math.Max(0, col - 1), buffer);
+                }
+                catch (Exception ex) { MonacoSpikeLog.Write("overlay signatureHelp error: " + ex.Message); }
+                editor.PostResponse(reqId, new Dictionary<string, object> { { "signatureHelp", help } });
+            });
+        }
+
         // F12 go-to-definition. Resolves the definition via the LSP (shared or bundled) with the C#
         // CodeGraph fallback for cross-project targets, then opens/positions the target with
         // MonacoSourceNavigator (handles same-file reveal AND cross-file open uniformly). #40 / 2ba0ee17.

--- a/ClarionAssistant/Services/EmbedLspContext.cs
+++ b/ClarionAssistant/Services/EmbedLspContext.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Real-module LSP context for the CA Embeditor (GitHub #56 — embed global scope via a synthetic
+    /// MEMBER header + the module's REAL path).
+    ///
+    /// The embed buffer is a procedure slice with no module header, and it used to be addressed to the
+    /// LSP by a synthetic bare name (e.g. "UpdateCustomer.clw", no directory). The Clarion LSP resolves
+    /// a member module's GLOBAL scope (program globals, file/field labels, ABC classes) by following its
+    /// MEMBER('App.clw') to the parent program file on disk — roughly path.resolve(dirOfCurrentFile, arg)
+    /// + fs.existsSync. A directory-less, header-less buffer gives that resolution nothing to work from,
+    /// so program globals never resolved inside the embed.
+    ///
+    /// This context fixes both halves, WITHOUT touching the Monaco buffer itself:
+    ///   1. Address the buffer by the generated module's REAL full path — PweeEditorDetails.AppName's
+    ///      directory + PweeEditorDetails.Module — the generated .clw already on disk and in the project.
+    ///      The buffer then lives in the real project directory (redirection/libsrc/project match).
+    ///   2. Prepend the module's own MEMBER(...) line — read VERBATIM from the on-disk module so the
+    ///      exact argument form matches — to every LSP-bound copy of the buffer. MEMBER→parent resolution
+    ///      then lands on the real PROGRAM .clw and pulls in global scope.
+    ///
+    /// The prepend happens ONLY in the LSP-facing buffer (requests carry <see cref="LineOffset"/>);
+    /// the Monaco model, editable ranges, caret mirror, and save/write-back all keep their existing
+    /// 1:1 line mapping with the native document.
+    ///
+    /// Capture timing matters: PweeEditorDetails exists only while the NATIVE embeditor is open, and the
+    /// snapshot launcher cancels it before the Monaco tab is constructed — so the launcher captures this
+    /// context at mirror time and passes it into the view.
+    ///
+    /// While a context is active, the pushed buffer SHADOWS the on-disk module in the LSP under the same
+    /// path. There is no didClose in the transport, so <see cref="RevertShadow"/> pushes the on-disk
+    /// content back on tab teardown to restore the server to the truth.
+    /// </summary>
+    public sealed class EmbedLspContext
+    {
+        /// <summary>Full path of the generated module .clw on disk (dir of the .app + module name).
+        /// The embed buffer is addressed to the LSP by this path.</summary>
+        public string RealPath { get; private set; }
+
+        /// <summary>The module's own MEMBER(...) line, read verbatim from disk (or synthesized from the
+        /// .app name when the read fails). Prepended to every LSP-bound buffer.</summary>
+        public string HeaderLine { get; private set; }
+
+        /// <summary>Lines prepended to the LSP-facing buffer (the MEMBER header). Add to a Monaco line
+        /// to get the LSP line; subtract from an LSP line to get back to Monaco.</summary>
+        public int LineOffset { get { return 1; } }
+
+        private EmbedLspContext(string realPath, string headerLine)
+        {
+            RealPath = realPath;
+            HeaderLine = headerLine;
+        }
+
+        /// <summary>
+        /// Build the context from the currently-open native embeditor's PweeEditorDetails, or null when
+        /// it can't be built (no embed open, details lack AppName/Module, or the generated module isn't
+        /// on disk — e.g. never generated). Null simply means "keep the synthetic-name behavior".
+        /// MUST be called while the native embeditor is still open (the snapshot path cancels it later).
+        /// </summary>
+        public static EmbedLspContext TryCapture(AppTreeService appTree = null)
+        {
+            try
+            {
+                var pwee = (appTree ?? new AppTreeService()).GetOpenPweeDetails();
+                if (pwee == null) return null;
+                string appName = GetProp(pwee, "AppName") as string;
+                string module = GetProp(pwee, "Module") as string;
+                if (string.IsNullOrEmpty(appName) || string.IsNullOrEmpty(module)) return null;
+
+                string dir = Path.GetDirectoryName(appName);
+                if (string.IsNullOrEmpty(dir)) return null;
+                string candidate = Path.Combine(dir, Path.GetFileName(module.Trim()));
+                if (!File.Exists(candidate))
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        "[EmbedLspContext] generated module not on disk: '" + candidate + "' — keeping synthetic LSP name.");
+                    return null;
+                }
+
+                string header = ReadMemberLine(candidate)
+                    ?? "  MEMBER('" + Path.GetFileNameWithoutExtension(appName) + ".clw')";
+                System.Diagnostics.Debug.WriteLine(
+                    "[EmbedLspContext] captured: realPath='" + candidate + "', header='" + header.Trim() + "'");
+                return new EmbedLspContext(candidate, header);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[EmbedLspContext] TryCapture: " + ex.Message);
+                return null;
+            }
+        }
+
+        /// <summary>The LSP-facing copy of a Monaco buffer: the MEMBER header + the buffer. The embed
+        /// buffer is a procedure slice, so it never carries its own MEMBER/PROGRAM — but guard anyway
+        /// (a buffer that already opens with one is passed through untouched, offset stays harmless-safe
+        /// only because such a buffer never occurs in embed mode).</summary>
+        public string WrapBuffer(string buffer)
+        {
+            string b = buffer ?? "";
+            string firstLine = b;
+            int nl = b.IndexOf('\n');
+            if (nl >= 0) firstLine = b.Substring(0, nl);
+            string t = firstLine.TrimStart();
+            if (t.StartsWith("MEMBER", StringComparison.OrdinalIgnoreCase) ||
+                t.StartsWith("PROGRAM", StringComparison.OrdinalIgnoreCase))
+                return b;
+            return HeaderLine + "\r\n" + b;
+        }
+
+        /// <summary>
+        /// Un-shadow the on-disk module in the LSP. While the embeditor tab is open, every request pushes
+        /// the (wrapped) embed buffer to the server under <see cref="RealPath"/>, overriding the on-disk
+        /// file in the server's view. The transport exposes no didClose, so on tab teardown we push the
+        /// REAL on-disk content back. Safe no-op when the LSP isn't running or the file vanished.
+        /// </summary>
+        public void RevertShadow()
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(RealPath) || !File.Exists(RealPath)) return;
+                if (!SharedLspBridge.IsRunning) return;
+                SharedLspBridge.EnsureBufferSynced(RealPath, File.ReadAllText(RealPath));
+                System.Diagnostics.Debug.WriteLine("[EmbedLspContext] reverted LSP shadow for '" + RealPath + "'.");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[EmbedLspContext] RevertShadow: " + ex.Message);
+            }
+        }
+
+        /// <summary>The module's own MEMBER(...) line, verbatim from disk (skipping leading blanks and
+        /// '!' comments), or null when none precedes the first real statement.</summary>
+        private static string ReadMemberLine(string path)
+        {
+            try
+            {
+                foreach (var line in File.ReadLines(path))
+                {
+                    var t = line.Trim();
+                    if (t.StartsWith("MEMBER", StringComparison.OrdinalIgnoreCase)) return line;
+                    if (t.Length > 0 && !t.StartsWith("!")) break; // first real statement — MEMBER must precede it
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        private static object GetProp(object obj, string name)
+        {
+            if (obj == null) return null;
+            try
+            {
+                var p = obj.GetType().GetProperty(name,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                return (p != null && p.GetIndexParameters().Length == 0) ? p.GetValue(obj, null) : null;
+            }
+            catch { return null; }
+        }
+    }
+}

--- a/ClarionAssistant/Services/LspClient.cs
+++ b/ClarionAssistant/Services/LspClient.cs
@@ -414,6 +414,23 @@ namespace ClarionAssistant.Services
         }
 
         /// <summary>
+        /// textDocument/signatureHelp - parameter hints for the call site at the position. Buffer-aware
+        /// like GetHover so the hints resolve against live embeditor/editor content.
+        /// </summary>
+        public Dictionary<string, object> GetSignatureHelp(string filePath, int line, int character, string bufferText = null)
+        {
+            TrackRequest("signatureHelp", filePath);
+            try
+            {
+                if (!string.IsNullOrEmpty(bufferText)) EnsureDocumentOpenWithText(filePath, bufferText);
+                else EnsureDocumentOpen(filePath);
+            }
+            catch { }
+            var parms = BuildTextDocumentPosition(filePath, line, character);
+            return SendRequest("textDocument/signatureHelp", parms, 1500);
+        }
+
+        /// <summary>
         /// textDocument/documentSymbol - get all symbols in a document.
         /// </summary>
         public Dictionary<string, object> GetDocumentSymbols(string filePath) { return GetDocumentSymbols(filePath, null); }

--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -79,7 +79,7 @@ namespace ClarionAssistant.Services
         /// </summary>
         public static List<Dictionary<string, object>> Compute(
             string lspFileName, string buffer, List<int[]> ranges, string procedureName,
-            bool embedSlotChecks = true)
+            bool embedSlotChecks = true, EmbedLspContext lspContext = null)
         {
             var markers = new List<Dictionary<string, object>>();
             if (string.IsNullOrEmpty(buffer) || ranges == null || ranges.Count == 0) return markers;
@@ -92,7 +92,11 @@ namespace ClarionAssistant.Services
                 // Route through SharedLspBridge: shared ClarionLsp when active, else the bundled LspClient.
                 if (SharedLspBridge.IsRunning && !string.IsNullOrEmpty(lspFileName))
                 {
-                    SharedLspBridge.EnsureBufferSynced(lspFileName, buffer);
+                    // #56: with a real-module context the LSP sees the MEMBER-wrapped buffer, so its line
+                    // numbers run one AHEAD of Monaco's — subtract the offset before clamping to slots.
+                    int off = (lspContext != null) ? lspContext.LineOffset : 0;
+                    SharedLspBridge.EnsureBufferSynced(lspFileName,
+                        (lspContext != null) ? lspContext.WrapBuffer(buffer) : buffer);
                     var wait = SharedLspBridge.WaitForDiagnostics(lspFileName, 1500, true);
                     List<LspClient.DiagnosticEntry> entries =
                         (wait != null && !wait.Pending && wait.Entries != null)
@@ -102,9 +106,10 @@ namespace ClarionAssistant.Services
                     foreach (var d in entries)
                     {
                         // DiagnosticEntry is 0-based; ranges are 1-based inclusive.
-                        int line1 = d.Line + 1;
+                        int line1 = d.Line + 1 - off;
+                        if (line1 < 1) continue; // marker on the injected MEMBER header — not user code
                         if (!InAnyRange(line1, ranges)) continue; // drop generated-line noise / mislocations
-                        markers.Add(Marker(line1, d.Character + 1, d.EndLine + 1, d.EndCharacter + 1,
+                        markers.Add(Marker(line1, d.Character + 1, Math.Max(line1, d.EndLine + 1 - off), d.EndCharacter + 1,
                             string.IsNullOrEmpty(d.Message) ? "Clarion diagnostic" : d.Message,
                             LspSevToMonaco(d.Severity)));
                     }

--- a/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
@@ -43,6 +43,11 @@ namespace ClarionAssistant.Services
                 // ~halving it. Idempotent, fire-and-forget.
                 try { EmbeditorCompletionService.LspStarter?.Invoke(); } catch { }
 
+                // #56: capture the real-module LSP context NOW — PweeEditorDetails only exists while the
+                // native embeditor is open, and CancelEmbeditor below tears it down.
+                EmbedLspContext lspCtx = null;
+                try { lspCtx = EmbedLspContext.TryCapture(appTree); } catch { }
+
                 // OpenAndMirror leaves the embeditor open; we made no edits, so discard/close to free the lock.
                 try { appTree.CancelEmbeditor(); } catch { }
                 WaitForEmbedClosed(appTree, 3000);
@@ -57,11 +62,13 @@ namespace ClarionAssistant.Services
                 // and the message/input state drains first — deterministically reproducing that gap.
                 var ctx = WindowsFormsSynchronizationContext.Current ?? new WindowsFormsSynchronizationContext();
                 string capProc = procName; string capSrc = source; List<int[]> capRanges = ranges; bool capDark = isDark;
+                EmbedLspContext capLspCtx = lspCtx;
                 ctx.Post(_ =>
                 {
                     try
                     {
-                        var view = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc);
+                        var view = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc,
+                            false, 0, capLspCtx);
                         WorkbenchSingleton.Workbench.ShowView(view);
                     }
                     catch (Exception ex)
@@ -133,6 +140,11 @@ namespace ClarionAssistant.Services
                 // Warm the LSP now so its background parse overlaps the WebView2/Monaco load. Fire-and-forget.
                 try { EmbeditorCompletionService.LspStarter?.Invoke(); } catch { }
 
+                // #56: capture the real-module LSP context from the live embed (it stays open in overlay
+                // mode, but capture eagerly for symmetry with the snapshot path).
+                EmbedLspContext lspCtx = null;
+                try { lspCtx = EmbedLspContext.TryCapture(appTree); } catch { }
+
                 // Read the native caret position NOW (before the embed closes under us) so Monaco lands at the
                 // embed point the developer had the cursor on — not the last-saved cursor for this procedure.
                 int nativeLine = 0;
@@ -143,6 +155,7 @@ namespace ClarionAssistant.Services
                 var ctx = WindowsFormsSynchronizationContext.Current ?? new WindowsFormsSynchronizationContext();
                 string capProc = procName; string capSrc = source; List<int[]> capRanges = ranges; bool capDark = isDark;
                 int capNativeLine = nativeLine;
+                EmbedLspContext capLspCtx = lspCtx;
                 var capHost = host; var capCover = preCover; var capEditor = appTree.GetOpenClaGenEditor();
                 ctx.Post(_ =>
                 {
@@ -155,7 +168,7 @@ namespace ClarionAssistant.Services
                             System.Diagnostics.Debug.WriteLine("[ModernEmbeditorLauncher] AttachOverlayToOpenEmbed: no ClaGenEditor host — cannot overlay.");
                             return;
                         }
-                        var overlay = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc, false, capNativeLine);
+                        var overlay = new ModernEmbeditorViewContent(capProc, capSrc, capRanges, "clarion", capDark, capProc, false, capNativeLine, capLspCtx);
                         overlay.ShowAsEmbedOverlay(h, capEditor ?? new AppTreeService().GetOpenClaGenEditor(), capCover);
                     }
                     catch (Exception ex)

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using ClarionLsp.Contracts;
 using ClarionCodeGraph.Graph;
@@ -173,6 +174,164 @@ namespace ClarionAssistant.Services
                 return (sym != null && mLabel == "ClarionGraph") ? sym : null;
             }
             catch { return null; }
+        }
+
+        /// <summary>textDocument/signatureHelp → a Monaco-ready dict {signatures:[{label, documentation,
+        /// parameters:[{label, documentation}]}], activeSignature, activeParameter}, or null when the call
+        /// site yields no signatures. SHARED path goes through REFLECTION: GetSignatureHelpAsync shipped in
+        /// ClarionLsp contracts v1.4.0, NEWER than the vendored copy we compile against, so no static
+        /// reference is possible (and per the class-header JIT-safety note, none would be safe anyway).
+        /// BUNDLED path parses the raw LSP response shape.</summary>
+        public static Dictionary<string, object> GetSignatureHelp(string filePath, int line, int character, string bufferText = null)
+        {
+            var c = Shared;
+            if (c != null)
+            {
+                MethodInfo m = null;
+                try { m = c.GetType().GetMethod("GetSignatureHelpAsync"); } catch { }
+                if (m == null)
+                {
+                    Debug.WriteLine("[SharedLspBridge] shared client lacks GetSignatureHelpAsync — install ClarionLsp >= 1.4.0 for parameter hints.");
+                    return null;
+                }
+                return SharedSignatureHelpViaReflection(c, m, filePath, line, character, bufferText);
+            }
+            var lsp = LspClient.Active;
+            if (lsp == null) return null;
+            try { return ParseLspSignatureHelp(lsp.GetSignatureHelp(filePath, line, character, bufferText)); }
+            catch (Exception ex) { Debug.WriteLine("[SharedLspBridge] signatureHelp (bundled) failed: " + ex.Message); return null; }
+        }
+
+        // Invoke the v1.4.0 GetSignatureHelpAsync(string, int, int, string, int) purely reflectively and
+        // flatten SignatureHelpResult/SignatureInfo/SignatureParameter (types from the ADDIN's newer
+        // contracts assembly, unknown to our compile) into the Monaco-ready dict.
+        private static Dictionary<string, object> SharedSignatureHelpViaReflection(
+            object client, MethodInfo m, string filePath, int line, int character, string bufferText)
+        {
+            try
+            {
+                object taskObj = m.Invoke(client, new object[] { filePath, line, character, bufferText, 2000 });
+                var task = taskObj as System.Threading.Tasks.Task;
+                if (task == null) return null;
+                task.GetAwaiter().GetResult();
+                object r = taskObj.GetType().GetProperty("Result").GetValue(taskObj, null);
+                if (r == null) return null;
+
+                var sigList = new List<object>();
+                if (ReflProp(r, "Signatures") is System.Collections.IEnumerable sigs)
+                {
+                    foreach (var s in sigs)
+                    {
+                        if (s == null) continue;
+                        var ps = new List<object>();
+                        if (ReflProp(s, "Parameters") is System.Collections.IEnumerable pars)
+                            foreach (var p in pars)
+                            {
+                                if (p == null) continue;
+                                ps.Add(new Dictionary<string, object>
+                                {
+                                    { "label", ReflProp(p, "Label") as string ?? "" },
+                                    { "documentation", ReflProp(p, "Documentation") as string }
+                                });
+                            }
+                        sigList.Add(new Dictionary<string, object>
+                        {
+                            { "label", ReflProp(s, "Label") as string ?? "" },
+                            { "documentation", ReflProp(s, "Documentation") as string },
+                            { "parameters", ps }
+                        });
+                    }
+                }
+                if (sigList.Count == 0) return null;
+                return new Dictionary<string, object>
+                {
+                    { "signatures", sigList },
+                    { "activeSignature", Convert.ToInt32(ReflProp(r, "ActiveSignature") ?? 0) },
+                    { "activeParameter", Convert.ToInt32(ReflProp(r, "ActiveParameter") ?? 0) }
+                };
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("[SharedLspBridge] signatureHelp (shared) failed: " + ex.Message);
+                return null;
+            }
+        }
+
+        private static object ReflProp(object obj, string name)
+        {
+            if (obj == null) return null;
+            try
+            {
+                var p = obj.GetType().GetProperty(name);
+                return p != null ? p.GetValue(obj, null) : null;
+            }
+            catch { return null; }
+        }
+
+        // Raw LSP signatureHelp response → the same Monaco-ready dict as the shared path. Handles the
+        // spec's variant shapes: documentation as string OR MarkupContent {kind,value}; parameter label
+        // as string OR [start,end] offsets into the signature label (resolved to the substring).
+        private static Dictionary<string, object> ParseLspSignatureHelp(Dictionary<string, object> resp)
+        {
+            if (resp == null || !resp.ContainsKey("result")) return null;
+            var res = resp["result"] as Dictionary<string, object>;
+            if (res == null || !res.ContainsKey("signatures")) return null;
+
+            var sigList = new List<object>();
+            if (res["signatures"] is System.Collections.IEnumerable sigs)
+            {
+                foreach (var so in sigs)
+                {
+                    var s = so as Dictionary<string, object>;
+                    if (s == null) continue;
+                    string sigLabel = (s.ContainsKey("label") ? s["label"] as string : null) ?? "";
+                    var ps = new List<object>();
+                    if (s.ContainsKey("parameters") && s["parameters"] is System.Collections.IEnumerable pars)
+                        foreach (var po in pars)
+                        {
+                            var p = po as Dictionary<string, object>;
+                            if (p == null) continue;
+                            string pLabel = null;
+                            object rawLabel = p.ContainsKey("label") ? p["label"] : null;
+                            if (rawLabel is string sl) pLabel = sl;
+                            else if (rawLabel is System.Collections.IEnumerable offs)
+                            {
+                                // [start, end] offsets into the signature label
+                                var idx = new List<int>();
+                                foreach (var o in offs) { try { idx.Add(Convert.ToInt32(o)); } catch { } }
+                                if (idx.Count >= 2 && idx[0] >= 0 && idx[1] <= sigLabel.Length && idx[1] > idx[0])
+                                    pLabel = sigLabel.Substring(idx[0], idx[1] - idx[0]);
+                            }
+                            ps.Add(new Dictionary<string, object>
+                            {
+                                { "label", pLabel ?? "" },
+                                { "documentation", DocString(p.ContainsKey("documentation") ? p["documentation"] : null) }
+                            });
+                        }
+                    sigList.Add(new Dictionary<string, object>
+                    {
+                        { "label", sigLabel },
+                        { "documentation", DocString(s.ContainsKey("documentation") ? s["documentation"] : null) },
+                        { "parameters", ps }
+                    });
+                }
+            }
+            if (sigList.Count == 0) return null;
+            int actSig = 0, actPar = 0;
+            try { if (res.ContainsKey("activeSignature") && res["activeSignature"] != null) actSig = Convert.ToInt32(res["activeSignature"]); } catch { }
+            try { if (res.ContainsKey("activeParameter") && res["activeParameter"] != null) actPar = Convert.ToInt32(res["activeParameter"]); } catch { }
+            return new Dictionary<string, object>
+            {
+                { "signatures", sigList }, { "activeSignature", actSig }, { "activeParameter", actPar }
+            };
+        }
+
+        // LSP documentation is string | MarkupContent {kind, value} — flatten to plain text (or null).
+        private static string DocString(object doc)
+        {
+            if (doc is string s) return s;
+            var d = doc as Dictionary<string, object>;
+            return (d != null && d.ContainsKey("value")) ? d["value"] as string : null;
         }
 
         /// <summary>textDocument/definition → raw LSP-response-shaped dict. Falls back to the C#

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -228,18 +228,9 @@ namespace ClarionAssistant.Services
                             foreach (var p in pars)
                             {
                                 if (p == null) continue;
-                                ps.Add(new Dictionary<string, object>
-                                {
-                                    { "label", ReflProp(p, "Label") as string ?? "" },
-                                    { "documentation", ReflProp(p, "Documentation") as string }
-                                });
+                                ps.Add(SigDict(ReflProp(p, "Label") as string, ReflProp(p, "Documentation") as string, null));
                             }
-                        sigList.Add(new Dictionary<string, object>
-                        {
-                            { "label", ReflProp(s, "Label") as string ?? "" },
-                            { "documentation", ReflProp(s, "Documentation") as string },
-                            { "parameters", ps }
-                        });
+                        sigList.Add(SigDict(ReflProp(s, "Label") as string, ReflProp(s, "Documentation") as string, ps));
                     }
                 }
                 if (sigList.Count == 0) return null;
@@ -266,6 +257,18 @@ namespace ClarionAssistant.Services
                 return p != null ? p.GetValue(obj, null) : null;
             }
             catch { return null; }
+        }
+
+        // Signature/parameter dict for Monaco. The "documentation" key is emitted ONLY when non-empty:
+        // Monaco 0.52's parameter-hints render checks `documentation !== undefined`, so an explicit NULL
+        // enters the markdown-docs path and ABORTS the render mid-way — the overload counter ("1/4")
+        // never gets its text and the widget shows without it. Omitting the key keeps it undefined.
+        private static Dictionary<string, object> SigDict(string label, string documentation, List<object> parameters)
+        {
+            var d = new Dictionary<string, object> { { "label", label ?? "" } };
+            if (!string.IsNullOrEmpty(documentation)) d["documentation"] = documentation;
+            if (parameters != null) d["parameters"] = parameters;
+            return d;
         }
 
         // Raw LSP signatureHelp response → the same Monaco-ready dict as the shared path. Handles the
@@ -302,18 +305,9 @@ namespace ClarionAssistant.Services
                                 if (idx.Count >= 2 && idx[0] >= 0 && idx[1] <= sigLabel.Length && idx[1] > idx[0])
                                     pLabel = sigLabel.Substring(idx[0], idx[1] - idx[0]);
                             }
-                            ps.Add(new Dictionary<string, object>
-                            {
-                                { "label", pLabel ?? "" },
-                                { "documentation", DocString(p.ContainsKey("documentation") ? p["documentation"] : null) }
-                            });
+                            ps.Add(SigDict(pLabel, DocString(p.ContainsKey("documentation") ? p["documentation"] : null), null));
                         }
-                    sigList.Add(new Dictionary<string, object>
-                    {
-                        { "label", sigLabel },
-                        { "documentation", DocString(s.ContainsKey("documentation") ? s["documentation"] : null) },
-                        { "parameters", ps }
-                    });
+                    sigList.Add(SigDict(sigLabel, DocString(s.ContainsKey("documentation") ? s["documentation"] : null), ps));
                 }
             }
             if (sigList.Count == 0) return null;

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -44,6 +44,9 @@ namespace ClarionAssistant.Terminal
         private List<string> _originalSlotTexts;     // baseline slot contents for change detection
         private readonly bool _saveEnabled;
         private readonly string _lspFileName;        // synthetic .clw URI for LSP completion/hover requests
+        // Real-module LSP context (#56): when captured, _lspFileName is the generated module's REAL path and
+        // every LSP-bound buffer is wrapped with its MEMBER header (+1 line) — Monaco itself is untouched.
+        private readonly Services.EmbedLspContext _lspContext;
 
         // LIVE-LINKED mode (ticket a5bbf005): this tab holds Clarion's native embeditor OPEN underneath the
         // floating Monaco, so save writes straight back into it (no re-open / no locator re-type). At most ONE
@@ -207,7 +210,7 @@ namespace ClarionAssistant.Terminal
             {
                 var lsp = LspClient.Active;
                 if (lsp == null) return result;
-                var resp = lsp.GetDocumentSymbols(_lspFileName, _sourceText);
+                var resp = lsp.GetDocumentSymbols(_lspFileName, LspBuffer(_sourceText));
                 object res = (resp != null && resp.ContainsKey("result")) ? resp["result"] : null;
                 CollectSymbols(res, result);
             }
@@ -955,7 +958,7 @@ namespace ClarionAssistant.Terminal
 
         public ModernEmbeditorViewContent(string title, string sourceText, List<int[]> editableRanges,
             string language = "clarion", bool isDark = true, string procedureName = null, bool liveLinked = false,
-            int initialLine = 0)
+            int initialLine = 0, Services.EmbedLspContext lspContext = null)
         {
             _title = title ?? "Embeditor";
             _sourceText = sourceText ?? "";
@@ -965,7 +968,11 @@ namespace ClarionAssistant.Terminal
             _procedureName = procedureName;
             _saveEnabled = !string.IsNullOrWhiteSpace(procedureName);
             _originalSlotTexts = ModernEmbeditorSaver.ExtractSlotTexts(_sourceText, _editableRanges);
-            _lspFileName = MakeLspFileName(procedureName);
+            // #56: prefer the real generated-module path (captured by the launcher while the native embed
+            // was open) so the LSP resolves the buffer inside the real project dir with PROGRAM scope via
+            // the prepended MEMBER header. Falls back to the classic synthetic name when not captured.
+            _lspContext = lspContext;
+            _lspFileName = (_lspContext != null) ? _lspContext.RealPath : MakeLspFileName(procedureName);
             _initialLine = initialLine;
             TitleName = "CA: " + _title;
 
@@ -2194,6 +2201,22 @@ namespace ClarionAssistant.Terminal
             catch { }
         }
 
+        // #56 helpers — the LSP-facing view of the buffer/positions. With a real-module context the
+        // LSP buffer carries a prepended MEMBER header, so LSP lines run one AHEAD of Monaco lines;
+        // without one these degrade to the classic identity mapping (±1 base conversion only).
+        private string LspBuffer(string buffer)
+        {
+            return (_lspContext != null) ? _lspContext.WrapBuffer(buffer) : buffer;
+        }
+        private int LspLine0(int monacoLine1)
+        {
+            return Math.Max(0, monacoLine1 - 1) + ((_lspContext != null) ? _lspContext.LineOffset : 0);
+        }
+        private int MonacoLine1(int lspLine0)
+        {
+            return Math.Max(1, lspLine0 + 1 - ((_lspContext != null) ? _lspContext.LineOffset : 0));
+        }
+
         private void HandleCompletion(string json)
         {
             int reqId, line, column; string buffer;
@@ -2211,7 +2234,7 @@ namespace ClarionAssistant.Terminal
                     {
                         // Pass the LIVE buffer (mirror HandleHover). Passing null made the shared server complete
                         // against an empty document → always "no suggestions" (John's test; root-caused with Bob).
-                        var comps = SharedLspBridge.GetCompletion(_lspFileName, Math.Max(0, line - 1), Math.Max(0, column - 1), 2500, buffer);
+                        var comps = SharedLspBridge.GetCompletion(_lspFileName, LspLine0(line), Math.Max(0, column - 1), 2500, LspBuffer(buffer));
                         if (comps != null)
                             foreach (var c in comps)
                                 items.Add(new Dictionary<string, object>
@@ -2252,17 +2275,29 @@ namespace ClarionAssistant.Terminal
                     EnsureLspStarted();
                     if (SharedLspBridge.IsRunning)
                     {
-                        var def = SharedLspBridge.GetDefinition(_lspFileName, Math.Max(0, line - 1), Math.Max(0, column - 1), buffer);
+                        var def = SharedLspBridge.GetDefinition(_lspFileName, LspLine0(line), Math.Max(0, column - 1), LspBuffer(buffer));
                         string targetPath; int targetLine0, targetChar0;
                         bool got = SharedLspBridge.TryGetFirstLocation(def, out targetPath, out targetLine0, out targetChar0);
                         // The embeditor's LSP document is a SYNTHETIC file (_lspFileName has no file on disk),
                         // so a SAME-FILE definition resolves to that synthetic path — NavigateToFileAndLine can't
                         // open it and returns false, which is why F12 did nothing. When the LSP resolves in-buffer
                         // (e.g. a local var) its line numbers ARE this buffer's, so reveal in-place. (task 37e2079f)
+                        // With the real-module context (#56) the same-file path is the REAL module path our buffer
+                        // shadows: LSP results are in wrapped-buffer coords (MonacoLine1 unwraps them), but the
+                        // CodeGraph fallback returns ON-DISK module lines that mean nothing in this buffer — for
+                        // routines TryResolveLocalRoutine is authoritative in-buffer, so it wins when it matches.
                         bool sameFile = got && IsSameLspFile(targetPath);
                         if (sameFile)
                         {
-                            if (_panel != null) _panel.RevealLine(targetLine0 + 1, targetChar0 + 1);
+                            int localLine;
+                            if (_lspContext != null && TryResolveLocalRoutine(buffer, line, column, out localLine))
+                            {
+                                if (_panel != null) _panel.RevealLine(localLine, 1);
+                            }
+                            else if (_panel != null)
+                            {
+                                _panel.RevealLine(MonacoLine1(targetLine0), targetChar0 + 1);
+                            }
                             navigated = _panel != null;
                         }
                         else
@@ -2353,7 +2388,7 @@ namespace ClarionAssistant.Terminal
                     EnsureLspStarted();
                     if (SharedLspBridge.IsRunning)
                     {
-                        var resp = SharedLspBridge.GetHover(_lspFileName, Math.Max(0, line - 1), Math.Max(0, column - 1), buffer);
+                        var resp = SharedLspBridge.GetHover(_lspFileName, LspLine0(line), Math.Max(0, column - 1), LspBuffer(buffer));
                         contents = ExtractHoverString(resp);
                     }
                 }
@@ -2383,7 +2418,8 @@ namespace ClarionAssistant.Terminal
                         buffer ?? _sourceText,
                         (ranges != null && ranges.Count > 0) ? ranges : _editableRanges,
                         _procedureName,
-                        embedSlotChecks: !_fileMode);   // file mode: LSP only, skip embed-slot heuristics
+                        embedSlotChecks: !_fileMode,    // file mode: LSP only, skip embed-slot heuristics
+                        lspContext: _lspContext);       // #56: wrap the LSP pass with the MEMBER header
                 }
                 catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] diagnostics: " + ex.Message); }
                 PostResponse(reqId, new Dictionary<string, object> { { "markers", markers } });
@@ -3136,6 +3172,10 @@ namespace ClarionAssistant.Terminal
             // confirm MessageBox can't get stuck behind the live WebView2 (the documented native<->WebView2 deadlock).
             bool promptSave = _fileMode && _fileDirty && _fileLiveText != null && !_disposed;
             _disposed = true;
+
+            // #56: while this tab was open, LSP requests shadowed the on-disk generated module under its
+            // real path. No didClose exists, so push the on-disk content back to un-shadow it.
+            try { if (_lspContext != null) _lspContext.RevertShadow(); } catch { }
 
             lock (_instances) { _instances.Remove(this); }
             try { _settingsReg?.Dispose(); } catch { }

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1154,6 +1154,7 @@ namespace ClarionAssistant.Terminal
         void IMonacoEditorHost.OnHover(MonacoEditorControl editor, string rawJson) { HandleHover(rawJson); }
         void IMonacoEditorHost.OnDefinition(MonacoEditorControl editor, string rawJson) { HandleDefinition(rawJson); }
         void IMonacoEditorHost.OnDiagnostics(MonacoEditorControl editor, string rawJson) { HandleDiagnostics(rawJson); }
+        void IMonacoEditorHost.OnSignatureHelp(MonacoEditorControl editor, string rawJson) { HandleSignatureHelp(rawJson); }
         void IMonacoEditorHost.OnSaveSettings(MonacoEditorControl editor, string rawJson) { HandleSaveSettings(rawJson); }
         void IMonacoEditorHost.OnSaveHistory(MonacoEditorControl editor, string rawJson) { HandleSaveHistory(rawJson); }
         void IMonacoEditorHost.OnSnippetCommand(MonacoEditorControl editor, string rawJson)
@@ -2373,6 +2374,26 @@ namespace ClarionAssistant.Terminal
             }
             catch { }
             return false;
+        }
+
+        /// <summary>LSP signature-help request from Monaco (typing '(' or ',' at a call site). Same
+        /// position/buffer contract as hover; replies {signatureHelp: {...}|null}.</summary>
+        private void HandleSignatureHelp(string json)
+        {
+            int reqId, line, column; string buffer;
+            if (!ParseRequest(json, out reqId, out line, out column, out buffer)) return;
+            Task.Run(() =>
+            {
+                Dictionary<string, object> help = null;
+                try
+                {
+                    EnsureLspStarted();
+                    if (SharedLspBridge.IsRunning)
+                        help = SharedLspBridge.GetSignatureHelp(_lspFileName, LspLine0(line), Math.Max(0, column - 1), LspBuffer(buffer));
+                }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] signatureHelp: " + ex.Message); }
+                PostResponse(reqId, new Dictionary<string, object> { { "signatureHelp", help } });
+            });
         }
 
         /// <summary>LSP hover request from Monaco. Syncs the current buffer (needed to resolve the symbol).</summary>

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -68,6 +68,10 @@ namespace ClarionAssistant.Terminal
         /// <summary>{action:"diagnostics"} — hybrid LSP + slot diagnostics; host replies via PostResponse.</summary>
         void OnDiagnostics(MonacoEditorControl editor, string rawJson);
 
+        /// <summary>{action:"signatureHelp"} — LSP parameter hints at a call site (typing '(' or ',');
+        /// host replies via PostResponse with {signatureHelp: {...}|null}.</summary>
+        void OnSignatureHelp(MonacoEditorControl editor, string rawJson);
+
         /// <summary>{action:"saveSettings"} — persist gear-panel settings + broadcast to all tabs.</summary>
         void OnSaveSettings(MonacoEditorControl editor, string rawJson);
 
@@ -246,6 +250,7 @@ namespace ClarionAssistant.Terminal
                     case "hover":             h.OnHover(this, json); break;
                     case "definition":        h.OnDefinition(this, json); break;
                     case "diagnostics":       h.OnDiagnostics(this, json); break;
+                    case "signatureHelp":     h.OnSignatureHelp(this, json); break;
                     case "saveSettings":      h.OnSaveSettings(this, json); break;
                     case "saveHistory":       h.OnSaveHistory(this, json); break;
                     case "snippetCommand":    h.OnSnippetCommand(this, json); break;

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -2852,6 +2852,30 @@
                     .catch(function () { return null; });
             }
         });
+        // Signature help — parameter hints when typing '(' or ',' at a call site (mirrors VS Code).
+        // The host answers {signatureHelp: {signatures, activeSignature, activeParameter}|null}; a null
+        // (comment position, no LSP, bare identifier) simply keeps the widget hidden.
+        monaco.languages.registerSignatureHelpProvider('clarion', {
+            signatureHelpTriggerCharacters: ['(', ','],
+            signatureHelpRetriggerCharacters: [','],
+            provideSignatureHelp: function (model, position, token, context) {
+                if (isInClarionComment(model.getLineContent(position.lineNumber), position.column - 1)) return null;
+                return requestFromHost('signatureHelp', { line: position.lineNumber, column: position.column, buffer: model.getValue() })
+                    .then(function (resp) {
+                        var h = resp && resp.signatureHelp;
+                        if (!h || !h.signatures || !h.signatures.length) return null;
+                        return {
+                            value: {
+                                signatures: h.signatures,
+                                activeSignature: h.activeSignature || 0,
+                                activeParameter: h.activeParameter || 0
+                            },
+                            dispose: function () { }
+                        };
+                    })
+                    .catch(function () { return null; });
+            }
+        });
     }
 
     // Clarion syntax highlighting (Monarch) + language configuration now live in the shared


### PR DESCRIPTION
> **Builds on #74** — the branch is stacked on `feat/embeditor-member-scope`, so this diff shows those commits too until #74 merges. This PR's own changes are the last two commits (`5f43fb4`, `7a8e08b`).

## What

Typing `(` (retrigger on `,`) at a call site now shows the VS Code-style parameter-hint overlay — signature label, active parameter bolded, and the `1/4` overload pager — in both the CA Embeditor and the Monaco source editor. Fed by `textDocument/signatureHelp`, which the Clarion LSP has advertised all along but nothing in the addin consumed.

Related: #72 — together with #74 this rounds out the embeditor completion experience (PROGRAM-scope completion from #74, parameter hints from this PR).

## How

- **`monaco-embeditor.html`**: `registerSignatureHelpProvider` (`(` trigger, `,` retrigger), suppressed inside comments like hover. One registration serves both surfaces (same page).
- **`MonacoEditorControl`**: new `{action:"signatureHelp"}` host callback on `IMonacoEditorHost`.
- **`ModernEmbeditorViewContent`**: handler with the same position/buffer contract as hover — including the #74 real-module wrap, so hints resolve with full PROGRAM scope inside embeds.
- **`MonacoClarionSourceEditor`**: same handler against the real file path.
- **`LspClient.GetSignatureHelp`**: buffer-aware `textDocument/signatureHelp` (bundled server ≥ v0.9.6 advertises the capability).
- **`SharedLspBridge.GetSignatureHelp`**: bundled path parses the raw LSP shapes (string-or-MarkupContent docs, string-or-`[start,end]`-offset parameter labels). The SHARED path invokes `GetSignatureHelpAsync` via **reflection**: the method shipped in ClarionLsp contracts **v1.4.0**, newer than the vendored `ClarionLsp.Contracts.dll` we compile against — and per the class-header JIT-safety note (both assemblies are AssemblyVersion 1.0.0.0, first-load-wins), a static reference wouldn't be safe anyway. A ClarionLsp < 1.4.0 install logs once and returns null; the widget simply stays hidden.

## The bug worth knowing about (second commit)

First cut rendered the label + arrows but a blank overload counter. Root cause: the bridge emitted `"documentation": null` on every signature dict. Monaco 0.52's render gate is `documentation !== undefined`, so an explicit null enters the markdown-docs path and aborts the render midway — after the label paints, before the counter text is written (`.overloads` left `""`/`visibility:hidden`/`width:0`). Reproduced deterministically outside the IDE by driving the real `monaco-embeditor.html` in headless Edge with a shimmed `chrome.webview` host: same payload with `documentation: null` → blank counter; key omitted → `1/4` renders. Fix: `SigDict()` only emits `documentation` when non-empty, on both paths. If you ever hand Monaco widget data from C#, omit empty keys rather than passing nulls.

## Testing

- Live in Clarion 11.1: `Body.SetValue(` (StringTheory) in a code embed shows all 4 overloads with the pager; `↑`/`↓` cycle; active parameter bolds across commas. Verified on the shared-addin path (ClarionLsp 1.4.0).
- Server-level via a standalone LSP harness (initialize + `clarion/updatePaths` + didOpen of the MEMBER-wrapped buffer): `WebClient.Fetch(` returns both overloads (`String` / `StringTheory`) with parameters and active indices.
- Widget-level via the headless-Edge harness above, light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)