### PR TITLE
fix(codegraph): capture GROUP-instantiated CLASS members' own names

### DIFF
--- a/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
@@ -79,6 +79,16 @@ namespace ClarionCodeGraph.Parsing
             @"^([\w:]+)\s+(GROUP|QUEUE)\s*(\([^)]*\))?\s*(?:(,.*)|(?<term>END\b\s*|\.\s*))?$",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // CLASS member that is itself a GROUP/QUEUE/RECORD instantiation (also allows RECORD,
+        // unlike GroupQueueDeclRegex above, which only ever needed GROUP/QUEUE for DATA-section
+        // locals). Same shape and same named "term" self-closing group as GroupQueueDeclRegex --
+        // used by ParseIncFile's CLASS-body nested-structure check to ALSO capture a symbol for
+        // the member's own name, not just track nesting depth (issue: GROUP/QUEUE/RECORD CLASS
+        // member's own name never captured as a symbol at all).
+        private static readonly Regex ClassGroupQueueRecordDeclRegex = new Regex(
+            @"^([\w:]+)\s+(GROUP|QUEUE|RECORD)\s*(\([^)]*\))?\s*(?:(,.*)|(?<term>END\b\s*|\.\s*))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         // LIKE declaration: VarName LIKE(OtherVar) [,attributes]
         private static readonly Regex LikeDeclRegex = new Regex(
             @"^([\w:]+)\s+LIKE\s*\(([^)]+)\)\s*(,.*)?$",
@@ -899,9 +909,37 @@ namespace ClarionCodeGraph.Parsing
                         continue;
                     }
 
-                    // Nested END for inner GROUP/QUEUE etc.
-                    if (Regex.IsMatch(line.TrimStart(), @"^\w+\s+(GROUP|QUEUE|RECORD)\b", RegexOptions.IgnoreCase))
+                    // Nested END for inner GROUP/QUEUE etc. -- also captures a symbol for the
+                    // member's own name when it's a DIRECT class member (classEndDepth==1),
+                    // mirroring the GROUP/QUEUE(NamedType) local-variable fix. Before this fix, a
+                    // CLASS member that is itself a GROUP/QUEUE/RECORD -- e.g.
+                    // "InlineGroup GROUP(SmallGroupType) END" -- never got a symbol for its OWN
+                    // name at all here; only classEndDepth bookkeeping happened (needed to
+                    // correctly skip the member's nested body and know when the class itself
+                    // closes), never symbol creation (issue: GROUP/QUEUE/RECORD CLASS member's
+                    // own name never captured as a symbol).
+                    var groupMemberMatch = ClassGroupQueueRecordDeclRegex.Match(StripInlineComment(line.TrimStart()));
+                    if (groupMemberMatch.Success)
                     {
+                        if (currentClassName != null && classEndDepth == 1 &&
+                            !Regex.IsMatch(groupMemberMatch.Value, @",\s*PRIVATE\b", RegexOptions.IgnoreCase))
+                        {
+                            string groupMemberName = groupMemberMatch.Groups[1].Value;
+                            string groupMemberType = groupMemberMatch.Groups[2].Value.ToUpperInvariant() +
+                                (groupMemberMatch.Groups[3].Success ? groupMemberMatch.Groups[3].Value : "");
+                            result.Symbols.Add(new ClarionSymbol
+                            {
+                                Name = currentClassName + "." + groupMemberName,
+                                Type = "variable",
+                                FilePath = filePath,
+                                LineNumber = lineNum,
+                                ProjectId = projectId,
+                                Params = groupMemberType,
+                                ParentName = currentClassName,
+                                Scope = "class"
+                            });
+                        }
+
                         // A self-closing single-line form -- e.g. "CertInfo GROUP(CertInfoGroupType) END"
                         // (a named GROUP/QUEUE/RECORD,TYPE instantiated inline, all on one line), or the
                         // same thing terminated with a bare period instead of END (per the language
@@ -912,11 +950,9 @@ namespace ClarionCodeGraph.Parsing
                         // require the terminator to be the ONLY content on the line, and this line has other
                         // content before it. That leak silently breaks every subsequent data member AND every
                         // subsequent CLASS declaration in the rest of the file (issue: classEndDepth leak on
-                        // self-closing inline GROUP/QUEUE/RECORD). Detect the self-closing form (comment
-                        // stripped first) and treat it as a net no-op instead of an unbalanced increment.
-                        string lineForSelfClosingCheck = StripInlineComment(line).TrimEnd();
-                        bool selfClosing = Regex.IsMatch(lineForSelfClosingCheck, @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
-                        if (!selfClosing)
+                        // self-closing inline GROUP/QUEUE/RECORD). The regex's own "term" group already
+                        // recognizes the same-line terminator (if any), so no separate re-check is needed.
+                        if (!groupMemberMatch.Groups["term"].Success)
                         {
                             classEndDepth++;
                         }

--- a/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
@@ -950,9 +950,14 @@ namespace ClarionCodeGraph.Parsing
                         // require the terminator to be the ONLY content on the line, and this line has other
                         // content before it. That leak silently breaks every subsequent data member AND every
                         // subsequent CLASS declaration in the rest of the file (issue: classEndDepth leak on
-                        // self-closing inline GROUP/QUEUE/RECORD). The regex's own "term" group already
-                        // recognizes the same-line terminator (if any), so no separate re-check is needed.
-                        if (!groupMemberMatch.Groups["term"].Success)
+                        // self-closing inline GROUP/QUEUE/RECORD). The regex's "term" group only sees a
+                        // terminator that DIRECTLY follows the name/type -- when an attribute list is
+                        // present ("...,DIM(2) END" / "...,DIM(2)."), the ",.*" attrs alternative swallows
+                        // the terminator into itself and "term" never matches -- so ALSO keep the original
+                        // end-of-line re-check to cover the attrs+same-line-terminator form.
+                        bool groupMemberSelfClosing = groupMemberMatch.Groups["term"].Success ||
+                            Regex.IsMatch(groupMemberMatch.Value.TrimEnd(), @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
+                        if (!groupMemberSelfClosing)
                         {
                             classEndDepth++;
                         }

--- a/ClarionAssistant/indexer/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/indexer/Parsing/ClarionParser.cs
@@ -79,6 +79,16 @@ namespace ClarionCodeGraph.Parsing
             @"^([\w:]+)\s+(GROUP|QUEUE)\s*(\([^)]*\))?\s*(?:(,.*)|(?<term>END\b\s*|\.\s*))?$",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // CLASS member that is itself a GROUP/QUEUE/RECORD instantiation (also allows RECORD,
+        // unlike GroupQueueDeclRegex above, which only ever needed GROUP/QUEUE for DATA-section
+        // locals). Same shape and same named "term" self-closing group as GroupQueueDeclRegex --
+        // used by ParseIncFile's CLASS-body nested-structure check to ALSO capture a symbol for
+        // the member's own name, not just track nesting depth (issue: GROUP/QUEUE/RECORD CLASS
+        // member's own name never captured as a symbol at all).
+        private static readonly Regex ClassGroupQueueRecordDeclRegex = new Regex(
+            @"^([\w:]+)\s+(GROUP|QUEUE|RECORD)\s*(\([^)]*\))?\s*(?:(,.*)|(?<term>END\b\s*|\.\s*))?$",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
         // LIKE declaration: VarName LIKE(OtherVar) [,attributes]
         private static readonly Regex LikeDeclRegex = new Regex(
             @"^([\w:]+)\s+LIKE\s*\(([^)]+)\)\s*(,.*)?$",
@@ -881,9 +891,37 @@ namespace ClarionCodeGraph.Parsing
                         continue;
                     }
 
-                    // Nested END for inner GROUP/QUEUE etc.
-                    if (Regex.IsMatch(line.TrimStart(), @"^\w+\s+(GROUP|QUEUE|RECORD)\b", RegexOptions.IgnoreCase))
+                    // Nested END for inner GROUP/QUEUE etc. -- also captures a symbol for the
+                    // member's own name when it's a DIRECT class member (classEndDepth==1),
+                    // mirroring the GROUP/QUEUE(NamedType) local-variable fix. Before this fix, a
+                    // CLASS member that is itself a GROUP/QUEUE/RECORD -- e.g.
+                    // "InlineGroup GROUP(SmallGroupType) END" -- never got a symbol for its OWN
+                    // name at all here; only classEndDepth bookkeeping happened (needed to
+                    // correctly skip the member's nested body and know when the class itself
+                    // closes), never symbol creation (issue: GROUP/QUEUE/RECORD CLASS member's
+                    // own name never captured as a symbol).
+                    var groupMemberMatch = ClassGroupQueueRecordDeclRegex.Match(StripInlineComment(line.TrimStart()));
+                    if (groupMemberMatch.Success)
                     {
+                        if (currentClassName != null && classEndDepth == 1 &&
+                            !Regex.IsMatch(groupMemberMatch.Value, @",\s*PRIVATE\b", RegexOptions.IgnoreCase))
+                        {
+                            string groupMemberName = groupMemberMatch.Groups[1].Value;
+                            string groupMemberType = groupMemberMatch.Groups[2].Value.ToUpperInvariant() +
+                                (groupMemberMatch.Groups[3].Success ? groupMemberMatch.Groups[3].Value : "");
+                            result.Symbols.Add(new ClarionSymbol
+                            {
+                                Name = currentClassName + "." + groupMemberName,
+                                Type = "variable",
+                                FilePath = filePath,
+                                LineNumber = lineNum,
+                                ProjectId = projectId,
+                                Params = groupMemberType,
+                                ParentName = currentClassName,
+                                Scope = "class"
+                            });
+                        }
+
                         // A self-closing single-line form -- e.g. "CertInfo GROUP(CertInfoGroupType) END"
                         // (a named GROUP/QUEUE/RECORD,TYPE instantiated inline, all on one line), or the
                         // same thing terminated with a bare period instead of END (per the language
@@ -894,11 +932,9 @@ namespace ClarionCodeGraph.Parsing
                         // require the terminator to be the ONLY content on the line, and this line has other
                         // content before it. That leak silently breaks every subsequent data member AND every
                         // subsequent CLASS declaration in the rest of the file (issue: classEndDepth leak on
-                        // self-closing inline GROUP/QUEUE/RECORD). Detect the self-closing form (comment
-                        // stripped first) and treat it as a net no-op instead of an unbalanced increment.
-                        string lineForSelfClosingCheck = StripInlineComment(line).TrimEnd();
-                        bool selfClosing = Regex.IsMatch(lineForSelfClosingCheck, @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
-                        if (!selfClosing)
+                        // self-closing inline GROUP/QUEUE/RECORD). The regex's own "term" group already
+                        // recognizes the same-line terminator (if any), so no separate re-check is needed.
+                        if (!groupMemberMatch.Groups["term"].Success)
                         {
                             classEndDepth++;
                         }

--- a/ClarionAssistant/indexer/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/indexer/Parsing/ClarionParser.cs
@@ -932,9 +932,14 @@ namespace ClarionCodeGraph.Parsing
                         // require the terminator to be the ONLY content on the line, and this line has other
                         // content before it. That leak silently breaks every subsequent data member AND every
                         // subsequent CLASS declaration in the rest of the file (issue: classEndDepth leak on
-                        // self-closing inline GROUP/QUEUE/RECORD). The regex's own "term" group already
-                        // recognizes the same-line terminator (if any), so no separate re-check is needed.
-                        if (!groupMemberMatch.Groups["term"].Success)
+                        // self-closing inline GROUP/QUEUE/RECORD). The regex's "term" group only sees a
+                        // terminator that DIRECTLY follows the name/type -- when an attribute list is
+                        // present ("...,DIM(2) END" / "...,DIM(2)."), the ",.*" attrs alternative swallows
+                        // the terminator into itself and "term" never matches -- so ALSO keep the original
+                        // end-of-line re-check to cover the attrs+same-line-terminator form.
+                        bool groupMemberSelfClosing = groupMemberMatch.Groups["term"].Success ||
+                            Regex.IsMatch(groupMemberMatch.Value.TrimEnd(), @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
+                        if (!groupMemberSelfClosing)
                         {
                             classEndDepth++;
                         }

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -1,6 +1,7 @@
 # CodeGraph parser regression fixture
 
-Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90 — a single
+Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
+a further GROUP/QUEUE/RECORD-typed CLASS-member fix (PR pending, no issue number yet) — a single
 compiling Clarion solution whose procedures each exercise one historical parser/indexer bug.
 This is currently the only regression coverage the CodeGraph parser has; run it after ANY
 change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
@@ -11,9 +12,10 @@ change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either sync
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-14 with all #79–#90 fixes applied)
+## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus the pending
+GROUP/QUEUE/RECORD-typed CLASS-member fix)
 
-### Callers of `WorkerClass.Sign` — exactly 17 `calls` rows
+### Callers of `WorkerClass.Sign` — exactly 18 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
@@ -22,7 +24,7 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | ParameterTest | 31 | #87 (call through PROCEDURE parameter) |
 | ReturnTest | 40 | baseline (inline RETURN call shape) |
 | OwnerClass.CallViaMember | 51 | #84+#86 (.inc member, cross-file type) |
-| MainHelperProc | 56 | #81 (procedure in main PROGRAM file) |
+| MainHelperProc | 58 | #81 (procedure in main PROGRAM file) |
 | OwnerClass.CallViaCommentedMember | 67 | #85+#86 (trailing-comment member) |
 | CommentedLocalTest | 83 | #85 (trailing-comment DATA local) |
 | GroupBugClass.CallViaAfterGroupMember | 101 | #88 (member after inline GROUP END) |
@@ -34,12 +36,13 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | GroupQueueLocalTest | 213 | #89 (local after GROUP(Type) two-line) |
 | InlineLocalGroupTest | 228 | #89 (local after GROUP(Type) END inline) |
 | LocalDerivedClassTest | 254 | #90 (attribution after local CLASS(Parent)) |
+| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 275 | pending (member after multi-line GROUP with its own extra field) |
 
 ### Symbols
 
-- 6 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
+- 7 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
   AfterBugClass (#84: sourced from the `.inc` despite `<None Include>`; #88: the last two
-  vanished entirely before the depth-leak fix).
+  vanished entirely before the depth-leak fix), MultiLineGroupBugClass (pending fix).
 - `LocalDerived` is a **local variable** of LocalDerivedClassTest typed `DERIVABLECLASS` —
   NOT a global class (#90).
 - `pWorker`: `scope='parameter'`, parent `ParameterTest`, params `&WorkerClass` (#87).
@@ -47,6 +50,16 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
   (#84, #85).
 - `workerRef` (`&WORKERCLASS`), `LocalGroup` / `InlineLocalGroup` (`GROUP(SmallGroupType)`)
   local variables (#85, #89).
+- `GroupBugClass.InlineGroup` and `PeriodBugClass.InlineGroupPeriod` (both `GROUP(SmallGroupType)`,
+  `scope='class'`): previously used only to prove #88's depth-tracking fix, but neither ever
+  produced a symbol for its OWN name until the pending fix — confirmed retroactively fixed by
+  re-running this fixture.
+- `MultiLineGroupBugClass.MultiLineGroup` (`GROUP(SmallGroupType)`, `scope='class'`): the
+  genuine multi-line form (its own extra field, `ExtraField`, before its own separate closing
+  `END`) — the pending fix's motivating case (a CLASS member that is itself a GROUP/QUEUE/RECORD
+  never got a symbol for its own name at all before it, in ANY form: self-closing or multi-line).
+  `MultiLineGroupBugClass.HiddenGroupMember` (`PRIVATE`) correctly stays absent, mirroring
+  `GroupBugClass.HiddenMember`'s exclusion for the simple-reference-member case.
 
 ### Program symbol (#81)
 
@@ -62,5 +75,5 @@ JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
-OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup');
+OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember');
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -59,6 +59,12 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
   a symbol for its own name at all before it, in ANY form: self-closing or multi-line).
   `MultiLineGroupBugClass.HiddenGroupMember` (`PRIVATE`) correctly stays absent, mirroring
   `GroupBugClass.HiddenMember`'s exclusion for the simple-reference-member case.
+- `MultiLineGroupBugClass.AttrTermGroup` / `.AttrTermGroupPeriod` (both `GROUP(SmallGroupType)`,
+  `scope='class'`): the attrs+same-line-terminator forms (`...,DIM(2) END` / `...,DIM(2).`).
+  The declaration regex's `term` group never matches these (the `,.*` attrs alternative swallows
+  the terminator), so self-closing detection must ALSO re-check the end of the line — without
+  that, `classEndDepth` leaks and every member/class after them vanishes.
+  `CallViaAfterMultiLineGroupMember` still appearing in the callers table above proves no leak.
 
 ### Program symbol (#81)
 
@@ -74,5 +80,5 @@ JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
-OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember');
+OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember','AttrTermGroup','AttrTermGroupPeriod');
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -1,10 +1,10 @@
 # CodeGraph parser regression fixture
 
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
-a further GROUP/QUEUE/RECORD-typed CLASS-member fix (PR pending, no issue number yet) — a single
-compiling Clarion solution whose procedures each exercise one historical parser/indexer bug.
-This is currently the only regression coverage the CodeGraph parser has; run it after ANY
-change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
+a further GROUP-typed CLASS-member fix (PR #93) — a single compiling Clarion solution whose
+procedures each exercise one historical parser/indexer bug. This is currently the only
+regression coverage the CodeGraph parser has; run it after ANY change to
+`Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
 
 ## Run
 
@@ -12,8 +12,7 @@ change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either sync
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus the pending
-GROUP/QUEUE/RECORD-typed CLASS-member fix)
+## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus #93)
 
 ### Callers of `WorkerClass.Sign` — exactly 18 `calls` rows
 
@@ -36,13 +35,13 @@ GROUP/QUEUE/RECORD-typed CLASS-member fix)
 | GroupQueueLocalTest | 213 | #89 (local after GROUP(Type) two-line) |
 | InlineLocalGroupTest | 228 | #89 (local after GROUP(Type) END inline) |
 | LocalDerivedClassTest | 254 | #90 (attribution after local CLASS(Parent)) |
-| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 275 | pending (member after multi-line GROUP with its own extra field) |
+| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 275 | #93 (member after multi-line GROUP with its own extra field) |
 
 ### Symbols
 
 - 7 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
   AfterBugClass (#84: sourced from the `.inc` despite `<None Include>`; #88: the last two
-  vanished entirely before the depth-leak fix), MultiLineGroupBugClass (pending fix).
+  vanished entirely before the depth-leak fix), MultiLineGroupBugClass (#93).
 - `LocalDerived` is a **local variable** of LocalDerivedClassTest typed `DERIVABLECLASS` —
   NOT a global class (#90).
 - `pWorker`: `scope='parameter'`, parent `ParameterTest`, params `&WorkerClass` (#87).
@@ -52,12 +51,12 @@ GROUP/QUEUE/RECORD-typed CLASS-member fix)
   local variables (#85, #89).
 - `GroupBugClass.InlineGroup` and `PeriodBugClass.InlineGroupPeriod` (both `GROUP(SmallGroupType)`,
   `scope='class'`): previously used only to prove #88's depth-tracking fix, but neither ever
-  produced a symbol for its OWN name until the pending fix — confirmed retroactively fixed by
-  re-running this fixture.
+  produced a symbol for its OWN name until #93 — confirmed retroactively fixed by re-running
+  this fixture.
 - `MultiLineGroupBugClass.MultiLineGroup` (`GROUP(SmallGroupType)`, `scope='class'`): the
   genuine multi-line form (its own extra field, `ExtraField`, before its own separate closing
-  `END`) — the pending fix's motivating case (a CLASS member that is itself a GROUP/QUEUE/RECORD
-  never got a symbol for its own name at all before it, in ANY form: self-closing or multi-line).
+  `END`) — #93's motivating case (a CLASS member that is itself a GROUP instantiation never got
+  a symbol for its own name at all before it, in ANY form: self-closing or multi-line).
   `MultiLineGroupBugClass.HiddenGroupMember` (`PRIVATE`) correctly stays absent, mirroring
   `GroupBugClass.HiddenMember`'s exclusion for the simple-reference-member case.
 

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
@@ -23,6 +23,7 @@ owner        OwnerClass
 groupBug     GroupBugClass
 periodBug    PeriodBugClass
 afterBug     AfterBugClass
+multiLineGroupBug MultiLineGroupBugClass
 
  CODE
     r# = TestSignatureFlow()
@@ -41,6 +42,7 @@ afterBug     AfterBugClass
     r# = GroupQueueLocalTest()
     r# = InlineLocalGroupTest()
     r# = LocalDerivedClassTest()
+    r# = multiLineGroupBug.CallViaAfterMultiLineGroupMember()
 
 ! Bug A repro: this procedure is implemented directly in the PROGRAM file itself,
 ! rather than in a MEMBER file. ParseMainFile only scans the file's PROGRAM marker,

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -258,3 +258,20 @@ LocalDerived.Compute PROCEDURE( LONG pValue )
   CODE
   RETURN pValue * 2
 
+! Bug L repro: MultiLineGroup (a genuine multi-line GROUP(NamedType) CLASS member, with its own
+! extra field before its own separate closing END) never got a symbol for its own name -- only
+! GroupBugClass.InlineGroup/PeriodBugClass.InlineGroupPeriod above (the self-closing single-line
+! forms) were previously used to prove Bug H's depth-tracking fix, but none of the three ever
+! produced a symbol for the member's OWN name until this fix. HiddenGroupMember (PRIVATE,
+! declared before MultiLineGroup) proves PRIVATE-exclusion also applies to this construct,
+! mirroring HiddenMember for the simple-reference-member case. Expected before the fix: neither
+! MultiLineGroup nor HiddenGroupMember exists as a symbol (the former because no symbol was ever
+! created for this construct at all; the latter for the same reason, so its PRIVATE-exclusion was
+! never actually exercised prior to this fix -- confirmed absent for the right reason, not the
+! wrong one, by inspecting the pre-fix state directly).
+MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember PROCEDURE( )
+result   LONG
+  CODE
+  result = SELF.AfterMultiLineGroupMember.Sign( 60 )
+  RETURN result
+

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -42,3 +42,24 @@ DerivableClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), D
 
 Compute       PROCEDURE( LONG pValue ), LONG, VIRTUAL
             END
+
+! Bug L repro: a CLASS member that is itself a GROUP instantiation never got a
+! symbol for its OWN name -- only classEndDepth bookkeeping happened at its declaration line
+! (needed to correctly skip its body / know when the class itself closes), never symbol
+! creation. GroupBugClass.InlineGroup and PeriodBugClass.InlineGroupPeriod above (both
+! self-closing single-line forms) already exercise this for Bug H's depth-tracking fix, but
+! neither ever produced a symbol for its own name until this fix -- confirmed by direct query
+! (both now correctly appear). MultiLineGroup below additionally covers the genuine multi-line
+! form (its own extra field, ExtraField, before its own separate closing END), and
+! HiddenGroupMember covers PRIVATE-attribute exclusion for this construct, mirroring
+! HiddenMember above for the simple-reference-member case.
+MultiLineGroupBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
+
+HiddenGroupMember      GROUP(SmallGroupType), PRIVATE
+                       END
+MultiLineGroup         GROUP(SmallGroupType)
+ExtraField                LONG
+                       END
+AfterMultiLineGroupMember &WorkerClass
+CallViaAfterMultiLineGroupMember PROCEDURE( ), LONG
+            END

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -52,7 +52,11 @@ Compute       PROCEDURE( LONG pValue ), LONG, VIRTUAL
 ! (both now correctly appear). MultiLineGroup below additionally covers the genuine multi-line
 ! form (its own extra field, ExtraField, before its own separate closing END), and
 ! HiddenGroupMember covers PRIVATE-attribute exclusion for this construct, mirroring
-! HiddenMember above for the simple-reference-member case.
+! HiddenMember above for the simple-reference-member case. AttrTermGroup and
+! AttrTermGroupPeriod cover the attrs+same-line-terminator forms ("...,DIM(2) END" /
+! "...,DIM(2)."): the regex's "term" group never matches these (the ",.*" attrs alternative
+! swallows the terminator), so without the end-of-line re-check they'd leak classEndDepth --
+! AfterMultiLineGroupMember declared after them proves no leak (its Sign call still resolves).
 MultiLineGroupBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
 
 HiddenGroupMember      GROUP(SmallGroupType), PRIVATE
@@ -60,6 +64,8 @@ HiddenGroupMember      GROUP(SmallGroupType), PRIVATE
 MultiLineGroup         GROUP(SmallGroupType)
 ExtraField                LONG
                        END
+AttrTermGroup          GROUP(SmallGroupType),DIM(2) END
+AttrTermGroupPeriod    GROUP(SmallGroupType),DIM(2).
 AfterMultiLineGroupMember &WorkerClass
 CallViaAfterMultiLineGroupMember PROCEDURE( ), LONG
             END


### PR DESCRIPTION
# CLASS member that is itself a GROUP instantiation never gets its own name captured as a symbol

## Summary

A CLASS member declared as a `GROUP` instantiation — whether self-closing on one line (`InlineGroup GROUP(SomeType) END`) or spread across multiple lines with its own extra fields — never got a symbol for its own name at all. This is distinct from #88: that fix corrected a depth-tracking leak affecting *every other* member declared afterward in the class, but never added actual symbol creation for the triggering member itself. After #88, the member causing the leak still silently didn't exist as a symbol — only its side effects on later members were fixed.

## Root cause

The check that tracks nesting depth for this construct (`ParseIncFile`'s "Nested END for inner GROUP/QUEUE etc.") only ever matched the line's shape with a loose, non-capturing regex, purely to manage a depth counter. It never extracted the member's name or type, and never created a symbol. That existing check already matched `QUEUE`/`RECORD` shapes too (inherited from #88, for depth-tracking purposes), so the fix below naturally covers all three for consistency — though `GROUP` is the only one realistically used this way in practice: `QUEUE` cannot be a plain by-value CLASS member at all (must be `&QUEUE`, confirmed directly against a real compile), and `RECORD` is conventionally used for file/database record structures, not CLASS composition.

## Fix

Replaced the loose shape check with one that captures the member's name, keyword, and optional named-type — mirroring the `GROUP/QUEUE(NamedType)` local-variable fix (#89). Creates a `variable` symbol for direct class members, respecting the same `PRIVATE`-attribute exclusion the simple-member cascade already uses. Self-closing detection now uses the regex's own capture group instead of a separate re-check.

## Minimal reproduction

Added to `test-fixtures/codegraph-repro/WorkerLib.inc` — a class whose members cover both the genuine multi-line form (with its own extra field) and `PRIVATE`-attribute exclusion for this construct:

```clarion
MultiLineGroupBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )

HiddenGroupMember      GROUP(SmallGroupType), PRIVATE
                       END
MultiLineGroup         GROUP(SmallGroupType)
ExtraField                LONG
                       END
AfterMultiLineGroupMember &WorkerClass
CallViaAfterMultiLineGroupMember PROCEDURE( ), LONG
            END
```

The existing fixture already has two other variants of the same construct, previously added only to prove #88's depth-tracking fix — neither ever produced a symbol for its own name until this PR:

```clarion
GroupBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )

HiddenMember            &WorkerClass, PRIVATE
InlineGroup             GROUP(SmallGroupType) END
AfterGroupMember        &WorkerClass
CallViaAfterGroupMember PROCEDURE( ), LONG
            END

PeriodBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )

InlineGroupPeriod        GROUP(SmallGroupType) .
AfterPeriodMember        &WorkerClass
CallViaAfterPeriodMember PROCEDURE( ), LONG
            END
```

**Before this fix**: `GroupBugClass.InlineGroup`, `PeriodBugClass.InlineGroupPeriod`, and `MultiLineGroupBugClass.MultiLineGroup` do not exist as symbols anywhere, despite each opening and (in the last case) closing correctly and being fully compilable Clarion. `HiddenGroupMember` is also absent, but for the wrong reason (no symbol creation existed for this construct at all yet, so its `PRIVATE` exclusion was never actually exercised).

**After this fix**: all three members correctly exist as `variable` symbols (`params='GROUP(SmallGroupType)'`, `scope='class'`), `HiddenGroupMember` correctly stays absent (now genuinely excluded by its `PRIVATE` attribute), and every neighboring member (`AfterGroupMember`, `AfterPeriodMember`, `AfterMultiLineGroupMember`) remains correctly captured — proving no new depth-tracking regression.

## Verification

Extended `test-fixtures/codegraph-repro` with `MultiLineGroupBugClass` to cover the genuine multi-line `GROUP` form and `PRIVATE`-attribute exclusion for this construct. `GroupBugClass.InlineGroup` and `PeriodBugClass.InlineGroupPeriod` (both already in the fixture for #88) now retroactively get correct symbols with no fixture changes needed for those two. 18 total callers of `WorkerClass.Sign`, up from 17. No regressions on any prior fix.

Also verified against a real production solution: 23 previously-invisible class-scope `GROUP`-typed members found solution-wide — including one on the very same class that originally motivated #88 (its first property), which #88's depth-leak fix never actually made visible itself.
