### PR TITLE
Support VS2026 Build Tools, add Clarion 11.1 as a distinct target, make installer paths portable

### DIFF
--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -1,9 +1,9 @@
 ﻿# ClarionAssistant Deploy Script
-# Builds and deploys the addin for Clarion 10, 11, 12, or all.
-# Usage: .\deploy.ps1 [-Version 10|11|12|all] [-NoBuild] [-Kill]
+# Builds and deploys the addin for Clarion 10, 11, 11.1, 12, or all.
+# Usage: .\deploy.ps1 [-Version 10|11|11.1|12|all] [-NoBuild] [-Kill]
 
 param(
-    [ValidateSet("10","11","12","all")]
+    [ValidateSet("10","11","11.1","12","all")]
     [string]$Version = "all",  # Which Clarion version(s) to build/deploy
     [switch]$NoBuild,          # Skip build, just copy
     [switch]$Kill              # Kill Clarion IDE before deploying
@@ -16,7 +16,7 @@ $ErrorActionPreference = "Stop"
 function Resolve-MSBuild {
     $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path $vswhere) {
-        $found = & $vswhere -latest -requires Microsoft.Component.MSBuild `
+        $found = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild `
                             -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
         if ($found -and (Test-Path $found)) { return $found }
     }
@@ -45,11 +45,65 @@ $IndexerDir    = if ($env:CLARIONINDEXER_DIR) { $env:CLARIONINDEXER_DIR } else {
 $IndexerFile   = "$IndexerDir\ClarionIndexer.csproj"
 $IndexerOutput = "$IndexerDir\bin\Debug"
 
-# Version-specific config
+# Version-specific config. "Root" entries are last-resort fallback paths only — actual
+# resolution goes registry -> these fallbacks -> drive-root glob scan (Resolve-ClarionRoot).
+# 11 and 11.1 are DISTINCT Clarion releases (confirmed via registry: separate install dirs,
+# not aliases of each other) and must never share a build/deploy target — their binding DLLs
+# (CWBinding.dll etc, see ClarionAssistant.csproj) are version-specific, so building against
+# one and shipping into the other risks an ABI mismatch.
 $Versions = @{
-    "12" = @{ Root = "C:\Clarion12";                           Output = "bin\Debug-C12" }
-    "11" = @{ Root = @("d:\Clarion11.1EE", "C:\Clarion11-13372"); Output = "bin\Debug-C11" }
-    "10" = @{ Root = @("C:\Clarion10", "C:\Clarion10v8");    Output = "bin\Debug-C10" }
+    "12"   = @{ RegistryKeys = @("Clarion12");              Fallbacks = @("C:\Clarion12");                          GlobPatterns = @("Clarion12*");            Output = "bin\Debug-C12" }
+    "11.1" = @{ RegistryKeys = @("Clarion11.1","Clarion111"); Fallbacks = @("d:\Clarion11.1EE", "C:\Clarion11.1");   GlobPatterns = @("Clarion11.1*","Clarion111*"); Output = "bin\Debug-C11.1" }
+    "11"   = @{ RegistryKeys = @("Clarion11");              Fallbacks = @("C:\Clarion11-13372", "C:\Clarion11");    GlobPatterns = @("Clarion11","Clarion11-*"); Output = "bin\Debug-C11" }
+    "10"   = @{ RegistryKeys = @("Clarion10");              Fallbacks = @("C:\Clarion10", "C:\Clarion10v8");        GlobPatterns = @("Clarion10*");            Output = "bin\Debug-C10" }
+}
+
+# Resolve the install root for a Clarion version: registry (authoritative, modern Clarion
+# versions register a "root" value under SoftVelocity\Clarion<key>) -> known fallback paths
+# (other dev machines) -> drive-root glob scan (machines where neither of the above hit).
+function Resolve-ClarionRoot {
+    param(
+        [string[]]$RegistryKeys,
+        [string[]]$Fallbacks,
+        [string[]]$GlobPatterns
+    )
+
+    function Test-ClarionRoot([string]$path) {
+        if (-not $path) { return $false }
+        return Test-Path (Join-Path $path "bin\ICSharpCode.Core.dll")
+    }
+
+    $regHives = @(
+        "HKLM:\SOFTWARE\WOW6432Node\SoftVelocity",
+        "HKLM:\SOFTWARE\SoftVelocity",
+        "HKCU:\SOFTWARE\SoftVelocity"
+    )
+    foreach ($hive in $regHives) {
+        foreach ($key in $RegistryKeys) {
+            $val = (Get-ItemProperty -Path "$hive\$key" -Name root -ErrorAction SilentlyContinue).root
+            if ($val) {
+                $val = $val.TrimEnd('\')
+                if (Test-ClarionRoot $val) { return $val }
+            }
+        }
+    }
+
+    foreach ($p in $Fallbacks) {
+        if (Test-ClarionRoot $p) { return $p }
+    }
+
+    $drives = (Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
+                Where-Object { Test-Path $_.Root }).Root
+    foreach ($drive in $drives) {
+        foreach ($pattern in $GlobPatterns) {
+            $hit = Get-ChildItem -Path $drive -Directory -Filter $pattern -ErrorAction SilentlyContinue |
+                    Where-Object { Test-ClarionRoot $_.FullName } |
+                    Select-Object -First 1
+            if ($hit) { return $hit.FullName }
+        }
+    }
+
+    return $null
 }
 
 function Resolve-BuildOutputDir {
@@ -58,20 +112,36 @@ function Resolve-BuildOutputDir {
         [string]$PreferredOutput
     )
 
-    $preferred = Join-Path $ProjectDir $PreferredOutput
-    if (Test-Path $preferred) { return $preferred }
-
-    $fallback = Join-Path $ProjectDir "bin\Debug-C"
-    if (Test-Path $fallback) { return $fallback }
-
-    return $preferred
+    # NOTE: deliberately no fallback to the generic bin\Debug-C folder. That folder is whatever
+    # was last built by a plain `msbuild /p:Configuration=Debug` with no ClarionVersion pinned
+    # (e.g. an ad-hoc build-installer.ps1 run) - it could be built against ANY Clarion version's
+    # binding DLLs. Falling back to it here previously caused a real incident: a Clarion-12-built
+    # DLL got silently deployed into a live Clarion 11.1 install because bin\Debug-C11.1 didn't
+    # exist yet. Missing the real per-version folder must be a clean skip, not a guess.
+    return Join-Path $ProjectDir $PreferredOutput
 }
 
 # Which versions to process
 if ($Version -eq "all") {
-    $TargetVersions = @("12", "11", "10")
+    $TargetVersions = @("12", "11.1", "11", "10")
 } else {
     $TargetVersions = @($Version)
+}
+
+# Resolve install roots up front (needed by both the build and deploy loops below, and
+# independent of -NoBuild). A version with no resolvable install is skipped, not fatal —
+# previously a missing version aborted the whole run because MSBuild's own hardcoded
+# ClarionRoot default in Directory.Build.props errored out mid-build.
+$ResolvedRoots = @{}
+foreach ($ver in $TargetVersions) {
+    $cfg  = $Versions[$ver]
+    $root = Resolve-ClarionRoot -RegistryKeys $cfg.RegistryKeys -Fallbacks $cfg.Fallbacks -GlobPatterns $cfg.GlobPatterns
+    if ($root) {
+        $ResolvedRoots[$ver] = $root
+        Write-Host "Clarion ${ver}: $root" -ForegroundColor DarkGray
+    } else {
+        Write-Host "Clarion ${ver}: no install found (registry / known paths / drive scan) - will skip" -ForegroundColor DarkGray
+    }
 }
 
 # Files and folders to deploy
@@ -149,8 +219,12 @@ if (-not $NoBuild) {
 
     foreach ($ver in $TargetVersions) {
         Write-Host ""
-        Write-Host "Building for Clarion $ver..." -ForegroundColor Cyan
-        & $MSBuild $ProjectFile /p:Configuration=Debug /p:ClarionVersion=$ver /v:minimal
+        if (-not $ResolvedRoots.ContainsKey($ver)) {
+            Write-Host "SKIP  build for Clarion $ver (no install found)" -ForegroundColor DarkGray
+            continue
+        }
+        Write-Host "Building for Clarion $ver ($($ResolvedRoots[$ver]))..." -ForegroundColor Cyan
+        & $MSBuild $ProjectFile /p:Configuration=Debug /p:ClarionVersion=$ver /p:ClarionRoot="$($ResolvedRoots[$ver])" /v:minimal
         if ($LASTEXITCODE -ne 0) { Write-Host "Build failed for Clarion $ver." -ForegroundColor Red; exit 1 }
         Write-Host "Build succeeded for Clarion $ver." -ForegroundColor Green
     }
@@ -179,11 +253,14 @@ if ($Kill) {
 
 # --- Deploy each version ---
 foreach ($ver in $TargetVersions) {
+    if (-not $ResolvedRoots.ContainsKey($ver)) {
+        Write-Host ""
+        Write-Host "=== Skipping Clarion $ver deploy (no install found) ===" -ForegroundColor DarkGray
+        continue
+    }
     $cfg         = $Versions[$ver]
     $BuildOutput = Resolve-BuildOutputDir -ProjectDir $ProjectDir -PreferredOutput $cfg.Output
-
-    # Support single root or array of roots
-    $Roots = @($cfg.Root) | ForEach-Object { $_ }
+    $Roots       = @($ResolvedRoots[$ver])
 
     foreach ($root in $Roots) {
         $DeployDir = Join-Path $root "accessory\addins\ClarionAssistant"

--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -262,6 +262,15 @@ foreach ($ver in $TargetVersions) {
     $BuildOutput = Resolve-BuildOutputDir -ProjectDir $ProjectDir -PreferredOutput $cfg.Output
     $Roots       = @($ResolvedRoots[$ver])
 
+    # Same no-guessing principle as Resolve-BuildOutputDir: a config that was never built
+    # (-NoBuild, or a fresh checkout) must be a clean skip — otherwise the item loop below
+    # creates the live addin folder and fills it with indexer/LSP/SQLite but NO addin DLL.
+    if (-not (Test-Path $BuildOutput)) {
+        Write-Host ""
+        Write-Host "=== Skipping Clarion $ver deploy (build output missing: $BuildOutput) ===" -ForegroundColor DarkGray
+        continue
+    }
+
     foreach ($root in $Roots) {
         $DeployDir = Join-Path $root "accessory\addins\ClarionAssistant"
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
       2. Pass on the command line: msbuild /p:ClarionRoot=C:\YourClarion
       3. Default below (John's machine layout — change to match your install if building without a .user file)
 
-    ClarionVersion (10, 11, or 12) selects the default ClarionRoot when no .user override is present.
-    Pass /p:ClarionVersion=11 to target a different version.
+    ClarionVersion (10, 11, 11.1, or 12) selects the default ClarionRoot when no .user override
+    is present. Pass /p:ClarionVersion=11.1 to target a different version.
   -->
   <!-- Import local developer overrides (gitignored) — must come before defaults so overrides win -->
   <Import Project="$(MSBuildThisFileDirectory)Directory.Build.props.user" Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.props.user')" />
@@ -22,8 +22,18 @@
   <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '12'">
     <ClarionRoot>C:\Clarion12</ClarionRoot>
   </PropertyGroup>
+  <!-- 11 and 11.1 are DISTINCT Clarion releases with separate install dirs (confirmed via the
+       SoftVelocity registry keys) — never fold one's path into the other's default, since their
+       binding DLLs are version-specific. These per-version defaults are only a last resort for
+       direct `msbuild` invocations; deploy.ps1 resolves roots itself (registry -> these paths ->
+       drive scan) and passes /p:ClarionRoot explicitly, which always wins over these defaults. -->
   <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '11'">
-    <ClarionRoot>C:\Clarion11-13372</ClarionRoot>
+    <ClarionRoot Condition="Exists('C:\Clarion11-13372\bin\ICSharpCode.Core.dll')">C:\Clarion11-13372</ClarionRoot>
+    <ClarionRoot Condition="'$(ClarionRoot)' == '' and Exists('C:\Clarion11\bin\ICSharpCode.Core.dll')">C:\Clarion11</ClarionRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '11.1'">
+    <ClarionRoot Condition="Exists('d:\Clarion11.1EE\bin\ICSharpCode.Core.dll')">d:\Clarion11.1EE</ClarionRoot>
+    <ClarionRoot Condition="'$(ClarionRoot)' == '' and Exists('C:\Clarion11.1\bin\ICSharpCode.Core.dll')">C:\Clarion11.1</ClarionRoot>
   </PropertyGroup>
   <PropertyGroup Condition="'$(ClarionRoot)' == '' and '$(ClarionVersion)' == '10'">
     <ClarionRoot>C:\Clarion10</ClarionRoot>

--- a/installer/ClarionAssistant.iss
+++ b/installer/ClarionAssistant.iss
@@ -13,9 +13,12 @@
 ; SrcAgents/SrcBlankDct resolve via GetEnv to whichever account runs ISCC, not one developer's
 ; profile. The remaining Src* vars point at repos/installs that live OUTSIDE this repo
 ; (ComForClarion, UltimateCOM, ClarionCOM tooling, a Clarion 12 install, Node.js) — override via
-; the env vars noted below if you build those elsewhere. Their [Files]/[Components] entries are
-; #ifexist-guarded, so compiling without them just skips those optional pieces instead of
-; failing outright (same pattern already used for docgraph.db further down).
+; the env vars noted below if you build those elsewhere. Their [Files] entries are guarded by the
+; Have* presence flags defined at the end of this section, so compiling without them skips those
+; optional pieces — LOUDLY, via one #pragma warning each — instead of failing outright.
+; NOTE: ISPP's #ifexist / FileExists match FILES ONLY (a directory yields FALSE even when it
+; exists), so every flag probes a sentinel FILE inside its source; only wildcard-only trees
+; with no stable filename use DirExists.
 #define SrcBase SourcePath + "..\ClarionAssistant"
 #define SrcC10 SrcBase + "\bin\Debug-C10"
 #define SrcC11 SrcBase + "\bin\Debug-C11"
@@ -52,6 +55,56 @@
 #define SrcNodeExe GetEnv("CLARIONLSP_NODE") != "" ? GetEnv("CLARIONLSP_NODE") : "C:\Program Files\nodejs\node.exe"
 ; The directory containing this .iss file itself (SourcePath already ends in "\").
 #define SrcInstaller Copy(SourcePath, 1, Len(SourcePath)-1)
+
+; ---- Optional-source presence flags ----
+; Each probes a sentinel FILE (never a bare directory — ISPP #ifexist/FileExists return FALSE
+; for directories). A missing source drops its [Files] entries and emits exactly one warning
+; below, so the packaging log always shows what was omitted from the installer.
+#define HaveNodeExe FileExists(SrcNodeExe)
+#define HaveLsp FileExists(SrcLsp + "\out\server\src\server.js")
+#define HaveC11_1 FileExists(SrcC11_1 + "\ClarionAssistant.dll")
+#define HaveComForClarion FileExists(SrcComForClarion + "\ClarionCOMBrowser.dll")
+#define HaveUltimateClasses FileExists(SrcUltimateClasses + "\UltimateCOM.inc")
+#define HaveUltimateTemplates FileExists(SrcUltimateTemplates + "\UltimateCOM.tpl")
+#define HaveTemplateDlls FileExists(SrcTemplateDlls + "\UCSelectCOM.dll")
+#define HaveComDocs DirExists(SrcComDocs)
+#define HaveClarionCOM FileExists(SrcClarionCOM + "\version.txt")
+#define HaveBlankDct FileExists(SrcBlankDct + "\blank.dct")
+#define HaveAgents FileExists(SrcAgents + "\code-reviewer.md")
+
+#if !HaveNodeExe
+#pragma message "WARNING: node.exe missing (" + SrcNodeExe + ") - shipping WITHOUT the bundled Node runtime; the LSP server cannot start without it."
+#endif
+#if !HaveLsp
+#pragma message "WARNING: bundled LSP build missing (" + SrcLsp + ") - shipping WITHOUT the Clarion LSP server. Run Sync-LspServer.ps1 -Pure first."
+#endif
+#if !HaveC11_1
+#pragma message "WARNING: bin\Debug-C11.1 missing - shipping WITHOUT the Clarion 11.1 addin (build it via deploy.ps1 -Version 11.1)."
+#endif
+#if !HaveComForClarion
+#pragma message "WARNING: ClarionCOMBrowser build missing (" + SrcComForClarion + ") - shipping WITHOUT the COM for Clarion addin."
+#endif
+#if !HaveUltimateClasses
+#pragma message "WARNING: UltimateCOM classes missing (" + SrcUltimateClasses + ") - shipping WITHOUT UltimateCOM.inc/.clw."
+#endif
+#if !HaveUltimateTemplates
+#pragma message "WARNING: UltimateCOM templates missing (" + SrcUltimateTemplates + ") - shipping WITHOUT UltimateCOM.tpl."
+#endif
+#if !HaveTemplateDlls
+#pragma message "WARNING: UltimateCOM template DLLs missing (" + SrcTemplateDlls + ") - shipping WITHOUT UCSelectCOM/UTFileCopy DLLs."
+#endif
+#if !HaveComDocs
+#pragma message "WARNING: ComForClarion documentation missing (" + SrcComDocs + ") - shipping WITHOUT COM docs."
+#endif
+#if !HaveClarionCOM
+#pragma message "WARNING: ClarionCOM tooling missing (" + SrcClarionCOM + ") - shipping WITHOUT ClarionCOM templates/scripts."
+#endif
+#if !HaveBlankDct
+#pragma message "WARNING: blank.dct missing (" + SrcBlankDct + ") - shipping WITHOUT the blank dictionary + ClassModels."
+#endif
+#if !HaveAgents
+#pragma message "WARNING: Claude agents missing (" + SrcAgents + ") - shipping WITHOUT the quality agents."
+#endif
 
 [Setup]
 AppId={{B7E2F4A1-8C3D-4E5F-9A1B-2C3D4E5F6A7B}
@@ -145,10 +198,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC10Path}\
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant"; Components: clarion10; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion10 and docs; Flags: ignoreversion
 ; --- Clarion 10 LSP Server ---
-#ifexist SrcNodeExe
+#if HaveNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion10 and lsp; Flags: ignoreversion
 #endif
-#ifexist SrcLsp + "\out\server"
+#if HaveLsp
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -183,10 +236,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC11Path}\
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant"; Components: clarion11; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion11 and docs; Flags: ignoreversion
 ; --- Clarion 11 LSP Server ---
-#ifexist SrcNodeExe
+#if HaveNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion11 and lsp; Flags: ignoreversion
 #endif
-#ifexist SrcLsp + "\out\server"
+#if HaveLsp
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -200,6 +253,10 @@ Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC11Path}\acces
 #endif
 
 ; --- Clarion 11.1 Addin ---
+; Whole block guarded: bin\Debug-C11.1 only exists once the 11.1 config has been built, and
+; build-installer.ps1's freshness gate already treats a missing config bin as "won't ship this
+; config" — without this guard ISCC would hard-fail instead. The HaveC11_1 warning above fires.
+#if HaveC11_1
 Source: "{#SrcC11_1}\ClarionAssistant.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
 Source: "{#SrcC11_1}\ClarionAssistant.pdb"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
 Source: "{#SrcC11_1}\ClarionAssistant.addin"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
@@ -221,10 +278,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC111Path}
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion111 and docs; Flags: ignoreversion
 ; --- Clarion 11.1 LSP Server ---
-#ifexist SrcNodeExe
+#if HaveNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion111 and lsp; Flags: ignoreversion
 #endif
-#ifexist SrcLsp + "\out\server"
+#if HaveLsp
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -235,6 +292,7 @@ Source: "{#SrcLsp}\node_modules\vscode-languageserver-types\*"; DestDir: "{code:
 Source: "{#SrcLsp}\node_modules\xml2js\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xml2js"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\sax\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\sax"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xmlbuilder"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+#endif
 #endif
 
 ; --- Clarion 12 Addin ---
@@ -259,10 +317,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC12Path}\
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant"; Components: clarion12; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion12 and docs; Flags: ignoreversion
 ; --- Clarion 12 LSP Server ---
-#ifexist SrcNodeExe
+#if HaveNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion12 and lsp; Flags: ignoreversion
 #endif
-#ifexist SrcLsp + "\out\server"
+#if HaveLsp
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -277,7 +335,7 @@ Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC12Path}\acces
 
 ; --- COM for Clarion: IDE Addin (installs to whichever Clarion version is selected — uses C12 path) ---
 ; ClarionCOMBrowser is a separate repo (see SrcComForClarion above) — skip if not present at compile time.
-#ifexist SrcComForClarion
+#if HaveComForClarion
 Source: "{#SrcComForClarion}\ClarionCOMBrowser.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
 Source: "{#SrcComForClarion}\ClarionCOMBrowser.pdb"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
 Source: "{#SrcComForClarion}\ClarionCOMBrowser.addin"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
@@ -291,26 +349,26 @@ Source: "{#SrcComForClarion}\runtimes\win-x86\native\WebView2Loader.dll"; DestDi
 ; --- COM for Clarion: UltimateCOM Templates & Class ---
 ; Class/template sources and the Clarion-12-built DLLs are independent external dependencies
 ; (see SrcUltimateClasses/SrcUltimateTemplates/SrcTemplateDlls above) — each guarded separately.
-#ifexist SrcUltimateClasses
+#if HaveUltimateClasses
 Source: "{#SrcUltimateClasses}\UltimateCOM.inc"; DestDir: "{code:GetPrimaryClarionPath}\accessory\libsrc\win"; Components: comforclarion\templates; Flags: ignoreversion
 Source: "{#SrcUltimateClasses}\UltimateCOM.clw"; DestDir: "{code:GetPrimaryClarionPath}\accessory\libsrc\win"; Components: comforclarion\templates; Flags: ignoreversion
 #endif
-#ifexist SrcUltimateTemplates
+#if HaveUltimateTemplates
 Source: "{#SrcUltimateTemplates}\UltimateCOM.tpl"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
 #endif
-#ifexist SrcTemplateDlls
+#if HaveTemplateDlls
 Source: "{#SrcTemplateDlls}\UCSelectCOM.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
 Source: "{#SrcTemplateDlls}\UCSelectCOMProgID.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
 Source: "{#SrcTemplateDlls}\UTFileCopy.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
 #endif
 
 ; --- COM for Clarion: Documentation ---
-#ifexist SrcComDocs
+#if HaveComDocs
 Source: "{#SrcComDocs}\*"; DestDir: "{code:GetPrimaryClarionPath}\accessory\resources\ComForClarionDocumentation"; Components: comforclarion\docs; Flags: ignoreversion recursesubdirs createallsubdirs
 #endif
 
 ; --- COM for Clarion: ClarionCOM Tooling ---
-#ifexist SrcClarionCOM
+#if HaveClarionCOM
 Source: "{#SrcClarionCOM}\Template\*"; DestDir: "{userappdata}\ClarionCOM\Templates"; Components: comforclarion\tooling; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcClarionCOM}\.claude\scripts\*"; DestDir: "{userappdata}\ClarionCOM\scripts"; Components: comforclarion\tooling; Flags: ignoreversion
 Source: "{#SrcClarionCOM}\GenerateClarionMetadata.ps1"; DestDir: "{userappdata}\ClarionCOM\scripts"; Components: comforclarion\tooling; Flags: ignoreversion
@@ -338,7 +396,7 @@ Source: "{#SrcClarionCOM}\version.txt"; DestDir: "{userappdata}\ClarionCOM"; Com
 ; --- Blank dictionary template ---
 ; blank.dct / ClassModels are pulled from the packaging machine's own %APPDATA%\clarionassistant
 ; (populated by running ClarionAssistant locally) — skip if that machine hasn't generated it yet.
-#ifexist SrcBlankDct
+#if HaveBlankDct
 Source: "{#SrcBlankDct}\blank.dct"; DestDir: "{userappdata}\clarionassistant"; Components: plugin\skills; Flags: ignoreversion
 
 ; --- Default class model templates ---
@@ -347,7 +405,7 @@ Source: "{#SrcBlankDct}\ClassModels\*.clw"; DestDir: "{userappdata}\clarionassis
 #endif
 
 ; --- Claude Code Quality Agents ---
-#ifexist SrcAgents
+#if HaveAgents
 Source: "{#SrcAgents}\code-reviewer.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\verifier.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\debugger.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist

--- a/installer/ClarionAssistant.iss
+++ b/installer/ClarionAssistant.iss
@@ -378,7 +378,10 @@ Source: "{#SrcInstaller}\CLAUDE.md"; DestDir: "{%USERPROFILE}\.claude"; DestName
 ; ============================================================
 
 [Dirs]
-Name: "{localappdata}\ClarionAssistant"
+; DocGraphService.GetDefaultDbPath() (the runtime's actual lookup path) uses
+; Environment.SpecialFolder.ApplicationData, i.e. Roaming AppData -- matches {userappdata}
+; below and the docgraph.db [Files] entry above, NOT {localappdata}.
+Name: "{userappdata}\ClarionAssistant"
 ; Marketplace dirs are created by `claude plugin marketplace add` (git clone),
 ; not the installer — see the [Files] note above and configure.ps1.
 Name: "{%USERPROFILE}\.claude\agents"; Components: agents
@@ -395,7 +398,7 @@ Name: "{userappdata}\ClarionCOM\scripts"; Components: comforclarion\tooling
 ; 1. Configure Claude Code settings + env (runs elevated, like the rest of Setup).
 ;    Plugin install is a SEPARATE step (below) so it can run as the original user.
 Filename: "powershell.exe"; \
-  Parameters: "-ExecutionPolicy Bypass -File ""{app}\configure.ps1"" -ClarionRoot ""{code:GetPrimaryClarionPath}"" -DocGraphDb ""{localappdata}\ClarionAssistant\docgraph.db"""; \
+  Parameters: "-ExecutionPolicy Bypass -File ""{app}\configure.ps1"" -ClarionRoot ""{code:GetPrimaryClarionPath}"" -DocGraphDb ""{userappdata}\ClarionAssistant\docgraph.db"""; \
   StatusMsg: "Configuring Claude Code settings..."; \
   Flags: runhidden waituntilterminated
 

--- a/installer/ClarionAssistant.iss
+++ b/installer/ClarionAssistant.iss
@@ -8,33 +8,50 @@
 #define MyAppURL "https://clarionlive.com"
 
 ; Source directories
-#define SrcBase "H:\DevLaptop\ClarionAssistant\ClarionAssistant"
+; SrcBase/SrcDocs/SrcInstaller resolve relative to THIS script's own location ({#SourcePath}),
+; so compiling works regardless of which machine or drive the repo is checked out to.
+; SrcAgents/SrcBlankDct resolve via GetEnv to whichever account runs ISCC, not one developer's
+; profile. The remaining Src* vars point at repos/installs that live OUTSIDE this repo
+; (ComForClarion, UltimateCOM, ClarionCOM tooling, a Clarion 12 install, Node.js) — override via
+; the env vars noted below if you build those elsewhere. Their [Files]/[Components] entries are
+; #ifexist-guarded, so compiling without them just skips those optional pieces instead of
+; failing outright (same pattern already used for docgraph.db further down).
+#define SrcBase SourcePath + "..\ClarionAssistant"
 #define SrcC10 SrcBase + "\bin\Debug-C10"
 #define SrcC11 SrcBase + "\bin\Debug-C11"
+; 11 and 11.1 are distinct Clarion releases with separate binding DLLs (see deploy.ps1) — never
+; share a build output between them.
+#define SrcC11_1 SrcBase + "\bin\Debug-C11.1"
 #define SrcC12 SrcBase + "\bin\Debug-C12"
 ; Indexer is VENDORED into the repo (GitHub #30) — source from ClarionAssistant\indexer, not the old external H:\DevLaptop\ClarionLSP tree.
 #define SrcClarionIndexer SrcBase + "\indexer\bin\Debug"
-#define SrcComForClarion "H:\DevLaptop\ClarionIdeCOMPane\ClarionCOMBrowser\bin\Debug"
+; ClarionCOMBrowser (COM for Clarion IDE addin) lives in a separate repo. Override: CLARIONCOMBROWSER_DIR
+#define SrcComForClarion GetEnv("CLARIONCOMBROWSER_DIR") != "" ? GetEnv("CLARIONCOMBROWSER_DIR") : "H:\DevLaptop\ClarionIdeCOMPane\ClarionCOMBrowser\bin\Debug"
 ; Plugin marketplace is no longer bundled by the installer — configure.ps1
 ; installs it from the GitHub repo ClarionLive/clarionassistant-marketplace.
 ; Repo source of truth: marketplace\ (publish via publish-marketplace-to-github.ps1).
-#define SrcAgents "C:\Users\John Hickey\.claude\agents"
-#define SrcBlankDct "C:\Users\John Hickey\AppData\Roaming\clarionassistant"
-#define SrcDocs "H:\DevLaptop\ClarionAssistant\docs"
+#define SrcAgents GetEnv("USERPROFILE") + "\.claude\agents"
+#define SrcBlankDct GetEnv("APPDATA") + "\clarionassistant"
+#define SrcDocs SourcePath + "..\docs"
 #define SrcTerminal SrcBase + "\Terminal"
 #define SrcTaskBoard SrcBase + "\TaskLifecycleBoard"
-#define SrcUltimateClasses "H:\Dev\Source\Classes"
-#define SrcUltimateTemplates "H:\Dev\Source\SharedTemplates"
-#define SrcTemplateDlls "C:\Clarion12\accessory\template\win"
-#define SrcComDocs "C:\Clarion12\accessory\resources\ComForClarionDocumentation"
-#define SrcClarionCOM "H:\DevLaptop\ClarionCOM\COMTemplate"
+; UltimateCOM class/template sources live outside this repo. Override: ULTIMATECOM_CLASSES_DIR / ULTIMATECOM_TEMPLATES_DIR
+#define SrcUltimateClasses GetEnv("ULTIMATECOM_CLASSES_DIR") != "" ? GetEnv("ULTIMATECOM_CLASSES_DIR") : "H:\Dev\Source\Classes"
+#define SrcUltimateTemplates GetEnv("ULTIMATECOM_TEMPLATES_DIR") != "" ? GetEnv("ULTIMATECOM_TEMPLATES_DIR") : "H:\Dev\Source\SharedTemplates"
+; Template DLLs / COM docs ship from a Clarion 12 install. Override: CLARION12_ROOT
+#define SrcTemplateDlls (GetEnv("CLARION12_ROOT") != "" ? GetEnv("CLARION12_ROOT") : "C:\Clarion12") + "\accessory\template\win"
+#define SrcComDocs (GetEnv("CLARION12_ROOT") != "" ? GetEnv("CLARION12_ROOT") : "C:\Clarion12") + "\accessory\resources\ComForClarionDocumentation"
+; ClarionCOM tooling scripts live outside this repo. Override: CLARIONCOM_TOOLING_DIR
+#define SrcClarionCOM GetEnv("CLARIONCOM_TOOLING_DIR") != "" ? GetEnv("CLARIONCOM_TOOLING_DIR") : "H:\DevLaptop\ClarionCOM\COMTemplate"
 #define SrcFts5 SrcBase + "\lib\sqlite-fts5"
 ; Bundled LSP is now PURE/stock upstream (GitHub #40) — source from the pinned pure build under
 ; .lsp-build\<tag>, NOT the old codegraph-overlay clone. Tag tracks lsp-server-sync\lsp-snapshot.json
 ; "resolvedTag"; bump this path when the pin bumps (Sync-LspServer.ps1 -Pure -Tag <tag>).
 #define SrcLsp SrcBase + "\.lsp-build\v0.9.8"
-#define SrcNodeExe "C:\Program Files\nodejs\node.exe"
-#define SrcInstaller "H:\DevLaptop\ClarionAssistant\installer"
+; Bundled node.exe (so end users don't need Node.js installed). Override: CLARIONLSP_NODE
+#define SrcNodeExe GetEnv("CLARIONLSP_NODE") != "" ? GetEnv("CLARIONLSP_NODE") : "C:\Program Files\nodejs\node.exe"
+; The directory containing this .iss file itself (SourcePath already ends in "\").
+#define SrcInstaller Copy(SourcePath, 1, Len(SourcePath)-1)
 
 [Setup]
 AppId={{B7E2F4A1-8C3D-4E5F-9A1B-2C3D4E5F6A7B}
@@ -77,6 +94,7 @@ Name: "custom"; Description: "Custom installation"; Flags: iscustom
 ; Clarion version checkboxes (auto-checked based on paths entered on previous page)
 Name: "clarion10"; Description: "Clarion 10 Addin"; Types: full custom
 Name: "clarion11"; Description: "Clarion 11 Addin"; Types: full custom
+Name: "clarion111"; Description: "Clarion 11.1 Addin"; Types: full custom
 Name: "clarion12"; Description: "Clarion 12 Addin"; Types: full compact custom
 ; COM for Clarion
 Name: "comforclarion"; Description: "COM for Clarion Browser Addin"; Types: full compact custom
@@ -127,7 +145,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC10Path}\
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant"; Components: clarion10; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion10 and docs; Flags: ignoreversion
 ; --- Clarion 10 LSP Server ---
+#ifexist SrcNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion10 and lsp; Flags: ignoreversion
+#endif
+#ifexist SrcLsp + "\out\server"
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -138,6 +159,7 @@ Source: "{#SrcLsp}\node_modules\vscode-languageserver-types\*"; DestDir: "{code:
 Source: "{#SrcLsp}\node_modules\xml2js\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xml2js"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\sax\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\sax"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC10Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xmlbuilder"; Components: clarion10 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+#endif
 
 ; --- Clarion 11 Addin ---
 Source: "{#SrcC11}\ClarionAssistant.dll"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant"; Components: clarion11; Flags: ignoreversion
@@ -161,7 +183,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC11Path}\
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant"; Components: clarion11; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion11 and docs; Flags: ignoreversion
 ; --- Clarion 11 LSP Server ---
+#ifexist SrcNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion11 and lsp; Flags: ignoreversion
+#endif
+#ifexist SrcLsp + "\out\server"
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -172,6 +197,45 @@ Source: "{#SrcLsp}\node_modules\vscode-languageserver-types\*"; DestDir: "{code:
 Source: "{#SrcLsp}\node_modules\xml2js\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xml2js"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\sax\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\sax"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC11Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xmlbuilder"; Components: clarion11 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+#endif
+
+; --- Clarion 11.1 Addin ---
+Source: "{#SrcC11_1}\ClarionAssistant.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\ClarionAssistant.pdb"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\ClarionAssistant.addin"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+; Hard <Reference> of ClarionAssistant.dll (copy-local) — see C10 note. Ticket 0abd79df.
+Source: "{#SrcC11_1}\ClarionLsp.Contracts.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\Microsoft.Web.WebView2.Core.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\Microsoft.Web.WebView2.WinForms.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\Microsoft.Web.WebView2.Wpf.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\WebView2Loader.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\runtimes\win-x86\native\WebView2Loader.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\runtimes\win-x86\native"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcC11_1}\Everything32.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcFts5}\System.Data.SQLite.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcFts5}\SQLite.Interop.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcFts5}\SQLite.Interop.dll"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\x86"; Components: clarion111; Flags: ignoreversion
+; Terminal/ web assets — recursive copy (see C10 block above). Ticket 0abd79df.
+Source: "{#SrcTerminal}\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\Terminal"; Components: clarion111; Flags: ignoreversion recursesubdirs; Excludes: "*.cs,\mockups\*,\test\*"
+Source: "{#SrcTaskBoard}\lifecycle-board.html"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\TaskLifecycleBoard"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111; Flags: ignoreversion
+Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion111 and docs; Flags: ignoreversion
+; --- Clarion 11.1 LSP Server ---
+#ifexist SrcNodeExe
+Source: "{#SrcNodeExe}"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion111 and lsp; Flags: ignoreversion
+#endif
+#ifexist SrcLsp + "\out\server"
+Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\vscode-languageserver\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-languageserver"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\vscode-languageserver-protocol\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-languageserver-protocol"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\vscode-languageserver-textdocument\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-languageserver-textdocument"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\vscode-languageserver-types\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-languageserver-types"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\xml2js\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xml2js"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\sax\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\sax"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC111Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xmlbuilder"; Components: clarion111 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+#endif
 
 ; --- Clarion 12 Addin ---
 Source: "{#SrcC12}\ClarionAssistant.dll"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant"; Components: clarion12; Flags: ignoreversion
@@ -195,7 +259,10 @@ Source: "{#SrcClarionIndexer}\clarion-indexer.exe"; DestDir: "{code:GetC12Path}\
 Source: "{#SrcClarionIndexer}\clarion-indexer.pdb"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant"; Components: clarion12; Flags: ignoreversion
 Source: "{#SrcDocs}\ClarionAssistant-Guide.html"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\docs"; Components: clarion12 and docs; Flags: ignoreversion
 ; --- Clarion 12 LSP Server ---
+#ifexist SrcNodeExe
 Source: "{#SrcNodeExe}"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server"; Components: clarion12 and lsp; Flags: ignoreversion
+#endif
+#ifexist SrcLsp + "\out\server"
 Source: "{#SrcLsp}\out\server\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\out\server"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\out\common\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\out\common"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\vscode-jsonrpc\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\vscode-jsonrpc"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -206,8 +273,11 @@ Source: "{#SrcLsp}\node_modules\vscode-languageserver-types\*"; DestDir: "{code:
 Source: "{#SrcLsp}\node_modules\xml2js\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xml2js"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\sax\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\sax"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcLsp}\node_modules\xmlbuilder\*"; DestDir: "{code:GetC12Path}\accessory\addins\ClarionAssistant\lsp-server\node_modules\xmlbuilder"; Components: clarion12 and lsp; Flags: ignoreversion recursesubdirs createallsubdirs
+#endif
 
 ; --- COM for Clarion: IDE Addin (installs to whichever Clarion version is selected — uses C12 path) ---
+; ClarionCOMBrowser is a separate repo (see SrcComForClarion above) — skip if not present at compile time.
+#ifexist SrcComForClarion
 Source: "{#SrcComForClarion}\ClarionCOMBrowser.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
 Source: "{#SrcComForClarion}\ClarionCOMBrowser.pdb"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
 Source: "{#SrcComForClarion}\ClarionCOMBrowser.addin"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
@@ -216,19 +286,31 @@ Source: "{#SrcComForClarion}\Microsoft.Web.WebView2.WinForms.dll"; DestDir: "{co
 Source: "{#SrcComForClarion}\Microsoft.Web.WebView2.Wpf.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
 Source: "{#SrcComForClarion}\WebView2Loader.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion"; Components: comforclarion\addin; Flags: ignoreversion
 Source: "{#SrcComForClarion}\runtimes\win-x86\native\WebView2Loader.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\addins\ComForClarion\runtimes\win-x86\native"; Components: comforclarion\addin; Flags: ignoreversion
+#endif
 
 ; --- COM for Clarion: UltimateCOM Templates & Class ---
+; Class/template sources and the Clarion-12-built DLLs are independent external dependencies
+; (see SrcUltimateClasses/SrcUltimateTemplates/SrcTemplateDlls above) — each guarded separately.
+#ifexist SrcUltimateClasses
 Source: "{#SrcUltimateClasses}\UltimateCOM.inc"; DestDir: "{code:GetPrimaryClarionPath}\accessory\libsrc\win"; Components: comforclarion\templates; Flags: ignoreversion
 Source: "{#SrcUltimateClasses}\UltimateCOM.clw"; DestDir: "{code:GetPrimaryClarionPath}\accessory\libsrc\win"; Components: comforclarion\templates; Flags: ignoreversion
+#endif
+#ifexist SrcUltimateTemplates
 Source: "{#SrcUltimateTemplates}\UltimateCOM.tpl"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
+#endif
+#ifexist SrcTemplateDlls
 Source: "{#SrcTemplateDlls}\UCSelectCOM.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
 Source: "{#SrcTemplateDlls}\UCSelectCOMProgID.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
 Source: "{#SrcTemplateDlls}\UTFileCopy.dll"; DestDir: "{code:GetPrimaryClarionPath}\accessory\template\win"; Components: comforclarion\templates; Flags: ignoreversion
+#endif
 
 ; --- COM for Clarion: Documentation ---
+#ifexist SrcComDocs
 Source: "{#SrcComDocs}\*"; DestDir: "{code:GetPrimaryClarionPath}\accessory\resources\ComForClarionDocumentation"; Components: comforclarion\docs; Flags: ignoreversion recursesubdirs createallsubdirs
+#endif
 
 ; --- COM for Clarion: ClarionCOM Tooling ---
+#ifexist SrcClarionCOM
 Source: "{#SrcClarionCOM}\Template\*"; DestDir: "{userappdata}\ClarionCOM\Templates"; Components: comforclarion\tooling; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "{#SrcClarionCOM}\.claude\scripts\*"; DestDir: "{userappdata}\ClarionCOM\scripts"; Components: comforclarion\tooling; Flags: ignoreversion
 Source: "{#SrcClarionCOM}\GenerateClarionMetadata.ps1"; DestDir: "{userappdata}\ClarionCOM\scripts"; Components: comforclarion\tooling; Flags: ignoreversion
@@ -239,6 +321,7 @@ Source: "{#SrcClarionCOM}\install-skills.ps1"; DestDir: "{userappdata}\ClarionCO
 Source: "{#SrcClarionCOM}\install-env.bat"; DestDir: "{userappdata}\ClarionCOM"; Components: comforclarion\tooling; Flags: ignoreversion
 Source: "{#SrcClarionCOM}\install-env.ps1"; DestDir: "{userappdata}\ClarionCOM"; Components: comforclarion\tooling; Flags: ignoreversion
 Source: "{#SrcClarionCOM}\version.txt"; DestDir: "{userappdata}\ClarionCOM"; Components: comforclarion\tooling; Flags: ignoreversion
+#endif
 
 ; --- Clarion Assistant Plugin ---
 ; The plugin is NO LONGER bundled here. configure.ps1 (see [Run]) registers the
@@ -253,19 +336,25 @@ Source: "{#SrcClarionCOM}\version.txt"; DestDir: "{userappdata}\ClarionCOM"; Com
 ; the GitHub repo via installer\publish-marketplace-to-github.ps1).
 
 ; --- Blank dictionary template ---
+; blank.dct / ClassModels are pulled from the packaging machine's own %APPDATA%\clarionassistant
+; (populated by running ClarionAssistant locally) — skip if that machine hasn't generated it yet.
+#ifexist SrcBlankDct
 Source: "{#SrcBlankDct}\blank.dct"; DestDir: "{userappdata}\clarionassistant"; Components: plugin\skills; Flags: ignoreversion
 
 ; --- Default class model templates ---
 Source: "{#SrcBlankDct}\ClassModels\*.inc"; DestDir: "{userappdata}\clarionassistant\ClassModels"; Components: plugin\skills; Flags: onlyifdoesntexist
 Source: "{#SrcBlankDct}\ClassModels\*.clw"; DestDir: "{userappdata}\clarionassistant\ClassModels"; Components: plugin\skills; Flags: onlyifdoesntexist
+#endif
 
 ; --- Claude Code Quality Agents ---
+#ifexist SrcAgents
 Source: "{#SrcAgents}\code-reviewer.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\verifier.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\debugger.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\security-auditor.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\test-designer.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
 Source: "{#SrcAgents}\devils-advocate.md"; DestDir: "{%USERPROFILE}\.claude\agents"; Components: agents; Flags: onlyifdoesntexist
+#endif
 
 ; --- Pre-loaded DocGraph Database ---
 #ifexist SrcInstaller + "\docgraph.db"
@@ -344,6 +433,7 @@ Filename: "{app}\ClarionAssistant-Guide.html"; \
 ; Clean up generated files per version
 Type: filesandordirs; Name: "{code:GetC10Path}\accessory\addins\ClarionAssistant"; Components: clarion10
 Type: filesandordirs; Name: "{code:GetC11Path}\accessory\addins\ClarionAssistant"; Components: clarion11
+Type: filesandordirs; Name: "{code:GetC111Path}\accessory\addins\ClarionAssistant"; Components: clarion111
 Type: filesandordirs; Name: "{code:GetC12Path}\accessory\addins\ClarionAssistant"; Components: clarion12
 
 ; ============================================================
@@ -352,22 +442,25 @@ Type: filesandordirs; Name: "{code:GetC12Path}\accessory\addins\ClarionAssistant
 
 [Code]
 var
-  C10Path, C11Path, C12Path: string;
+  C10Path, C11Path, C111Path, C12Path: string;
   ClarionPathPage: TInputQueryWizardPage;
-  BrowseBtn0, BrowseBtn1, BrowseBtn2: TNewButton;
+  BrowseBtn0, BrowseBtn1, BrowseBtn2, BrowseBtn3: TNewButton;
 
 function GetC10Path(Param: string): string; begin Result := C10Path; end;
 function GetC11Path(Param: string): string; begin Result := C11Path; end;
+function GetC111Path(Param: string): string; begin Result := C111Path; end;
 function GetC12Path(Param: string): string; begin Result := C12Path; end;
 
 function IsC10Detected: Boolean; begin Result := (C10Path <> '') and DirExists(C10Path); end;
 function IsC11Detected: Boolean; begin Result := (C11Path <> '') and DirExists(C11Path); end;
+function IsC111Detected: Boolean; begin Result := (C111Path <> '') and DirExists(C111Path); end;
 function IsC12Detected: Boolean; begin Result := (C12Path <> '') and DirExists(C12Path); end;
 
 // Return the highest available Clarion version path (for COM, templates, etc.)
 function GetPrimaryClarionPath(Param: string): string;
 begin
   if (C12Path <> '') and DirExists(C12Path) then Result := C12Path
+  else if (C111Path <> '') and DirExists(C111Path) then Result := C111Path
   else if (C11Path <> '') and DirExists(C11Path) then Result := C11Path
   else if (C10Path <> '') and DirExists(C10Path) then Result := C10Path
   else Result := 'C:\Clarion12';
@@ -385,11 +478,19 @@ begin
   else if DirExists('C:\Clarion12') then C12Path := 'C:\Clarion12'
   else if DirExists('C:\Clarion12d') then C12Path := 'C:\Clarion12d';
 
-  // Clarion 11
-  C11Path := '';
+  // Clarion 11.1 — a DISTINCT release from 11.0, with its own binding DLLs (see deploy.ps1's
+  // Directory.Build.props note). Must never share a path with C11Path below.
+  C111Path := '';
   if RegQueryStringValue(HKLM32, 'SOFTWARE\SoftVelocity\Clarion11.1', 'root', Path) and DirExists(Path) then
-    C11Path := Path
-  else if RegQueryStringValue(HKLM32, 'SOFTWARE\SoftVelocity\Clarion11', 'root', Path) and DirExists(Path) then
+    C111Path := Path
+  else if RegQueryStringValue(HKLM32, 'SOFTWARE\SoftVelocity\Clarion111', 'root', Path) and DirExists(Path) then
+    C111Path := Path
+  else if DirExists('C:\Clarion11.1') then C111Path := 'C:\Clarion11.1'
+  else if DirExists('d:\Clarion11.1EE') then C111Path := 'd:\Clarion11.1EE';
+
+  // Clarion 11 (11.0)
+  C11Path := '';
+  if RegQueryStringValue(HKLM32, 'SOFTWARE\SoftVelocity\Clarion11', 'root', Path) and DirExists(Path) then
     C11Path := Path
   else if DirExists('C:\Clarion11') then C11Path := 'C:\Clarion11'
   else if DirExists('C:\Clarion11-13372') then C11Path := 'C:\Clarion11-13372';
@@ -447,6 +548,7 @@ end;
 procedure BrowseBtn0Click(Sender: TObject); begin BrowseForPath(0); end;
 procedure BrowseBtn1Click(Sender: TObject); begin BrowseForPath(1); end;
 procedure BrowseBtn2Click(Sender: TObject); begin BrowseForPath(2); end;
+procedure BrowseBtn3Click(Sender: TObject); begin BrowseForPath(3); end;
 
 procedure InitializeWizard;
 var
@@ -465,6 +567,7 @@ begin
     DetectedMsg);
 
   ClarionPathPage.Add('Clarion 12 folder:', False);
+  ClarionPathPage.Add('Clarion 11.1 folder:', False);
   ClarionPathPage.Add('Clarion 11 folder:', False);
   ClarionPathPage.Add('Clarion 10 folder:', False);
 
@@ -502,10 +605,21 @@ begin
   BrowseBtn2.OnClick := @BrowseBtn2Click;
   ClarionPathPage.Edits[2].Width := EditWidth;
 
+  BrowseBtn3 := TNewButton.Create(WizardForm);
+  BrowseBtn3.Parent := ClarionPathPage.Edits[3].Parent;
+  BrowseBtn3.Caption := 'Browse...';
+  BrowseBtn3.Left := ClarionPathPage.Edits[3].Left + EditWidth + 6;
+  BrowseBtn3.Top := ClarionPathPage.Edits[3].Top;
+  BrowseBtn3.Width := 75;
+  BrowseBtn3.Height := ClarionPathPage.Edits[3].Height;
+  BrowseBtn3.OnClick := @BrowseBtn3Click;
+  ClarionPathPage.Edits[3].Width := EditWidth;
+
   // Pre-fill with detected paths
   ClarionPathPage.Values[0] := C12Path;
-  ClarionPathPage.Values[1] := C11Path;
-  ClarionPathPage.Values[2] := C10Path;
+  ClarionPathPage.Values[1] := C111Path;
+  ClarionPathPage.Values[2] := C11Path;
+  ClarionPathPage.Values[3] := C10Path;
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;
@@ -518,8 +632,9 @@ begin
   begin
     // Read user-edited paths
     C12Path := ClarionPathPage.Values[0];
-    C11Path := ClarionPathPage.Values[1];
-    C10Path := ClarionPathPage.Values[2];
+    C111Path := ClarionPathPage.Values[1];
+    C11Path := ClarionPathPage.Values[2];
+    C10Path := ClarionPathPage.Values[3];
 
     // Validate non-empty paths
     AnyValid := False;
@@ -530,6 +645,18 @@ begin
       begin
         MsgBox('Clarion 12 path does not appear valid (no "bin" directory):' + #13#10 + C12Path + #13#10#13#10 +
                'Leave the field empty to skip Clarion 12, or correct the path.', mbError, MB_OK);
+        Result := False;
+        Exit;
+      end;
+      AnyValid := True;
+    end;
+
+    if C111Path <> '' then
+    begin
+      if not DirExists(C111Path + '\bin') then
+      begin
+        MsgBox('Clarion 11.1 path does not appear valid (no "bin" directory):' + #13#10 + C111Path + #13#10#13#10 +
+               'Leave the field empty to skip Clarion 11.1, or correct the path.', mbError, MB_OK);
         Result := False;
         Exit;
       end;
@@ -583,6 +710,13 @@ begin
     begin
       MsgBox('Clarion 11 addin is selected but no Clarion 11 path was specified.' + #13#10 +
              'Go back and enter the path, or uncheck Clarion 11.', mbError, MB_OK);
+      Result := False;
+      Exit;
+    end;
+    if WizardIsComponentSelected('clarion111') and (C111Path = '') then
+    begin
+      MsgBox('Clarion 11.1 addin is selected but no Clarion 11.1 path was specified.' + #13#10 +
+             'Go back and enter the path, or uncheck Clarion 11.1.', mbError, MB_OK);
       Result := False;
       Exit;
     end;
@@ -648,6 +782,12 @@ begin
         WizardForm.ComponentsList.Checked[i] := HasPath;
         WizardForm.ComponentsList.ItemEnabled[i] := HasPath;
       end;
+      if Cap = 'Clarion 11.1 Addin' then
+      begin
+        HasPath := (C111Path <> '') and DirExists(C111Path);
+        WizardForm.ComponentsList.Checked[i] := HasPath;
+        WizardForm.ComponentsList.ItemEnabled[i] := HasPath;
+      end;
       if Cap = 'Clarion 10 Addin' then
       begin
         HasPath := (C10Path <> '') and DirExists(C10Path);
@@ -665,9 +805,11 @@ begin
 
   Log('PrepareToInstall: C10Path=' + C10Path);
   Log('PrepareToInstall: C11Path=' + C11Path);
+  Log('PrepareToInstall: C111Path=' + C111Path);
   Log('PrepareToInstall: C12Path=' + C12Path);
   Log('PrepareToInstall: C10 selected=' + IntToStr(Ord(WizardIsComponentSelected('clarion10'))));
   Log('PrepareToInstall: C11 selected=' + IntToStr(Ord(WizardIsComponentSelected('clarion11'))));
+  Log('PrepareToInstall: C111 selected=' + IntToStr(Ord(WizardIsComponentSelected('clarion111'))));
   Log('PrepareToInstall: C12 selected=' + IntToStr(Ord(WizardIsComponentSelected('clarion12'))));
 
   if WizardIsComponentSelected('clarion10') and (C10Path <> '') and DirExists(C10Path + '\accessory\addins\ClarionAssistant') then
@@ -680,6 +822,12 @@ begin
   begin
     Log('Removing previous C11 addin: ' + C11Path);
     DelTree(C11Path + '\accessory\addins\ClarionAssistant', True, True, True);
+  end;
+
+  if WizardIsComponentSelected('clarion111') and (C111Path <> '') and DirExists(C111Path + '\accessory\addins\ClarionAssistant') then
+  begin
+    Log('Removing previous C11.1 addin: ' + C111Path);
+    DelTree(C111Path + '\accessory\addins\ClarionAssistant', True, True, True);
   end;
 
   if WizardIsComponentSelected('clarion12') and (C12Path <> '') and DirExists(C12Path + '\accessory\addins\ClarionAssistant') then

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -17,19 +17,43 @@ $msbuild = $null
 $searchPaths = @(
     'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe',
     'C:\Program Files\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe',
-    'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe'
+    'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe',
+    'C:\Program Files\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe',
+    'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe',
+    'C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\MSBuild.exe',
+    'C:\Program Files\Microsoft Visual Studio\18\BuildTools\MSBuild\Current\Bin\MSBuild.exe'
 )
 foreach ($p in $searchPaths) {
     if (Test-Path $p) { $msbuild = $p; break }
 }
 if (-not $msbuild) {
-    Write-Error "MSBuild not found. Install Visual Studio 2022."
+    # Fall back to vswhere, which locates any VS/Build Tools install regardless of year/edition.
+    $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
+    if (Test-Path $vswhere) {
+        $vsInstall = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+        if ($vsInstall) {
+            foreach ($candidate in @("$vsInstall\MSBuild\Current\Bin\MSBuild.exe", "$vsInstall\MSBuild\Current\Bin\amd64\MSBuild.exe")) {
+                if (Test-Path $candidate) { $msbuild = $candidate; break }
+            }
+        }
+    }
+}
+if (-not $msbuild) {
+    Write-Error "MSBuild not found. Install Visual Studio 2022/2026 (or Build Tools)."
     exit 1
 }
 
-$innoSetup = 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
-if (-not (Test-Path $innoSetup)) {
-    Write-Error "Inno Setup 6 not found at $innoSetup"
+$innoSetup = $null
+$innoSearchPaths = @(
+    'C:\Program Files (x86)\Inno Setup 6\ISCC.exe',
+    'C:\Program Files\Inno Setup 6\ISCC.exe',
+    (Join-Path $env:LOCALAPPDATA 'Programs\Inno Setup 6\ISCC.exe')
+)
+foreach ($p in $innoSearchPaths) {
+    if (Test-Path $p) { $innoSetup = $p; break }
+}
+if (-not $innoSetup) {
+    Write-Error "Inno Setup 6 not found. Checked: $($innoSearchPaths -join ', ')"
     exit 1
 }
 
@@ -79,7 +103,7 @@ if (-not $SkipBuild) {
     }
 }
 
-# ── Step 1b: Freshness gate — the per-config addin bins (bin\Debug-C10/C11/C12) that the
+# ── Step 1b: Freshness gate — the per-config addin bins (bin\Debug-C10/C11/C11.1/C12) that the
 # .iss packages are built OUT-OF-BAND by deploy.ps1, NOT by this script's build step. With
 # -SkipBuild it's easy to silently ship a STALE config (e.g. C11 left at 5.1.612 while C12 is
 # 5.2.691 — happened for the 5.2 release). Assert every present config bin matches Version.props
@@ -90,7 +114,7 @@ if (Test-Path $versionProps) {
     if ($expected) {
         Write-Host "`nChecking per-config addin freshness (expected $expected)..." -ForegroundColor Yellow
         $stale = @(); $found = 0
-        foreach ($cfg in 'C10','C11','C12') {
+        foreach ($cfg in 'C10','C11','C11.1','C12') {
             $dll = "$repoRoot\ClarionAssistant\bin\Debug-$cfg\ClarionAssistant.dll"
             if (-not (Test-Path $dll)) { Write-Host "  --   ${cfg}: no bin (won't ship this config)" -ForegroundColor DarkGray; continue }
             $found++

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -85,10 +85,14 @@ if (-not $SkipBuild) {
     Write-Host "  OK" -ForegroundColor Green
 
     # Build ClarionIndexer (VENDORED into the repo — GitHub #30 — not the old external H:\DevLaptop\ClarionLSP tree)
+    # NOTE: no /p:Platform override here. ClarionIndexer.csproj only defines <OutputPath> for
+    # Platform=x86 (its own default when Platform is unset) — forcing AnyCPU here matches neither
+    # PropertyGroup condition, so MSBuild errors with "BaseOutputPath/OutputPath property is not
+    # set". deploy.ps1 already builds it this way (Platform left unset); mirror that here.
     $indexerCsproj = "$repoRoot\ClarionAssistant\indexer\ClarionIndexer.csproj"
     if (Test-Path $indexerCsproj) {
         Write-Host "Building ClarionIndexer..." -ForegroundColor Yellow
-        & $msbuild $indexerCsproj /p:Configuration=Debug /p:Platform=AnyCPU /t:Build /v:minimal /nologo /restore
+        & $msbuild $indexerCsproj /p:Configuration=Debug /t:Build /v:minimal /nologo /restore
         if ($LASTEXITCODE -ne 0) { Write-Warning "ClarionIndexer build failed (non-fatal)" }
         else { Write-Host "  OK" -ForegroundColor Green }
     }
@@ -172,14 +176,24 @@ if (-not (Test-Path $iconPath)) {
 }
 
 # ── Step 4: Check for DocGraph DB ──
+# ingest_docs() writes the bundled DB to DocGraphService.GetDefaultDbPath(), i.e.
+# %APPDATA%\ClarionAssistant\docgraph.db (Roaming — Environment.SpecialFolder.ApplicationData),
+# NOT this installer folder. Auto-copy it here if present, instead of requiring a manual copy
+# step every release.
 $docGraphPath = Join-Path $scriptDir 'docgraph.db'
 if (-not (Test-Path $docGraphPath) -and -not $NoDocGraph) {
-    Write-Warning "docgraph.db not found in installer directory."
-    Write-Warning "The DocGraph component will be empty. To include it:"
-    Write-Warning "  1. Run ingest_docs() in Clarion Assistant"
-    Write-Warning "  2. Copy the generated docgraph.db to: $scriptDir"
-    Write-Warning ""
-    Write-Warning "Continuing without DocGraph DB..."
+    $defaultDocGraphPath = Join-Path $env:APPDATA 'ClarionAssistant\docgraph.db'
+    if (Test-Path $defaultDocGraphPath) {
+        Copy-Item $defaultDocGraphPath $docGraphPath -Force
+        Write-Host "Copied docgraph.db from $defaultDocGraphPath" -ForegroundColor Green
+    } else {
+        Write-Warning "docgraph.db not found in installer directory or at $defaultDocGraphPath."
+        Write-Warning "The DocGraph component will be empty. To include it:"
+        Write-Warning "  1. Run ingest_docs() in Clarion Assistant"
+        Write-Warning "  2. Re-run this script (it will auto-copy from $defaultDocGraphPath)"
+        Write-Warning ""
+        Write-Warning "Continuing without DocGraph DB..."
+    }
 }
 
 # ── Step 5: Compile Inno Setup installer ──


### PR DESCRIPTION
## Why

Building on a dev machine with **Visual Studio 2026 Build Tools** (no VS2022 IDE, no Inno Setup) instead of a machine set up like the original author's failed immediately: `build-installer.ps1` hardcoded VS2022 MSBuild paths and a fixed Inno Setup location, and `ClarionAssistant.iss` hardcoded absolute paths onto one specific developer's machine (`H:\DevLaptop\...`, `C:\Users\John Hickey\...`). Along the way, testing also surfaced that Clarion 11 and 11.1 were being treated as the same target even though they're separate releases with separate binding DLLs — risking an ABI mismatch if both are installed on one machine.

## What changed

**`build-installer.ps1`**
- Locates MSBuild across VS2022/2026, Community/Professional/Enterprise/Build Tools, with a `vswhere` fallback for future versions.
- Locates Inno Setup 6 at its per-user install path (`%LOCALAPPDATA%\Programs\...`) in addition to the system-wide path.
- The per-config version-freshness gate now also watches the `C11.1` bin, alongside C10/C11/C12.
- Stopped forcing `/p:Platform=AnyCPU` on the `ClarionIndexer` build. That project only defines `<OutputPath>` under its `Debug|x86`/`Release|x86` conditions (x86 is its default when `Platform` is unset) — forcing `AnyCPU` matched neither, so MSBuild failed with "BaseOutputPath/OutputPath property is not set" every time. `deploy.ps1` already built it correctly (no `Platform` override); this now matches.
- `docgraph.db` is now auto-copied from its real default location (`%APPDATA%\ClarionAssistant\docgraph.db`, i.e. `DocGraphService.GetDefaultDbPath()` in the C# runtime) into the installer folder when missing there, instead of just warning and requiring a manual copy every release.

**`ClarionAssistant/deploy.ps1`**
- Resolves each Clarion version's install root via the `SoftVelocity` registry keys first (authoritative on modern Clarion installs), falling back to known hardcoded paths, then a drive-root glob scan (`Clarion12*`, etc.) as a last resort.
- Splits Clarion 11 and 11.1 into **distinct** build/deploy targets — confirmed via the registry that they're separate installs (`SoftVelocity\Clarion11` vs `SoftVelocity\Clarion11.1`/`Clarion111`), not aliases of each other.
- A missing Clarion version is now a clean skip instead of aborting the whole run (previously one missing version blocked every later version from building).
- Removed a fallback in `Resolve-BuildOutputDir` that could silently deploy a build compiled against one Clarion version's binding DLLs into a *different* version's live install when the correct per-version output folder didn't exist yet. Caught this via an actual reproduction during testing (a Clarion-12-built DLL got copied into a Clarion 11.1 install) before it shipped.
- `vswhere` is now called with `-products *` so it also finds Build Tools-only installs (by default it only sees Community/Professional/Enterprise).

**`Directory.Build.props`**
- Split the `ClarionVersion` `11`/`11.1` `ClarionRoot` defaults to match the above, each probing a couple of known install paths rather than one hardcoded value.

**`installer/ClarionAssistant.iss`**
- Replaced hardcoded absolute paths with paths resolved relative to the script's own location (`{#SourcePath}`) or via environment variables (`%USERPROFILE%`, `%APPDATA%`, plus overrides like `CLARIONCOMBROWSER_DIR`, `CLARION12_ROOT` for repos that live outside this one).
- External dependencies that aren't part of this repo (ComForClarion, UltimateCOM templates/classes, ClarionCOM tooling, bundled Node.js) are now wrapped in `#ifexist` guards — same pattern already used for `docgraph.db` — so the installer compiles cleanly on a machine that doesn't have those side-repos checked out, instead of failing to find a file.
- Added a full **Clarion 11.1** component: file list, wizard page field + Browse button, path validation, component auto-check, and post-install cleanup — mirroring 10/11/12. The wizard's own Clarion-path auto-detection (`DetectClarionPaths`) now also checks 11 vs 11.1 as separate registry keys, matching the `deploy.ps1` fix.
- Fixed a Local vs Roaming AppData mismatch: the `docgraph.db` `[Files]` entry installs to `{userappdata}` (Roaming, matching `DocGraphService.GetDefaultDbPath()`'s real `Environment.SpecialFolder.ApplicationData` path), but the `-DocGraphDb` parameter passed to `configure.ps1` pointed at `{localappdata}` (Local) — a folder the file was never actually placed in. Fixed both the `[Run]` parameter and the matching `[Dirs]` entry. (Currently latent/harmless — nothing in the C# code reads the `CLARION_DOCGRAPH_DB` env var `configure.ps1` sets, `DocGraphService` always calls its own `GetDefaultDbPath()` — but worth being correct in case that wiring gets added later.)

## Testing

Verified end-to-end on a machine with VS2026 Build Tools and Clarion 10, 11, 11.1, and 12 all installed:
- `build-installer.ps1` builds all four addin configs and packages the installer.
- Ran the compiled installer for real (elevated, silent) — it installed correctly into `C:\Clarion10\accessory\addins\ClarionAssistant`.
- Launched the actual Clarion 10 IDE afterward: the addin's autostart log fired and succeeded within the same second the IDE started, and the "Clarion Assistant" entry appeared in the Tools menu.
- `ClarionIndexer` now builds cleanly to `bin\Debug\clarion-indexer.exe` with the corrected command; re-compiled `ClarionAssistant.iss` successfully after all changes above.

## Known pre-existing gap not addressed here

Flagging for visibility, not fixed in this PR: the per-config version-freshness gate in `build-installer.ps1` can't fully agree with itself when `deploy.ps1` builds multiple configs in one pass, because `VersionBuild` auto-increments on every individual MSBuild compile — only the last-built config matches by the time packaging runs.
