### PR TITLE
CodeGraph: CLASS-body member capture in .inc files misses LIKE(...) and EQUATE-aliased-type members

### DIFF
--- a/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
@@ -965,32 +965,92 @@ namespace ClarionCodeGraph.Parsing
                         // Strip a trailing inline comment before matching -- see the DATA-section
                         // fix above for why (e.g. "PrivKey &SomeClass !some comment" must still match).
                         string memberForTypeMatch = StripInlineComment(trimmedMember);
+
+                        // Only RefVariableDeclRegex/VariableDeclRegex were ever tried here, unlike
+                        // ParseMemberFile's own DATA-section cascade, which tries six different
+                        // declaration shapes for the identical purpose. A member declared via
+                        // LIKE(OtherType) (e.g. "GenCertData LIKE(GenCertGroupType)", borrowing
+                        // another structure's layout) or typed via a custom EQUATE-aliased scalar
+                        // synonym (e.g. "CRYPT_CONTEXT EQUATE(LONG)") matched neither regex and
+                        // silently never became a symbol at all (issue: LIKE()/EQUATE-alias-typed
+                        // CLASS member never captured). GroupQueueDeclRegex is deliberately NOT
+                        // added here: a GROUP/QUEUE/RECORD-shaped member line is already
+                        // intercepted earlier, by the "Nested END for inner GROUP/QUEUE etc."
+                        // check above, so it can never reach this cascade at all.
+                        string memberName = null;
+                        string memberType = null;
+                        string memberAttrs = "";
+
                         var refMatch = RefVariableDeclRegex.Match(memberForTypeMatch);
-                        var sclMatch = refMatch.Success ? Match.Empty : VariableDeclRegex.Match(memberForTypeMatch);
-                        if (refMatch.Success || sclMatch.Success)
+                        if (refMatch.Success)
                         {
-                            string memberName = (refMatch.Success ? refMatch : sclMatch).Groups[1].Value;
-                            string attrs = refMatch.Success
-                                ? (refMatch.Groups[3].Success ? refMatch.Groups[3].Value : "")
-                                : (sclMatch.Groups[4].Success ? sclMatch.Groups[4].Value : "");
-                            if (attrs.IndexOf("PRIVATE", StringComparison.OrdinalIgnoreCase) < 0)
+                            memberName = refMatch.Groups[1].Value;
+                            memberType = "&" + refMatch.Groups[2].Value;
+                            memberAttrs = refMatch.Groups[3].Success ? refMatch.Groups[3].Value : "";
+                        }
+                        else
+                        {
+                            var sclMatch = VariableDeclRegex.Match(memberForTypeMatch);
+                            if (sclMatch.Success)
                             {
-                                string memberType = refMatch.Success
-                                    ? "&" + refMatch.Groups[2].Value
-                                    : sclMatch.Groups[2].Value.ToUpperInvariant() +
-                                      (sclMatch.Groups[3].Success ? sclMatch.Groups[3].Value : "");
-                                result.Symbols.Add(new ClarionSymbol
-                                {
-                                    Name = currentClassName + "." + memberName,
-                                    Type = "variable",
-                                    FilePath = filePath,
-                                    LineNumber = lineNum,
-                                    ProjectId = projectId,
-                                    Params = memberType,
-                                    ParentName = currentClassName,
-                                    Scope = "class"
-                                });
+                                memberName = sclMatch.Groups[1].Value;
+                                memberType = sclMatch.Groups[2].Value.ToUpperInvariant() +
+                                    (sclMatch.Groups[3].Success ? sclMatch.Groups[3].Value : "");
+                                memberAttrs = sclMatch.Groups[4].Success ? sclMatch.Groups[4].Value : "";
                             }
+                            else
+                            {
+                                var likeMatch = LikeDeclRegex.Match(memberForTypeMatch);
+                                if (likeMatch.Success)
+                                {
+                                    memberName = likeMatch.Groups[1].Value;
+                                    memberType = "LIKE(" + likeMatch.Groups[2].Value + ")";
+                                    memberAttrs = likeMatch.Groups[3].Success ? likeMatch.Groups[3].Value : "";
+                                }
+                                else
+                                {
+                                    var eqMatch = EquateDeclRegex.Match(memberForTypeMatch);
+                                    if (eqMatch.Success)
+                                    {
+                                        memberName = eqMatch.Groups[1].Value;
+                                        memberType = "EQUATE";
+                                    }
+                                    else
+                                    {
+                                        // Catch-all, deliberately last (broadest match): a member
+                                        // typed with any other non-builtin name, e.g. a custom
+                                        // EQUATE-aliased scalar synonym -- mirrors ParseMemberFile's
+                                        // own identical catch-all.
+                                        var classInstMatch = ClassInstanceDeclRegex.Match(memberForTypeMatch);
+                                        if (classInstMatch.Success)
+                                        {
+                                            string ciType = classInstMatch.Groups[2].Value;
+                                            if (!ClarionBuiltins.IsBuiltInOrKeyword(ciType) &&
+                                                !ClarionBuiltins.IsClarionType(ciType))
+                                            {
+                                                memberName = classInstMatch.Groups[1].Value;
+                                                memberType = ciType.ToUpperInvariant();
+                                                memberAttrs = classInstMatch.Groups[3].Success ? classInstMatch.Groups[3].Value : "";
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (memberName != null && memberAttrs.IndexOf("PRIVATE", StringComparison.OrdinalIgnoreCase) < 0)
+                        {
+                            result.Symbols.Add(new ClarionSymbol
+                            {
+                                Name = currentClassName + "." + memberName,
+                                Type = "variable",
+                                FilePath = filePath,
+                                LineNumber = lineNum,
+                                ProjectId = projectId,
+                                Params = memberType,
+                                ParentName = currentClassName,
+                                Scope = "class"
+                            });
                         }
                     }
                     continue;

--- a/ClarionAssistant/indexer/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/indexer/Parsing/ClarionParser.cs
@@ -946,32 +946,92 @@ namespace ClarionCodeGraph.Parsing
                         // Strip a trailing inline comment before matching -- see the DATA-section
                         // fix above for why (e.g. "PrivKey &SomeClass !some comment" must still match).
                         string memberForTypeMatch = StripInlineComment(trimmedMember);
+
+                        // Only RefVariableDeclRegex/VariableDeclRegex were ever tried here, unlike
+                        // ParseMemberFile's own DATA-section cascade, which tries six different
+                        // declaration shapes for the identical purpose. A member declared via
+                        // LIKE(OtherType) (e.g. "GenCertData LIKE(GenCertGroupType)", borrowing
+                        // another structure's layout) or typed via a custom EQUATE-aliased scalar
+                        // synonym (e.g. "CRYPT_CONTEXT EQUATE(LONG)") matched neither regex and
+                        // silently never became a symbol at all (issue: LIKE()/EQUATE-alias-typed
+                        // CLASS member never captured). GroupQueueDeclRegex is deliberately NOT
+                        // added here: a GROUP/QUEUE/RECORD-shaped member line is already
+                        // intercepted earlier, by the "Nested END for inner GROUP/QUEUE etc."
+                        // check above, so it can never reach this cascade at all.
+                        string memberName = null;
+                        string memberType = null;
+                        string memberAttrs = "";
+
                         var refMatch = RefVariableDeclRegex.Match(memberForTypeMatch);
-                        var sclMatch = refMatch.Success ? Match.Empty : VariableDeclRegex.Match(memberForTypeMatch);
-                        if (refMatch.Success || sclMatch.Success)
+                        if (refMatch.Success)
                         {
-                            string memberName = (refMatch.Success ? refMatch : sclMatch).Groups[1].Value;
-                            string attrs = refMatch.Success
-                                ? (refMatch.Groups[3].Success ? refMatch.Groups[3].Value : "")
-                                : (sclMatch.Groups[4].Success ? sclMatch.Groups[4].Value : "");
-                            if (attrs.IndexOf("PRIVATE", StringComparison.OrdinalIgnoreCase) < 0)
+                            memberName = refMatch.Groups[1].Value;
+                            memberType = "&" + refMatch.Groups[2].Value;
+                            memberAttrs = refMatch.Groups[3].Success ? refMatch.Groups[3].Value : "";
+                        }
+                        else
+                        {
+                            var sclMatch = VariableDeclRegex.Match(memberForTypeMatch);
+                            if (sclMatch.Success)
                             {
-                                string memberType = refMatch.Success
-                                    ? "&" + refMatch.Groups[2].Value
-                                    : sclMatch.Groups[2].Value.ToUpperInvariant() +
-                                      (sclMatch.Groups[3].Success ? sclMatch.Groups[3].Value : "");
-                                result.Symbols.Add(new ClarionSymbol
-                                {
-                                    Name = currentClassName + "." + memberName,
-                                    Type = "variable",
-                                    FilePath = filePath,
-                                    LineNumber = lineNum,
-                                    ProjectId = projectId,
-                                    Params = memberType,
-                                    ParentName = currentClassName,
-                                    Scope = "class"
-                                });
+                                memberName = sclMatch.Groups[1].Value;
+                                memberType = sclMatch.Groups[2].Value.ToUpperInvariant() +
+                                    (sclMatch.Groups[3].Success ? sclMatch.Groups[3].Value : "");
+                                memberAttrs = sclMatch.Groups[4].Success ? sclMatch.Groups[4].Value : "";
                             }
+                            else
+                            {
+                                var likeMatch = LikeDeclRegex.Match(memberForTypeMatch);
+                                if (likeMatch.Success)
+                                {
+                                    memberName = likeMatch.Groups[1].Value;
+                                    memberType = "LIKE(" + likeMatch.Groups[2].Value + ")";
+                                    memberAttrs = likeMatch.Groups[3].Success ? likeMatch.Groups[3].Value : "";
+                                }
+                                else
+                                {
+                                    var eqMatch = EquateDeclRegex.Match(memberForTypeMatch);
+                                    if (eqMatch.Success)
+                                    {
+                                        memberName = eqMatch.Groups[1].Value;
+                                        memberType = "EQUATE";
+                                    }
+                                    else
+                                    {
+                                        // Catch-all, deliberately last (broadest match): a member
+                                        // typed with any other non-builtin name, e.g. a custom
+                                        // EQUATE-aliased scalar synonym -- mirrors ParseMemberFile's
+                                        // own identical catch-all.
+                                        var classInstMatch = ClassInstanceDeclRegex.Match(memberForTypeMatch);
+                                        if (classInstMatch.Success)
+                                        {
+                                            string ciType = classInstMatch.Groups[2].Value;
+                                            if (!ClarionBuiltins.IsBuiltInOrKeyword(ciType) &&
+                                                !ClarionBuiltins.IsClarionType(ciType))
+                                            {
+                                                memberName = classInstMatch.Groups[1].Value;
+                                                memberType = ciType.ToUpperInvariant();
+                                                memberAttrs = classInstMatch.Groups[3].Success ? classInstMatch.Groups[3].Value : "";
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if (memberName != null && memberAttrs.IndexOf("PRIVATE", StringComparison.OrdinalIgnoreCase) < 0)
+                        {
+                            result.Symbols.Add(new ClarionSymbol
+                            {
+                                Name = currentClassName + "." + memberName,
+                                Type = "variable",
+                                FilePath = filePath,
+                                LineNumber = lineNum,
+                                ProjectId = projectId,
+                                Params = memberType,
+                                ParentName = currentClassName,
+                                Scope = "class"
+                            });
                         }
                     }
                     continue;

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -23,7 +23,7 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | ParameterTest | 31 | #87 (call through PROCEDURE parameter) |
 | ReturnTest | 40 | baseline (inline RETURN call shape) |
 | OwnerClass.CallViaMember | 51 | #84+#86 (.inc member, cross-file type) |
-| MainHelperProc | 56 | #81 (procedure in main PROGRAM file) |
+| MainHelperProc | 58 | #81 (procedure in main PROGRAM file) |
 | OwnerClass.CallViaCommentedMember | 67 | #85+#86 (trailing-comment member) |
 | CommentedLocalTest | 83 | #85 (trailing-comment DATA local) |
 | GroupBugClass.CallViaAfterGroupMember | 101 | #88 (member after inline GROUP END) |

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -1,10 +1,10 @@
 # CodeGraph parser regression fixture
 
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
-a further `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR pending, no issue number yet) — a
-single compiling Clarion solution whose procedures each exercise one historical parser/indexer
-bug. This is currently the only regression coverage the CodeGraph parser has; run it after ANY
-change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
+a further `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92) — a single compiling Clarion
+solution whose procedures each exercise one historical parser/indexer bug. This is currently the
+only regression coverage the CodeGraph parser has; run it after ANY change to
+`Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
 
 ## Run
 
@@ -12,8 +12,7 @@ change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either sync
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus the pending
-`LIKE(...)`/`EQUATE`-alias CLASS-member fix)
+## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus #92)
 
 ### Callers of `WorkerClass.Sign` — exactly 18 `calls` rows
 
@@ -36,13 +35,13 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | GroupQueueLocalTest | 213 | #89 (local after GROUP(Type) two-line) |
 | InlineLocalGroupTest | 228 | #89 (local after GROUP(Type) END inline) |
 | LocalDerivedClassTest | 254 | #90 (attribution after local CLASS(Parent)) |
-| LikeMemberBugClass.CallViaPlainInstanceMember | 271 | pending (call through a reference CLASS member, unaffected control) |
+| LikeMemberBugClass.CallViaPlainInstanceMember | 271 | #92 (call through a reference CLASS member, unaffected control) |
 
 ### Symbols
 
 - 7 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
   AfterBugClass (#84: sourced from the `.inc` despite `<None Include>`; #88: the last two
-  vanished entirely before the depth-leak fix), LikeMemberBugClass (pending fix).
+  vanished entirely before the depth-leak fix), LikeMemberBugClass (#92).
 - `LocalDerived` is a **local variable** of LocalDerivedClassTest typed `DERIVABLECLASS` —
   NOT a global class (#90).
 - `pWorker`: `scope='parameter'`, parent `ParameterTest`, params `&WorkerClass` (#87).
@@ -51,9 +50,9 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 - `workerRef` (`&WORKERCLASS`), `LocalGroup` / `InlineLocalGroup` (`GROUP(SmallGroupType)`)
   local variables (#85, #89).
 - `LikeMemberBugClass.GenCertData` (`LIKE(SmallGroupType)`) and `LikeMemberBugClass.SomeHandle`
-  (`SMALLHANDLETYPE`, a custom `EQUATE`-aliased scalar synonym): both `scope='class'` — the
-  pending fix's motivating case (LIKE()-declared / EQUATE-alias-typed CLASS members were never
-  captured at all before it). `LikeMemberBugClass.PlainInstanceMember` (`&WorkerClass`) is an
+  (`SMALLHANDLETYPE`, a custom `EQUATE`-aliased scalar synonym): both `scope='class'` — #92's
+  motivating case (LIKE()-declared / EQUATE-alias-typed CLASS members were never captured at
+  all before it). `LikeMemberBugClass.PlainInstanceMember` (`&WorkerClass`) is an
   unrelated reference member, already handled correctly before this fix — kept as a negative
   control. An **earlier** version of this repro tried a plain by-value `WorkerClass` instance
   here instead of the `EQUATE`-alias case, to exercise the same catch-all fallback — that

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -1,8 +1,9 @@
 # CodeGraph parser regression fixture
 
-Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90 — a single
-compiling Clarion solution whose procedures each exercise one historical parser/indexer bug.
-This is currently the only regression coverage the CodeGraph parser has; run it after ANY
+Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
+a further `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR pending, no issue number yet) — a
+single compiling Clarion solution whose procedures each exercise one historical parser/indexer
+bug. This is currently the only regression coverage the CodeGraph parser has; run it after ANY
 change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
 
 ## Run
@@ -11,9 +12,10 @@ change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either sync
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-14 with all #79–#90 fixes applied)
+## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus the pending
+`LIKE(...)`/`EQUATE`-alias CLASS-member fix)
 
-### Callers of `WorkerClass.Sign` — exactly 17 `calls` rows
+### Callers of `WorkerClass.Sign` — exactly 18 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
@@ -34,12 +36,13 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | GroupQueueLocalTest | 213 | #89 (local after GROUP(Type) two-line) |
 | InlineLocalGroupTest | 228 | #89 (local after GROUP(Type) END inline) |
 | LocalDerivedClassTest | 254 | #90 (attribution after local CLASS(Parent)) |
+| LikeMemberBugClass.CallViaPlainInstanceMember | 271 | pending (call through a reference CLASS member, unaffected control) |
 
 ### Symbols
 
-- 6 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
+- 7 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
   AfterBugClass (#84: sourced from the `.inc` despite `<None Include>`; #88: the last two
-  vanished entirely before the depth-leak fix).
+  vanished entirely before the depth-leak fix), LikeMemberBugClass (pending fix).
 - `LocalDerived` is a **local variable** of LocalDerivedClassTest typed `DERIVABLECLASS` —
   NOT a global class (#90).
 - `pWorker`: `scope='parameter'`, parent `ParameterTest`, params `&WorkerClass` (#87).
@@ -47,6 +50,15 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
   (#84, #85).
 - `workerRef` (`&WORKERCLASS`), `LocalGroup` / `InlineLocalGroup` (`GROUP(SmallGroupType)`)
   local variables (#85, #89).
+- `LikeMemberBugClass.GenCertData` (`LIKE(SmallGroupType)`) and `LikeMemberBugClass.SomeHandle`
+  (`SMALLHANDLETYPE`, a custom `EQUATE`-aliased scalar synonym): both `scope='class'` — the
+  pending fix's motivating case (LIKE()-declared / EQUATE-alias-typed CLASS members were never
+  captured at all before it). `LikeMemberBugClass.PlainInstanceMember` (`&WorkerClass`) is an
+  unrelated reference member, already handled correctly before this fix — kept as a negative
+  control. An **earlier** version of this repro tried a plain by-value `WorkerClass` instance
+  here instead of the `EQUATE`-alias case, to exercise the same catch-all fallback — that
+  construct does NOT compile at all (confirmed directly); replaced with the actual real-world
+  trigger.
 
 ### Program symbol (#81)
 
@@ -62,5 +74,5 @@ JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
-OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup');
+OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','GenCertData','SomeHandle');
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
@@ -23,6 +23,7 @@ owner        OwnerClass
 groupBug     GroupBugClass
 periodBug    PeriodBugClass
 afterBug     AfterBugClass
+likeMemberBug LikeMemberBugClass
 
  CODE
     r# = TestSignatureFlow()
@@ -41,6 +42,7 @@ afterBug     AfterBugClass
     r# = GroupQueueLocalTest()
     r# = InlineLocalGroupTest()
     r# = LocalDerivedClassTest()
+    r# = likeMemberBug.CallViaPlainInstanceMember()
 
 ! Bug A repro: this procedure is implemented directly in the PROGRAM file itself,
 ! rather than in a MEMBER file. ParseMainFile only scans the file's PROGRAM marker,

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -258,3 +258,17 @@ LocalDerived.Compute PROCEDURE( LONG pValue )
   CODE
   RETURN pValue * 2
 
+! Bug K repro: GenCertData (LIKE(SmallGroupType)) and SomeHandle (typed via the EQUATE-aliased
+! SmallHandleType synonym) never matched RefVariableDeclRegex/VariableDeclRegex, the only two
+! regexes ParseIncFile's CLASS-member cascade tried -- silently absent from the index. Expected
+! before the fix: neither GenCertData nor SomeHandle exists as a symbol. PlainInstanceMember
+! (&WorkerClass) is unrelated to this fix -- a reference member, already handled correctly
+! before Bug K -- kept only because a call through it was already wired up here.
+LikeMemberBugClass.CallViaPlainInstanceMember PROCEDURE( )
+result   LONG
+  CODE
+  SELF.PlainInstanceMember &= NEW(WorkerClass)
+  result = SELF.PlainInstanceMember.Sign( 50 )
+  DISPOSE( SELF.PlainInstanceMember)
+  RETURN result
+

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -15,6 +15,12 @@ SmallGroupType GROUP,TYPE
 Field1            LONG
                  END
 
+! Bug K repro: an EQUATE-aliased scalar-type synonym, mirroring the real production case
+! (CRYPT_CONTEXT EQUATE(LONG), used e.g. for ML_CryptBaseClass.HashContext) that motivated the
+! ClassInstanceDeclRegex catch-all fallback -- NOT a class-in-a-class composition, which turned
+! out not to compile (see LikeMemberBugClass below).
+SmallHandleType EQUATE(LONG)
+
 GroupBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
 
 HiddenMember            &WorkerClass, PRIVATE
@@ -41,4 +47,21 @@ CallSomethingElse PROCEDURE( ), LONG
 DerivableClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
 
 Compute       PROCEDURE( LONG pValue ), LONG, VIRTUAL
+            END
+
+! Bug K repro: two CLASS data-member forms ParseIncFile's member-capture cascade never tried.
+! GenCertData: LIKE(NamedType), borrowing another structure's layout. SomeHandle: typed via the
+! EQUATE-aliased SmallHandleType synonym above -- mirrors the real production case
+! (ML_CryptBaseClass.HashContext CRYPT_CONTEXT) that motivated the ClassInstanceDeclRegex
+! catch-all fallback. PlainInstanceMember is a reference member (&WorkerClass) -- an EARLIER
+! version of this repro tried a plain by-value CLASS,TYPE/MODULE/LINK/DLL-declared class
+! instance here instead, which turned out NOT to compile at all (confirmed the hard way); a
+! by-value class-in-a-class composition is a different, apparently illegal construct, distinct
+! from the EQUATE-alias case this fix actually targets.
+LikeMemberBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
+
+GenCertData                LIKE(SmallGroupType)
+SomeHandle                 SmallHandleType
+PlainInstanceMember        &WorkerClass
+CallViaPlainInstanceMember PROCEDURE( ), LONG
             END


### PR DESCRIPTION
# CLASS-body member capture in `.inc` files misses `LIKE(...)` and `EQUATE`-aliased-type members

## Summary

While re-verifying a previous fix (#88) against a real production class, one of its data members was still conspicuously missing — even though every other member on the same class, including several right next to it, now indexed correctly. The missing member was declared with `LIKE(SomeOtherType)`, borrowing its layout from another structure entirely, rather than being a plain scalar field or a `&Reference`.

Digging further turned up a second, closely related gap in the same place: a member typed via a custom, `EQUATE`-aliased scalar-type synonym (a common pattern for giving a plain numeric type a more descriptive name, e.g. a handle or context type) was equally invisible, for the exact same underlying reason.

## Root cause

`ParseIncFile`'s CLASS-body member-capture cascade only ever tries two declaration patterns against each member line: one for a plain scalar type, one for a `&Reference`. `ParseMemberFile`'s own `DATA`-section cascade tries six, for the identical purpose.

Neither `Name LIKE(OtherType)` nor `Name MyAliasedType` (where `MyAliasedType EQUATE(LONG)`) fits either of the two patterns tried — both simply match nothing, and the member silently never becomes a symbol.

## Fix

Extended the cascade to also try `LikeDeclRegex`, `EquateDeclRegex`, and (last, broadest) `ClassInstanceDeclRegex` — mirroring `ParseMemberFile`'s own ordering. `GroupQueueDeclRegex` is deliberately **not** added: a `GROUP`/`QUEUE`/`RECORD`-shaped member line is already intercepted earlier by the existing depth-tracking check from #88, which manages `classEndDepth` but doesn't create a symbol for the member's own name — a separate, narrower, still-open gap.

## Verification

Extended `test-fixtures/codegraph-repro` with `LikeMemberBugClass` (`GenCertData LIKE(SmallGroupType)`, `SomeHandle` typed via a new `SmallHandleType EQUATE(LONG)` synonym). Both now correctly appear as symbols — 18 total callers of `WorkerClass.Sign`, up from 17. No regressions on any prior fix (#79–#90).

Also verified against a real production solution: the `LIKE(...)`-declared member that surfaced this gap now correctly appears, and its owning class shows its complete member list.
