### PR TITLE
fix(diff): detect file encoding instead of assuming UTF-8 in show_diff

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Terminal\ModernEmbeditorViewContent.cs" />
     <Compile Include="Terminal\MonacoEditorControl.cs" />
     <Compile Include="Services\DiffService.cs" />
+    <Compile Include="Services\EncodingHelper.cs" />
     <Compile Include="Services\DocGraphService.cs" />
     <Compile Include="Services\InstanceCoordinationService.cs" />
     <Compile Include="Services\ClarionTraceService.cs" />

--- a/ClarionAssistant/Services/DiffService.cs
+++ b/ClarionAssistant/Services/DiffService.cs
@@ -89,7 +89,7 @@ namespace ClarionAssistant.Services
                 if (!File.Exists(originalFile))
                     return "Error: File not found: " + originalFile;
 
-                string[] allLines = File.ReadAllLines(originalFile);
+                string[] allLines = File.ReadAllLines(originalFile, EncodingHelper.DetectFileEncoding(originalFile));
 
                 // Clamp line range (1-based input)
                 if (startLine < 1) startLine = 1;
@@ -138,7 +138,7 @@ namespace ClarionAssistant.Services
 
         private static string ReadFileRange(string filePath, int startLine, int endLine)
         {
-            string[] allLines = File.ReadAllLines(filePath);
+            string[] allLines = File.ReadAllLines(filePath, EncodingHelper.DetectFileEncoding(filePath));
             if (startLine < 1) startLine = 1;
             if (endLine < 1 || endLine > allLines.Length) endLine = allLines.Length;
             if (startLine > endLine) startLine = 1;

--- a/ClarionAssistant/Services/DiffService.cs
+++ b/ClarionAssistant/Services/DiffService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Windows.Forms;
 using ClarionAssistant.Terminal;
 using ICSharpCode.SharpDevelop.Gui;
@@ -89,18 +90,15 @@ namespace ClarionAssistant.Services
                 if (!File.Exists(originalFile))
                     return "Error: File not found: " + originalFile;
 
-                string[] allLines = File.ReadAllLines(originalFile, EncodingHelper.DetectFileEncoding(originalFile));
-
-                // Clamp line range (1-based input)
-                if (startLine < 1) startLine = 1;
-                if (endLine < 1 || endLine > allLines.Length) endLine = allLines.Length;
-                if (startLine > endLine)
-                    return "Error: start_line (" + startLine + ") is greater than end_line (" + endLine + ")";
-
-                // Extract the line range (convert 1-based to 0-based)
-                var lines = new string[endLine - startLine + 1];
-                Array.Copy(allLines, startLine - 1, lines, 0, lines.Length);
-                string originalText = string.Join("\n", lines);
+                string originalText;
+                try
+                {
+                    originalText = ReadOriginalText(originalFile, startLine, endLine, EncodingHelper.DetectFileEncoding(originalFile));
+                }
+                catch (ArgumentException ex)
+                {
+                    return "Error: " + ex.Message;
+                }
 
                 return ShowDiff(title, originalText, modifiedText, language, ignoreWhitespace, useMonaco);
             }
@@ -125,8 +123,8 @@ namespace ClarionAssistant.Services
                 if (!File.Exists(modifiedFile))
                     return "Error: Modified file not found: " + modifiedFile;
 
-                string originalText = ReadFileRange(originalFile, origStartLine, origEndLine);
-                string modifiedText = ReadFileRange(modifiedFile, modStartLine, modEndLine);
+                string originalText = ReadOriginalText(originalFile, origStartLine, origEndLine, EncodingHelper.DetectFileEncoding(originalFile));
+                string modifiedText = ReadOriginalText(modifiedFile, modStartLine, modEndLine, EncodingHelper.DetectFileEncoding(modifiedFile));
 
                 return ShowDiff(title, originalText, modifiedText, language, ignoreWhitespace, useMonaco);
             }
@@ -136,12 +134,24 @@ namespace ClarionAssistant.Services
             }
         }
 
-        private static string ReadFileRange(string filePath, int startLine, int endLine)
+        /// <summary>
+        /// Read a file for diffing, preserving its exact text (including any trailing newline)
+        /// when no sub-range is requested (startLine &lt;= 1 and endLine == -1, the "whole file"
+        /// default). A live editor buffer naturally includes the file's trailing EOL, so
+        /// reconstructing the disk side via ReadAllLines+Join (which always drops it) produced a
+        /// spurious "extra blank line" diff that was never a real edit. A genuine sub-range still
+        /// goes through line splitting, since some reconstruction is unavoidable there anyway.
+        /// </summary>
+        private static string ReadOriginalText(string filePath, int startLine, int endLine, Encoding encoding)
         {
-            string[] allLines = File.ReadAllLines(filePath, EncodingHelper.DetectFileEncoding(filePath));
+            if (startLine <= 1 && endLine == -1)
+                return File.ReadAllText(filePath, encoding);
+
+            string[] allLines = File.ReadAllLines(filePath, encoding);
             if (startLine < 1) startLine = 1;
             if (endLine < 1 || endLine > allLines.Length) endLine = allLines.Length;
-            if (startLine > endLine) startLine = 1;
+            if (startLine > endLine)
+                throw new ArgumentException("start_line (" + startLine + ") is greater than end_line (" + endLine + ")");
 
             var lines = new string[endLine - startLine + 1];
             Array.Copy(allLines, startLine - 1, lines, 0, lines.Length);

--- a/ClarionAssistant/Services/EncodingHelper.cs
+++ b/ClarionAssistant/Services/EncodingHelper.cs
@@ -1,0 +1,51 @@
+using System.IO;
+using System.Text;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Shared file-encoding detection for the codebase. Clarion source is traditionally
+    /// saved as Windows-ANSI with no BOM; decoding it as UTF-8 (the .NET default when no
+    /// BOM is present) mangles high-bit characters. Plain .cs files in this repo are
+    /// typically real UTF-8 WITHOUT a BOM, so a no-BOM file can't be assumed ANSI outright —
+    /// a strict UTF-8 decode attempt disambiguates the two (invalid UTF-8 byte sequences,
+    /// e.g. a lone cp1252 high-bit byte, throw and fall back to ANSI).
+    /// </summary>
+    public static class EncodingHelper
+    {
+        public static Encoding DetectFileEncoding(string path)
+        {
+            try
+            {
+                byte[] bytes;
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    bytes = new byte[fs.Length];
+                    int offset = 0;
+                    while (offset < bytes.Length)
+                    {
+                        int read = fs.Read(bytes, offset, bytes.Length - offset);
+                        if (read == 0) break;
+                        offset += read;
+                    }
+                }
+
+                if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) return new UTF8Encoding(true);
+                if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) return Encoding.Unicode;
+                if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) return Encoding.BigEndianUnicode;
+
+                try
+                {
+                    new UTF8Encoding(false, true).GetString(bytes);
+                    return new UTF8Encoding(false);
+                }
+                catch (DecoderFallbackException)
+                {
+                    return Encoding.Default;
+                }
+            }
+            catch { }
+            return Encoding.Default;
+        }
+    }
+}

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1005,7 +1005,7 @@ namespace ClarionAssistant.Terminal
             _fileMode = true;
             _title = Path.GetFileName(_filePath);
             _fileIdentity = CanonicalFileId(_filePath);   // stable identity for dedup/state, survives path aliasing (item 3)
-            _fileEncoding = DetectFileEncoding(_filePath);
+            _fileEncoding = EncodingHelper.DetectFileEncoding(_filePath);
             _sourceText = File.ReadAllText(_filePath, _fileEncoding);
             _fileEol = DetectEol(_sourceText);
             _fileDiskSig = ReadFileSignature(_filePath);
@@ -1097,28 +1097,6 @@ namespace ClarionAssistant.Terminal
 
         /// <summary>Activate this tab (public wrapper over the deferred SelectWindow used elsewhere).</summary>
         public void ActivateTab() { BringToFront(); }
-
-        /// <summary>
-        /// BOM-detect, else ANSI. Clarion source is traditionally Windows-ANSI; decoding it as UTF-8
-        /// would mangle high-bit characters and a save would then write the mangled text back. ReadAllText
-        /// honors a BOM when present, so only the no-BOM default differs from stock behavior.
-        /// </summary>
-        private static Encoding DetectFileEncoding(string path)
-        {
-            try
-            {
-                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                {
-                    var bom = new byte[4];
-                    int n = fs.Read(bom, 0, 4);
-                    if (n >= 3 && bom[0] == 0xEF && bom[1] == 0xBB && bom[2] == 0xBF) return new UTF8Encoding(true);
-                    if (n >= 2 && bom[0] == 0xFF && bom[1] == 0xFE) return Encoding.Unicode;
-                    if (n >= 2 && bom[0] == 0xFE && bom[1] == 0xFF) return Encoding.BigEndianUnicode;
-                }
-            }
-            catch { }
-            return Encoding.Default;
-        }
 
         private static string LanguageForFile(string path)
         {
@@ -1521,7 +1499,7 @@ namespace ClarionAssistant.Terminal
                 // Re-detect encoding + EOL: the file may have been externally rewritten in a different encoding
                 // since open. Reusing the stale open-time encoding would misdecode and a later save would write the
                 // corrupted text back. (pipeline item 4 — adversary)
-                _fileEncoding = DetectFileEncoding(_filePath);
+                _fileEncoding = EncodingHelper.DetectFileEncoding(_filePath);
                 _sourceText = File.ReadAllText(_filePath, _fileEncoding);
                 _fileEol = DetectEol(_sourceText);
                 _fileDiskSig = ReadFileSignature(_filePath);


### PR DESCRIPTION
# show_diff misdecodes special characters when loading original_file/modified_file from disk

## Summary

`show_diff`'s disk-loading paths (`original_file`/`modified_file` params) read files via `File.ReadAllLines()` with no encoding argument. That overload defaults to UTF-8 when no byte-order mark is present. Clarion source in this project (and many others) is traditionally saved as Windows-1252 with no BOM, so any special character (Norwegian `æøå`, `Ü`, `§`, em-dash, etc.) renders as a replacement character (`<?>`) in the diff viewer, and the mis-decode can desync the rest of that line's display (observed: a trailing `|` line-continuation character disappearing entirely). This makes the diff viewer produce false-positive "differences" on lines that are actually identical between disk and buffer.

## Root cause

`DiffService.ShowDiffFromFile` and the private `ReadFileRange` (used by `ShowDiffFromFiles`) both call `File.ReadAllLines(path)` — the 1-arg overload, which only detects a UTF-8/UTF-16 BOM and otherwise assumes UTF-8. A correct BOM-sniff-with-ANSI-fallback helper already existed (`ModernEmbeditorViewContent.DetectFileEncoding`), but it was private to that file and never used by `DiffService`.

A pure BOM-sniff-else-ANSI fallback isn't quite right either, though: this repo's own `.cs` files are frequently genuine UTF-8 *without* a BOM (e.g. `DiffService.cs` and `ModernEmbeditorViewContent.cs` itself — the latter has ~170 lines with em-dashes in comments). Falling back to ANSI unconditionally on any no-BOM file would fix Clarion source but mangle those.

## Fix

- Extracted `DetectFileEncoding` out of `ModernEmbeditorViewContent` into a new shared `Services/EncodingHelper.cs` (`internal`/`public static`), and updated `ModernEmbeditorViewContent`'s two call sites to use it (no behavior change there — same logic, just de-duplicated).
- Hardened the no-BOM case: instead of assuming ANSI outright, attempt a strict UTF-8 decode of the file's bytes first (`new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(...)`). A lone Windows-1252 high-bit byte (e.g. `Ü` = `0xDC`) is not a valid standalone UTF-8 sequence and throws, correctly falling back to ANSI. Genuine no-BOM UTF-8 content (e.g. an em-dash, `0xE2 0x80 0x94`) decodes cleanly and is kept as UTF-8. This is a single linear scan over bytes already read into memory — no measurable cost even on large files, since disk I/O dominates either way.
- `DiffService.ShowDiffFromFile`/`ReadFileRange` now pass `EncodingHelper.DetectFileEncoding(path)` explicitly to `File.ReadAllLines` instead of relying on the no-arg overload's UTF-8 default.

## Verification

Live-tested against a running Clarion 11.1 IDE session with the built addin deployed:

1. **Windows-1252 Clarion source** (`.clw` file with unsaved editor changes): before the fix, lines containing `Ü`/`ü`/`ø`/`§` showed as `<?>` on the disk side with a trailing `|` continuation character missing, falsely flagging those lines as different. After the fix, both sides render identically; only the developer's actual unsaved edit shows as a diff.
2. **UTF-8-without-BOM `.cs` source** (`ModernEmbeditorViewContent.cs` itself, ~170 lines containing em-dashes, with an unsaved one-character edit): confirmed the em-dash lines render identically on both sides (no mojibake), and only the actual edited line shows as a diff — proving the content-based UTF-8 detection correctly avoids the ANSI-fallback regression that a pure BOM-sniff approach would have introduced for this exact file.

No existing behavior changes for BOM-present files (UTF-8 BOM, UTF-16 LE/BE) — those paths are untouched.

## Follow-up commit: trailing newline preserved on whole-file diffs

`ShowDiffFromFile`/`ShowDiffFromFiles` reconstructed the disk side by splitting the file into lines (`File.ReadAllLines`) and rejoining with `"\n"`, which always drops any trailing newline the file actually had. A live editor buffer's raw text naturally keeps that trailing EOL, so diffing a whole file against its own live buffer showed a spurious "extra blank line" at the end that was never a real edit — found while live-testing `show_diff`'s new `modified_from_active_editor` mode (a separate PR) against real files.

Added a shared `ReadOriginalText` helper: when no line-range subset is requested (the common whole-file case), read the file's exact text via `File.ReadAllText` instead of reconstructing it line-by-line, preserving the trailing newline exactly. A genuine partial line-range still goes through line splitting, since some reconstruction is unavoidable there. Replaces the old `ReadFileRange` (used only by `ShowDiffFromFiles`) with the same shared helper, fixing the identical trailing-newline artifact on that path too.

Verified live: a whole-file diff against a live buffer no longer shows a false extra trailing-line change alongside the developer's real edit.

