### PR TITLE
feat(editor): Ctrl+F12 go-to-implementation in the Monaco embeditor + source editor

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -483,6 +483,39 @@ namespace ClarionAssistant
             });
         }
 
+        // Ctrl+F12 go-to-implementation — declaration → implementation body. Same navigation shape
+        // as OnDefinition: same-file targets reveal in-place, cross-file targets open the file.
+        void IMonacoEditorHost.OnImplementation(MonacoEditorControl editor, string rawJson)
+        {
+            int reqId, line, col; string buffer;
+            if (!ParseLspRequest(rawJson, out reqId, out line, out col, out buffer)) return;
+            System.Threading.Tasks.Task.Run(() =>
+            {
+                bool navigated = false;
+                try
+                {
+                    EnsureLsp();
+                    if (SharedLspBridge.IsRunning)
+                    {
+                        var impl = SharedLspBridge.GetImplementation(_filePath, Math.Max(0, line - 1), Math.Max(0, col - 1), buffer);
+                        string targetPath; int targetLine0, targetChar0;
+                        if (SharedLspBridge.TryGetFirstLocation(impl, out targetPath, out targetLine0, out targetChar0))
+                        {
+                            if (SameSourceFile(targetPath))
+                            {
+                                if (_editor != null) _editor.RevealLine(targetLine0 + 1, targetChar0 + 1);
+                                navigated = _editor != null;
+                            }
+                            else
+                                navigated = MonacoSourceNavigator.NavigateToFileAndLine(targetPath, targetLine0 + 1, 1);
+                        }
+                    }
+                }
+                catch (Exception ex) { MonacoSpikeLog.Write("overlay implementation error: " + ex.Message); }
+                editor.PostResponse(reqId, new Dictionary<string, object> { { "navigated", navigated } });
+            });
+        }
+
         // LSP signature help — parameter hints when typing '(' or ',' at a call site. Same
         // position/buffer contract as OnHover; the page hides the widget on a null reply.
         void IMonacoEditorHost.OnSignatureHelp(MonacoEditorControl editor, string rawJson)

--- a/ClarionAssistant/Services/LspClient.cs
+++ b/ClarionAssistant/Services/LspClient.cs
@@ -385,6 +385,22 @@ namespace ClarionAssistant.Services
         }
 
         /// <summary>
+        /// textDocument/implementation - jump from a declaration (e.g. a method prototype in a CLASS)
+        /// to its implementation body. Buffer-aware so the request resolves against live editor content.
+        /// </summary>
+        public Dictionary<string, object> GetImplementation(string filePath, int line, int character, string bufferText = null)
+        {
+            TrackRequest("implementation", filePath);
+            try
+            {
+                if (!string.IsNullOrEmpty(bufferText)) EnsureDocumentOpenWithText(filePath, bufferText);
+                else EnsureDocumentOpen(filePath);
+            }
+            catch { }
+            return SendTextDocumentPositionRequest("textDocument/implementation", filePath, line, character);
+        }
+
+        /// <summary>
         /// textDocument/references - find all references to a symbol.
         /// </summary>
         public Dictionary<string, object> GetReferences(string filePath, int line, int character)

--- a/ClarionAssistant/Services/LspClient.cs
+++ b/ClarionAssistant/Services/LspClient.cs
@@ -1358,8 +1358,15 @@ namespace ClarionAssistant.Services
 
         public static string UriToFilePath(string uri)
         {
+            // Full percent-decoding, not just %20 — the server encodes the drive colon (file:///c%3A/...),
+            // and a %20-only decode leaves "c%3A\..." paths that fail File.Exists (silent nav no-ops).
             if (uri.StartsWith("file:///"))
-                uri = uri.Substring(8).Replace("/", "\\").Replace("%20", " ");
+            {
+                string p = uri.Substring(8);
+                try { p = Uri.UnescapeDataString(p); }
+                catch { p = p.Replace("%3A", ":").Replace("%3a", ":").Replace("%20", " "); }
+                uri = p.Replace("/", "\\");
+            }
             return uri;
         }
 

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -1048,14 +1048,19 @@ namespace ClarionAssistant.Services
             return "file:///" + filePath.Replace("\\", "/").Replace(" ", "%20");
         }
 
-        /// <summary>Inverse of <see cref="FilePathToUri"/>: file:///H:/dir/f.clw -&gt; H:\dir\f.clw.</summary>
+        /// <summary>Inverse of <see cref="FilePathToUri"/>: file:///H:/dir/f.clw -&gt; H:\dir\f.clw.
+        /// Full percent-decoding, not just %20: the server (VS Code URI conventions) encodes the drive
+        /// COLON — file:///c%3A/dir/f.clw — and a %20-only decode left "c%3A\dir\f.clw", which fails
+        /// File.Exists and made navigation (go-to-implementation, any pure-LSP location) silently no-op.</summary>
         public static string UriToFilePath(string uri)
         {
             if (string.IsNullOrEmpty(uri)) return uri;
             string p = uri;
             if (p.StartsWith("file:///", StringComparison.OrdinalIgnoreCase)) p = p.Substring(8);
             else if (p.StartsWith("file://", StringComparison.OrdinalIgnoreCase)) p = p.Substring(7);
-            return p.Replace("/", "\\").Replace("%20", " ");
+            try { p = Uri.UnescapeDataString(p); }
+            catch { p = p.Replace("%3A", ":").Replace("%3a", ":").Replace("%20", " "); }
+            return p.Replace("/", "\\");
         }
 
         /// <summary>Extract the FIRST Location from a definition/references result dict

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -350,6 +350,81 @@ namespace ClarionAssistant.Services
             return CodeGraphDefinition(filePath, line, character, bufferText) ?? primary;
         }
 
+        /// <summary>textDocument/implementation → raw LSP-response-shaped dict (locations), or null.
+        /// Jump from a declaration (e.g. a method prototype in a CLASS) to its implementation body.
+        /// SHARED path goes through REFLECTION: GetImplementationAsync entered the ClarionLsp contracts
+        /// AFTER the vendored copy we compile against (pre-v1.4.0 line), so no static reference is
+        /// possible — same pattern as GetSignatureHelp. The contract method takes no bufferText, so the
+        /// live buffer is synced explicitly first. An older addin (method missing) logs and returns null.</summary>
+        public static Dictionary<string, object> GetImplementation(string filePath, int line, int character, string bufferText = null)
+        {
+            var c = Shared;
+            if (c != null)
+            {
+                MethodInfo m = null;
+                try { m = c.GetType().GetMethod("GetImplementationAsync"); } catch { }
+                if (m == null)
+                {
+                    Debug.WriteLine("[SharedLspBridge] shared client lacks GetImplementationAsync — update the ClarionLsp addin for go-to-implementation.");
+                    return null;
+                }
+                if (!string.IsNullOrEmpty(bufferText)) EnsureBufferSynced(filePath, bufferText);
+                return SharedImplementationViaReflection(c, m, filePath, line, character);
+            }
+            var lsp = LspClient.Active;
+            if (lsp == null) return null;
+            try { return lsp.GetImplementation(filePath, line, character, bufferText); }
+            catch (Exception ex) { Debug.WriteLine("[SharedLspBridge] implementation (bundled) failed: " + ex.Message); return null; }
+        }
+
+        // Invoke GetImplementationAsync(string, int, int) reflectively and flatten the LocationResult[]
+        // (types from the ADDIN's newer contracts assembly) into raw LSP location dicts — the shape
+        // TryGetFirstLocation and every navigation consumer already understands.
+        private static Dictionary<string, object> SharedImplementationViaReflection(
+            object client, MethodInfo m, string filePath, int line, int character)
+        {
+            try
+            {
+                object taskObj = m.Invoke(client, new object[] { filePath, line, character });
+                var task = taskObj as System.Threading.Tasks.Task;
+                if (task == null) return null;
+                task.GetAwaiter().GetResult();
+                object r = taskObj.GetType().GetProperty("Result").GetValue(taskObj, null);
+                var list = new System.Collections.ArrayList();
+                if (r is System.Collections.IEnumerable locs)
+                {
+                    foreach (var l in locs)
+                    {
+                        if (l == null) continue;
+                        string fp = ReflProp(l, "FilePath") as string;
+                        if (string.IsNullOrEmpty(fp)) continue;
+                        object rng = ReflProp(l, "Range");
+                        object start = ReflProp(rng, "Start");
+                        object end = ReflProp(rng, "End") ?? start;
+                        int sl = 0, sc = 0, el = 0, ec = 0;
+                        try { sl = Convert.ToInt32(ReflProp(start, "Line") ?? 0); sc = Convert.ToInt32(ReflProp(start, "Character") ?? 0); } catch { }
+                        try { el = Convert.ToInt32(ReflProp(end, "Line") ?? sl); ec = Convert.ToInt32(ReflProp(end, "Character") ?? sc); } catch { }
+                        list.Add(new Dictionary<string, object>
+                        {
+                            { "uri", FilePathToUri(fp) },
+                            { "range", new Dictionary<string, object>
+                                {
+                                    { "start", new Dictionary<string, object> { { "line", sl }, { "character", sc } } },
+                                    { "end",   new Dictionary<string, object> { { "line", el }, { "character", ec } } }
+                                }
+                            }
+                        });
+                    }
+                }
+                return list.Count > 0 ? WrapResult(list) : null;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("[SharedLspBridge] implementation (shared) failed: " + ex.Message);
+                return null;
+            }
+        }
+
         /// <summary>textDocument/references → raw LSP-response-shaped dict. CodeGraph fallback when empty.</summary>
         public static Dictionary<string, object> GetReferences(string filePath, int line, int character)
         {

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1155,6 +1155,7 @@ namespace ClarionAssistant.Terminal
         void IMonacoEditorHost.OnDefinition(MonacoEditorControl editor, string rawJson) { HandleDefinition(rawJson); }
         void IMonacoEditorHost.OnDiagnostics(MonacoEditorControl editor, string rawJson) { HandleDiagnostics(rawJson); }
         void IMonacoEditorHost.OnSignatureHelp(MonacoEditorControl editor, string rawJson) { HandleSignatureHelp(rawJson); }
+        void IMonacoEditorHost.OnImplementation(MonacoEditorControl editor, string rawJson) { HandleImplementation(rawJson); }
         void IMonacoEditorHost.OnSaveSettings(MonacoEditorControl editor, string rawJson) { HandleSaveSettings(rawJson); }
         void IMonacoEditorHost.OnSaveHistory(MonacoEditorControl editor, string rawJson) { HandleSaveHistory(rawJson); }
         void IMonacoEditorHost.OnSnippetCommand(MonacoEditorControl editor, string rawJson)
@@ -2374,6 +2375,43 @@ namespace ClarionAssistant.Terminal
             }
             catch { }
             return false;
+        }
+
+        /// <summary>Ctrl+F12 go-to-implementation from the embed editor — declaration → implementation
+        /// body (e.g. a method prototype in a CLASS to its .clw body). Mirrors HandleDefinition's
+        /// navigation: a same-file target reveals in-place (unwrapping the #56 header offset), a
+        /// cross-file target opens via MonacoSourceNavigator.</summary>
+        private void HandleImplementation(string json)
+        {
+            int reqId, line, column; string buffer;
+            if (!ParseRequest(json, out reqId, out line, out column, out buffer)) return;
+            Task.Run(() =>
+            {
+                bool navigated = false;
+                try
+                {
+                    EnsureLspStarted();
+                    if (SharedLspBridge.IsRunning)
+                    {
+                        var impl = SharedLspBridge.GetImplementation(_lspFileName, LspLine0(line), Math.Max(0, column - 1), LspBuffer(buffer));
+                        string targetPath; int targetLine0, targetChar0;
+                        if (SharedLspBridge.TryGetFirstLocation(impl, out targetPath, out targetLine0, out targetChar0))
+                        {
+                            if (IsSameLspFile(targetPath))
+                            {
+                                if (_panel != null) _panel.RevealLine(MonacoLine1(targetLine0), targetChar0 + 1);
+                                navigated = _panel != null;
+                            }
+                            else
+                            {
+                                navigated = MonacoSourceNavigator.NavigateToFileAndLine(targetPath, targetLine0 + 1, 1);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] implementation: " + ex.Message); }
+                PostResponse(reqId, new Dictionary<string, object> { { "navigated", navigated } });
+            });
         }
 
         /// <summary>LSP signature-help request from Monaco (typing '(' or ',' at a call site). Same

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -72,6 +72,10 @@ namespace ClarionAssistant.Terminal
         /// host replies via PostResponse with {signatureHelp: {...}|null}.</summary>
         void OnSignatureHelp(MonacoEditorControl editor, string rawJson);
 
+        /// <summary>{action:"implementation"} — Ctrl+F12 go-to-implementation (declaration → body);
+        /// host navigates (same- or cross-file) then replies via PostResponse with {navigated:bool}.</summary>
+        void OnImplementation(MonacoEditorControl editor, string rawJson);
+
         /// <summary>{action:"saveSettings"} — persist gear-panel settings + broadcast to all tabs.</summary>
         void OnSaveSettings(MonacoEditorControl editor, string rawJson);
 
@@ -251,6 +255,7 @@ namespace ClarionAssistant.Terminal
                     case "definition":        h.OnDefinition(this, json); break;
                     case "diagnostics":       h.OnDiagnostics(this, json); break;
                     case "signatureHelp":     h.OnSignatureHelp(this, json); break;
+                    case "implementation":    h.OnImplementation(this, json); break;
                     case "saveSettings":      h.OnSaveSettings(this, json); break;
                     case "saveHistory":       h.OnSaveHistory(this, json); break;
                     case "snippetCommand":    h.OnSnippetCommand(this, json); break;

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -3473,6 +3473,13 @@
                 ev.preventDefault(); ev.stopImmediatePropagation(); openFindPanel(true);
             } else if (ev.keyCode === 114 || ev.key === 'F3') {                             // F3 / Shift+F3
                 ev.preventDefault(); ev.stopImmediatePropagation(); gotoMatch(ev.shiftKey ? -1 : 1);
+            } else if (ctrl && (ev.keyCode === 123 || ev.key === 'F12')) {                  // Ctrl+F12 → go to implementation (declaration → body)
+                ev.preventDefault(); ev.stopImmediatePropagation();
+                var ipos = editor && editor.getPosition();
+                if (ipos) {
+                    recordNavAt(ipos.lineNumber, ipos.column);   // seed origin so Navigate Back returns here (#40)
+                    requestFromHost('implementation', { line: ipos.lineNumber, column: ipos.column, buffer: editor.getModel().getValue() });
+                }
             } else if (ev.keyCode === 123 || ev.key === 'F12') {                            // F12 → go to definition (#40)
                 ev.preventDefault(); ev.stopImmediatePropagation();
                 var dpos = editor && editor.getPosition();


### PR DESCRIPTION
> **Builds on #75** (which builds on #74) — the branch is stacked, so this diff shows those commits until they merge. This PR's own changes are the last commits from `78ac4b5` onward.

## What

**Ctrl+F12** jumps to a symbol's **implementation body** via `textDocument/implementation` — from a declaration OR from any call site/reference. It's the "skip the prototype" navigation: where plain F12 on a class method typically lands on the `.inc` prototype, Ctrl+F12 lands on the executable body. A capability the Clarion LSP has advertised since before the current bundle pin, with nothing consuming it. Works in both the CA Embeditor and the Monaco source editor:

- **From a call site** (the everyday case): Ctrl+F12 on `Body.SetValue(` (Body is a StringTheory) opens **`StringTheory.clw` at the SetValue implementation** — plain F12 on the same call goes to the `.inc` prototype.
- **From a declaration**: Ctrl+F12 on `Init` in `ThisWindow CLASS(WindowManager)` jumps to the `ThisWindow.Init PROCEDURE` body further down the embed buffer.
- In the source editor: Ctrl+F12 in an `.inc` prototype jumps to the `.clw` body.

## How

- `monaco-embeditor.html`: Ctrl+F12 branch in the capture-phase key interceptor, ahead of plain F12 (which is untouched); seeds Navigate Back the same way.
- `MonacoEditorControl`: `{action:"implementation"}` host callback.
- Both hosts: handlers mirroring their definition flows — same-file targets reveal in-place (unwrapping the #74 MEMBER-header offset in embed mode), cross-file targets open via `MonacoSourceNavigator`.
- `SharedLspBridge.GetImplementation`: SHARED path invokes the addin's `GetImplementationAsync` via **reflection** (it entered the ClarionLsp contracts after the vendored copy — same pattern and rationale as #75) and flattens `LocationResult[]` into the raw LSP location dicts `TryGetFirstLocation` already understands. The contract method takes no `bufferText`, so the live buffer is synced explicitly first. An older addin logs once and the keypress no-ops. BUNDLED path is a raw `textDocument/implementation` request.

## The bug worth knowing about

First cut: the addin resolved the location (`GetImplementation result: 1 location(s)`) but nothing opened. Root cause: the server percent-encodes the drive colon per VS Code URI conventions (`file:///c%3A/Clarion/.../StringTheory.clw`), and both `UriToFilePath` implementations (SharedLspBridge + bundled LspClient) only decoded `%20` — producing `c%3A\Clarion\...` paths that fail `File.Exists`, which `NavigateToFileAndLine` treats as a silent false **before any logging**.

F12 masked this for years because `GetDefinition` preempts the LSP on library member access with the ClarionGraph DB lookup (clean Windows paths) — implementation is pure-LSP and was the first feature to walk the encoded path. Both converters now run `Uri.UnescapeDataString` (with a minimal `%3A`/`%20` fallback), which also heals the same `%20`-only gap in the shared ClarionLsp addin's own `LocationResult.FilePath` values via the re-encode/decode round-trip (tracked separately in msarson/clarion-lsp#3). Any pure-LSP location consumer benefits, not just Ctrl+F12.

## Testing

- Live in Clarion 11.1 (shared ClarionLsp 1.4.0 path): Ctrl+F12 on the `Body.SetValue(` call site opens `StringTheory.clw` at the implementation; Ctrl+F12 on a CLASS-block method declaration reveals the body in-buffer; plain F12 behavior unchanged.
- Standalone server harness: `textDocument/implementation` on the `ThisWindow.Init` declaration resolves to the `ThisWindow.Init PROCEDURE` body line; from the `Body.SetValue(` call site resolves to `file:///c%3A/.../StringTheory.clw` — the URI shape that exposed the decode bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)