### PR TITLE
feat(embeditor): dictionary- and CodeGraph-aware completion in the CA Embeditor

### DIFF
--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -69,6 +69,9 @@ namespace ClarionAssistant.Services
             // SharedLspBridge answer cross-project definition/references/workspace-symbol in C#
             // when the LSP returns nothing (needed once we adopt Mark's pure upstream server.js).
             SharedLspBridge.CodeGraphDbPathProvider = () => FindCodeGraphDb();
+            // Same wiring for the dictionary schema DB — lets SharedLspBridge's completion merges resolve
+            // the same .schemagraph.db that query_schema/search_tables/get_table already use.
+            SharedLspBridge.SchemaGraphDbPathProvider = () => FindSchemaGraphDb();
         }
 
         public void SetDiffService(DiffService diffService)

--- a/ClarionAssistant/Services/SchemaGraphService.cs
+++ b/ClarionAssistant/Services/SchemaGraphService.cs
@@ -2067,6 +2067,211 @@ namespace ClarionAssistant.Services
             }
         }
 
+        /// <summary>
+        /// Dictionary-aware qualifier completion for the CA Embeditor: given a table PREFIX (e.g. "Cus"
+        /// from a "Cus:" qualifier typed in the Monaco buffer), returns that table's fields and keys as
+        /// completion items — "Cus:CustomerName" (field, Kind=5) and "Cus:KeyCustName" (key, Kind=20).
+        /// Consumed by SharedLspBridge.MergeDictionaryFieldCompletions. Matches on more than one table
+        /// when multiple ingested dictionaries share a prefix (rare but not prevented by the schema) —
+        /// results carry the owning table name in Detail so the two are distinguishable. Read-only,
+        /// defensive: returns an empty list instead of throwing.
+        /// </summary>
+        public List<LspClient.CompletionItemInfo> GetQualifierCompletions(string prefix, string partial)
+        {
+            var results = new List<LspClient.CompletionItemInfo>();
+            if (string.IsNullOrEmpty(prefix) || !File.Exists(_dbPath)) return results;
+
+            try
+            {
+                using (var conn = OpenConnection(readOnly: true))
+                {
+                    var tables = new List<Tuple<long, string>>();
+                    using (var cmd = new SQLiteCommand(
+                        "SELECT id, name FROM tables WHERE prefix = @p COLLATE NOCASE", conn))
+                    {
+                        cmd.Parameters.AddWithValue("@p", prefix);
+                        using (var reader = cmd.ExecuteReader())
+                            while (reader.Read())
+                                tables.Add(Tuple.Create(reader.GetInt64(0), reader.GetString(1)));
+                    }
+                    if (tables.Count == 0) return results;
+
+                    foreach (var t in tables)
+                    {
+                        using (var cmd = new SQLiteCommand(
+                            @"SELECT name, data_type, size, places, description FROM columns
+                              WHERE table_id = @t ORDER BY ordinal", conn))
+                        {
+                            cmd.Parameters.AddWithValue("@t", t.Item1);
+                            using (var reader = cmd.ExecuteReader())
+                            {
+                                while (reader.Read())
+                                {
+                                    string name = reader.IsDBNull(0) ? null : reader.GetString(0);
+                                    if (string.IsNullOrEmpty(name)) continue;
+                                    if (!string.IsNullOrEmpty(partial) &&
+                                        !name.StartsWith(partial, StringComparison.OrdinalIgnoreCase)) continue;
+                                    string dtype = reader.IsDBNull(1) ? null : reader.GetString(1);
+                                    int size = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2));
+                                    int places = reader.IsDBNull(3) ? 0 : Convert.ToInt32(reader.GetValue(3));
+                                    string desc = reader.IsDBNull(4) ? null : reader.GetString(4);
+                                    // Declared TYPE(size[,places]) as it reads after the field name in source —
+                                    // e.g. "DECIMAL(13,2)". Deliberately NOT the picture: a picture like
+                                    // "@n$4.2" is a display/edit format mask, not the field's storage size, and
+                                    // showing it as the size is misleading (a DECIMAL(13,2) can carry any
+                                    // picture, unrelated to its actual 13,2 precision).
+                                    string typeText = FormatColumnType(dtype, size, places);
+                                    // Detail stays short/single-line (Monaco doesn't wrap it); the description
+                                    // goes to Documentation, shown in Monaco's expandable docs panel instead.
+                                    string detail = typeText + "  (table '" + t.Item2 + "' field, dictionary)";
+                                    results.Add(new LspClient.CompletionItemInfo
+                                    {
+                                        Label = prefix + ":" + name,
+                                        Kind = 5, // Field
+                                        Detail = detail,
+                                        Documentation = string.IsNullOrEmpty(desc) ? null : desc,
+                                        InsertText = name
+                                    });
+                                }
+                            }
+                        }
+
+                        using (var cmd = new SQLiteCommand(
+                            "SELECT id, name, is_primary FROM keys WHERE table_id = @t", conn))
+                        {
+                            cmd.Parameters.AddWithValue("@t", t.Item1);
+                            var keyRows = new List<Tuple<long, string, bool>>();
+                            using (var reader = cmd.ExecuteReader())
+                                while (reader.Read())
+                                    keyRows.Add(Tuple.Create(reader.GetInt64(0), reader.GetString(1),
+                                        !reader.IsDBNull(2) && reader.GetInt64(2) != 0));
+
+                            foreach (var k in keyRows)
+                            {
+                                string name = k.Item2;
+                                if (string.IsNullOrEmpty(name)) continue;
+                                if (!string.IsNullOrEmpty(partial) &&
+                                    !name.StartsWith(partial, StringComparison.OrdinalIgnoreCase)) continue;
+                                // Detail stays short (Monaco doesn't wrap it); the field composition — which
+                                // can run long for multi-field keys — goes to Documentation instead, shown in
+                                // Monaco's expandable docs panel.
+                                string composition = GetKeyComposition(conn, k.Item1);
+                                string detail = (k.Item3 ? "primary key" : "key") +
+                                                 "  (table '" + t.Item2 + "', dictionary)";
+                                results.Add(new LspClient.CompletionItemInfo
+                                {
+                                    Label = prefix + ":" + name,
+                                    Kind = 20, // EnumMember — visually distinct from a field
+                                    Detail = detail,
+                                    Documentation = string.IsNullOrEmpty(composition) ? null : "Composition: " + composition,
+                                    InsertText = name
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            catch { }
+            return results;
+        }
+
+        /// <summary>
+        /// Renders a column's declared type as it reads in Clarion source: "STRING(30)", "DECIMAL(13,2)",
+        /// "LONG" (no parens when size is 0/absent, e.g. LONG/BYTE/DATE). NOT the picture — a picture is a
+        /// display/edit format mask, independent of and not a reliable stand-in for the field's actual size.
+        /// </summary>
+        private static string FormatColumnType(string dataType, int size, int places)
+        {
+            string dt = string.IsNullOrEmpty(dataType) ? "?" : dataType.ToUpperInvariant();
+            if (size <= 0) return dt;
+            return places > 0 ? dt + "(" + size + "," + places + ")" : dt + "(" + size + ")";
+        }
+
+        /// <summary>
+        /// A key's field composition in declared order, e.g. "LastName, FirstName DESC" — joins
+        /// key_columns → columns, ordered by key_columns.ordinal. Returns null on any failure or when the
+        /// key has no components (never throws).
+        /// </summary>
+        private static string GetKeyComposition(SQLiteConnection conn, long keyId)
+        {
+            try
+            {
+                using (var cmd = new SQLiteCommand(
+                    @"SELECT c.name, kc.ascending FROM key_columns kc
+                      JOIN columns c ON c.id = kc.column_id
+                      WHERE kc.key_id = @k ORDER BY kc.ordinal", conn))
+                {
+                    cmd.Parameters.AddWithValue("@k", keyId);
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        var parts = new List<string>();
+                        while (reader.Read())
+                        {
+                            if (reader.IsDBNull(0)) continue;
+                            string name = reader.GetString(0);
+                            bool ascending = reader.IsDBNull(1) || reader.GetInt64(1) != 0;
+                            parts.Add(ascending ? name : name + " DESC");
+                        }
+                        return parts.Count > 0 ? string.Join(", ", parts) : null;
+                    }
+                }
+            }
+            catch { return null; }
+        }
+
+        /// <summary>
+        /// Dictionary table-name completion for the CA Embeditor: bare-prefix match against ingested
+        /// table names (e.g. typing "Cus" suggests "Customers"). Consumed by SharedLspBridge's bare-prefix
+        /// completion merge. Read-only, defensive: returns an empty list instead of throwing.
+        /// </summary>
+        public List<LspClient.CompletionItemInfo> GetTableNameCompletions(string prefix, int limit = 25)
+        {
+            var results = new List<LspClient.CompletionItemInfo>();
+            if (string.IsNullOrEmpty(prefix) || !File.Exists(_dbPath)) return results;
+
+            try
+            {
+                using (var conn = OpenConnection(readOnly: true))
+                using (var cmd = new SQLiteCommand(
+                    @"SELECT name, prefix, driver, description FROM tables
+                      WHERE name LIKE @p ESCAPE '\' COLLATE NOCASE
+                      ORDER BY name LIMIT @limit", conn))
+                {
+                    cmd.Parameters.AddWithValue("@p", EscapeLike(prefix) + "%");
+                    cmd.Parameters.AddWithValue("@limit", limit);
+                    using (var reader = cmd.ExecuteReader())
+                    {
+                        while (reader.Read())
+                        {
+                            string name = reader.IsDBNull(0) ? null : reader.GetString(0);
+                            if (string.IsNullOrEmpty(name)) continue;
+                            string pre = reader.IsDBNull(1) ? "" : reader.GetString(1);
+                            string driver = reader.IsDBNull(2) ? "" : reader.GetString(2);
+                            string desc = reader.IsDBNull(3) ? "" : reader.GetString(3);
+                            string detail = string.IsNullOrEmpty(driver) ? "table" : driver + " table";
+                            if (!string.IsNullOrEmpty(pre)) detail += "  PRE(" + pre + ")";
+                            detail += "  (dictionary)";
+                            results.Add(new LspClient.CompletionItemInfo
+                            {
+                                Label = name,
+                                Kind = 9, // Module — distinct from Class/Field icons used elsewhere
+                                Detail = detail,
+                                Documentation = string.IsNullOrEmpty(desc) ? null : desc,
+                                InsertText = name
+                            });
+                        }
+                    }
+                }
+            }
+            catch { }
+            return results;
+        }
+
+        private static string EscapeLike(string s)
+        {
+            return (s ?? "").Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+        }
+
         #endregion
 
         #region Helpers

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -499,6 +499,16 @@ namespace ClarionAssistant.Services
             try { MergeQualifiedFieldCompletions(primary, filePath, line, character, bufferText); }
             catch (Exception ex) { Debug.WriteLine("[SharedLspBridge] qualified field completion merge failed: " + ex.Message); }
 
+            // Dictionary table FIELD/KEY completion ("Cus:" → columns + keys of the dictionary table whose
+            // PRE is "Cus", from the ingested .schemagraph.db). Same "<ident>:partial" qualifier context as
+            // MergeQualifiedFieldCompletions above, but a different data source (dictionary, not a GROUP/QUEUE
+            // visible in the current buffer) — a hand-coded FILE structure and a dictionary table can share a
+            // prefix, so this deliberately does NOT dedupe against what MergeQualifiedFieldCompletions already
+            // added; both are shown, distinguished by Detail ("... field, dictionary" vs "... (field)").
+            // Never throws, never overrides.
+            try { MergeDictionaryFieldCompletions(primary, filePath, line, character, bufferText); }
+            catch (Exception ex) { Debug.WriteLine("[SharedLspBridge] dictionary field completion merge failed: " + ex.Message); }
+
             // Class member-access (ticket 6e8f2439, item 5b): "oInstance." → that instance's ABC/library
             // methods from ClarionGraph (+ project CodeGraph), resolved by the instance's declared class
             // type. Mark's LSP answers member access for project-local types; this SUPPLEMENTS it for
@@ -1120,6 +1130,11 @@ namespace ClarionAssistant.Services
         /// <c>EmbeditorCompletionService.LspStarter</c>.)</summary>
         public static Func<string> CodeGraphDbPathProvider;
 
+        /// <summary>Set at startup (SetChatControl) to return the active solution's .schemagraph.db path
+        /// — mirrors <see cref="CodeGraphDbPathProvider"/>, same wiring pattern, resolved the same way
+        /// query_schema/search_tables/get_table already do (McpToolRegistry.FindSchemaGraphDb).</summary>
+        public static Func<string> SchemaGraphDbPathProvider;
+
         // Clarion identifier under the cursor — mirrors server.ts getWordAtPosition.
         private static readonly Regex CgWordPattern = new Regex(@"[A-Za-z_][A-Za-z0-9_:.]*");
 
@@ -1157,6 +1172,38 @@ namespace ClarionAssistant.Services
             {
                 if (!string.IsNullOrEmpty(filePathHint))
                     return CodeGraphProvider.FindDatabase(Path.GetDirectoryName(filePathHint));
+            }
+            catch { }
+            return null;
+        }
+
+        /// <summary>Resolves the active solution's .schemagraph.db, same hook-then-fallback shape as
+        /// <see cref="ResolveCodeGraphDb"/>. The fallback walks up from the request's file path looking
+        /// for a "*.schemagraph.db" — same directory-walk the hook itself does when wired.</summary>
+        private static string ResolveSchemaGraphDb(string filePathHint)
+        {
+            try
+            {
+                var hook = SchemaGraphDbPathProvider;
+                if (hook != null)
+                {
+                    string p = hook();
+                    if (!string.IsNullOrEmpty(p) && File.Exists(p)) return p;
+                }
+            }
+            catch { }
+            try
+            {
+                if (string.IsNullOrEmpty(filePathHint)) return null;
+                string dir = Path.GetDirectoryName(filePathHint);
+                while (!string.IsNullOrEmpty(dir))
+                {
+                    var hits = Directory.GetFiles(dir, "*.schemagraph.db");
+                    if (hits.Length > 0) return hits[0];
+                    var parent = Directory.GetParent(dir);
+                    if (parent == null) break;
+                    dir = parent.FullName;
+                }
             }
             catch { }
             return null;
@@ -1596,6 +1643,22 @@ namespace ClarionAssistant.Services
             // entries are skipped here (they belong to member-access completion). No-op until the version
             // DB is built. Additive + defensive: only ADDS, never overrides an LSP item.
             MergeDbBarePrefix(primary, seen, prefix, ClarionGraphService.ResolveDbPath(), bareNamesOnly: true);
+
+            // (6) Dictionary TABLE names (e.g. "Cus" → "Customers") from the ingested .schemagraph.db.
+            // Deliberately does NOT gate on `seen` — a table name colliding with a code symbol is a rare,
+            // legitimate case the developer should see both sides of (per the field-completion design,
+            // dictionary results are additive, distinguished via Detail, never silently dropped).
+            try
+            {
+                string schemaDb = ResolveSchemaGraphDb(filePath);
+                if (!string.IsNullOrEmpty(schemaDb))
+                {
+                    var service = new SchemaGraphService(schemaDb);
+                    var tables = service.GetTableNameCompletions(prefix);
+                    if (tables != null) primary.AddRange(tables);
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine("[SharedLspBridge] dictionary table-name completion merge failed: " + ex.Message); }
         }
 
         /// <summary>
@@ -1672,6 +1735,20 @@ namespace ClarionAssistant.Services
 
         private static string CgCompletionDetail(CodeGraphSymbol s)
         {
+            // Variables: Params holds the ACTUAL declared Clarion type (e.g. "STRING(30)", "DECIMAL(13,2)")
+            // -- s.Type is just the generic symbol kind ("variable") and would show that word instead of the
+            // type. Scope is "local" (procedure/routine-private) or "module" (file-scope, visible solution-
+            // wide via this DB) -- shown as Local/Global per the same wording the live-buffer variable merges
+            // use, so a variable reads the same whether it came from the current buffer or cross-file CodeGraph.
+            if (string.Equals(s.Type, "variable", StringComparison.OrdinalIgnoreCase))
+            {
+                string vt = !string.IsNullOrEmpty(s.Params) ? s.Params : "variable";
+                bool isLocal = string.Equals(s.Scope, "local", StringComparison.OrdinalIgnoreCase);
+                vt += "  (" + (isLocal ? "local" : "global") + ")";
+                if (!string.IsNullOrEmpty(s.ProjectName)) vt += "  (" + s.ProjectName + ")";
+                return vt;
+            }
+
             string t = string.IsNullOrEmpty(s.Type) ? "" : s.Type;
             if (!string.IsNullOrEmpty(s.ReturnType)) t += " : " + s.ReturnType;
             if (!string.IsNullOrEmpty(s.ProjectName)) t += "  (" + s.ProjectName + ")";
@@ -1691,6 +1768,30 @@ namespace ClarionAssistant.Services
         private static readonly Regex CgDataLabelPattern = new Regex(@"^([A-Za-z_][A-Za-z0-9_:]*)\s+(\S.*)$");
         // Trailing Clarion line comment (' ! ...') — stripped from the type shown in the detail column.
         private static readonly Regex CgTrailingComment = new Regex(@"\s+!.*$");
+        // Same trailing comment, but CAPTURING the text after '!' (group 1) — used as the variable's
+        // "description" in completion Detail, since Clarion source has no other description mechanism.
+        private static readonly Regex CgTrailingCommentCapture = new Regex(@"^(.*?)\s+!\s*(.*)$");
+
+        /// <summary>Builds a variable completion's Detail ("TYPE  (scope)" — short, single-line, shown right
+        /// in the suggestion row) and Documentation (the description, if any — shown in Monaco's expandable
+        /// docs panel, which wraps). Split on purpose: Monaco's Detail column doesn't wrap and truncates long
+        /// text, so the trailing '!' comment on a declaration (Clarion's only per-variable description
+        /// mechanism) goes to Documentation instead of being appended to Detail.</summary>
+        private static void BuildVarDetail(string restOfLine, string scopeTag, out string detail, out string documentation)
+        {
+            string typeText = restOfLine ?? "";
+            string description = null;
+            var cm = CgTrailingCommentCapture.Match(typeText);
+            if (cm.Success) { typeText = cm.Groups[1].Value; description = cm.Groups[2].Value.Trim(); }
+            typeText = typeText.Trim();
+            if (description != null && description.Length == 0) description = null;
+
+            var sb = new System.Text.StringBuilder();
+            if (typeText.Length > 0) sb.Append(typeText);
+            if (!string.IsNullOrEmpty(scopeTag)) { if (sb.Length > 0) sb.Append("  "); sb.Append(scopeTag); }
+            detail = sb.Length > 0 ? sb.ToString() : null;
+            documentation = description;
+        }
 
         /// <summary>Phase 2: merge in-scope local variables from the live buffer. Two scopes, most-specific
         /// first: (a) the enclosing ROUTINE's private DATA (visible only inside that routine), then (b) the
@@ -1741,10 +1842,12 @@ namespace ClarionAssistant.Services
                             string label = lm.Groups[1].Value;
                             if (label.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && seen.Add(label))
                             {
-                                string typeText = CgTrailingComment.Replace(lm.Groups[2].Value, "").Trim();
-                                string detail = string.IsNullOrEmpty(typeText) ? "(module)" : typeText + "  (module)";
+                                // Module (file) scope reads as "global" to match the CodeGraph cross-file
+                                // wording below — same TYPE/description/scope shape as CollectDataLabels.
+                                string detail, doc;
+                                BuildVarDetail(lm.Groups[2].Value, "(global)", out detail, out doc);
                                 primary.Add(new LspClient.CompletionItemInfo
-                                { Label = label, Kind = 6 /*Variable*/, Detail = detail, InsertText = label });
+                                { Label = label, Kind = 6 /*Variable*/, Detail = detail, Documentation = doc, InsertText = label });
                             }
                         }
                     }
@@ -1778,12 +1881,13 @@ namespace ClarionAssistant.Services
                         string label = lm.Groups[1].Value;
                         if (label.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) && seen.Add(label))
                         {
-                            // Show the declared type (e.g. "STRING(12)", "LONG", "GROUP") in the detail
-                            // column, stripping any trailing line comment. Fall back to the scope marker.
-                            string typeText = CgTrailingComment.Replace(lm.Groups[2].Value, "").Trim();
-                            string detail = string.IsNullOrEmpty(typeText) ? scopeMarker : typeText + "  " + scopeMarker;
+                            // Detail = "TYPE  (scope)" (short, single-line). Documentation = the trailing '!'
+                            // comment, if any (Clarion has no other per-variable description mechanism) —
+                            // shown in Monaco's expandable docs panel instead of the non-wrapping Detail line.
+                            string detail, doc;
+                            BuildVarDetail(lm.Groups[2].Value, scopeMarker, out detail, out doc);
                             primary.Add(new LspClient.CompletionItemInfo
-                            { Label = label, Kind = 6 /*Variable*/, Detail = detail, InsertText = label });
+                            { Label = label, Kind = 6 /*Variable*/, Detail = detail, Documentation = doc, InsertText = label });
                         }
                     }
                 }
@@ -2068,6 +2172,38 @@ namespace ClarionAssistant.Services
                     });
                 }
             }
+        }
+
+        /// <summary>Dictionary table FIELD/KEY completion: "Cus:partial" → columns + keys of the ingested
+        /// dictionary table whose PRE is "Cus" (SchemaGraphService, .schemagraph.db). Only the ':' form
+        /// applies — dictionary fields/keys are always PRE-qualified, never dot-accessed (dot access is
+        /// class/instance member-access, owned by MergeMemberAccessCompletions). Deliberately does NOT
+        /// dedupe against items MergeQualifiedFieldCompletions already added for a same-named in-buffer
+        /// GROUP/QUEUE — a hand-coded structure and a dictionary table can legitimately share a PRE, and
+        /// per design both should surface (Detail distinguishes "(field)" vs "(field, dictionary)"). Never
+        /// throws.</summary>
+        private static void MergeDictionaryFieldCompletions(
+            List<LspClient.CompletionItemInfo> primary, string filePath, int line, int character, string bufferText)
+        {
+            string lineText = CgLineAt(bufferText, filePath, line);
+            if (lineText == null) return;
+            int col = character < 0 ? 0 : (character > lineText.Length ? lineText.Length : character);
+            string upToCursor = lineText.Substring(0, col);
+            if (upToCursor.IndexOf('!') >= 0) return;   // comment
+
+            var q = CgQualifier.Match(upToCursor);
+            if (!q.Success) return;
+            char sep = q.Groups[2].Value[0];
+            if (sep != ':') return;   // dictionary fields/keys are PRE-qualified, never dot-accessed
+            string qualifier = q.Groups[1].Value;
+            string partial = q.Groups[3].Value;
+
+            string db = ResolveSchemaGraphDb(filePath);
+            if (string.IsNullOrEmpty(db)) return;
+
+            var service = new SchemaGraphService(db);
+            var items = service.GetQualifierCompletions(qualifier, partial);
+            if (items != null) primary.AddRange(items);
         }
 
         // === Class member-access completion (ticket 6e8f2439, item 5b) ===

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -1087,8 +1087,8 @@
             case 5: return M.Field; case 6: return M.Variable; case 7: return M.Class;
             case 8: return M.Interface; case 9: return M.Module; case 10: return M.Property;
             case 12: return M.Value; case 13: return M.Enum; case 14: return M.Keyword;
-            case 15: return M.Snippet; case 21: return M.Constant; case 22: return M.Struct;
-            case 25: return M.TypeParameter; default: return M.Text;
+            case 15: return M.Snippet; case 20: return M.EnumMember; case 21: return M.Constant;
+            case 22: return M.Struct; case 25: return M.TypeParameter; default: return M.Text;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ Ask it to write Clarion code, explain procedures, refactor classes, build COM co
 
 ---
 
+## What's New (Unreleased)
+
+### Dictionary- and CodeGraph-aware completion in the CA Embeditor
+
+The CA Embeditor's completion now reaches into your ingested **SchemaGraph** (dictionary tables/fields/keys) and **CodeGraph** (solution-wide symbols) databases, not just the LSP and the current buffer:
+
+- **Dictionary fields and keys** &mdash; typing a table's `PRE:` prefix (e.g. `Cus:`) now also suggests that table's columns and keys straight from the ingested `.dctx`, with declared type, description, and (for keys) full field composition shown in the completion detail/documentation panel. Shown alongside any same-named in-buffer `GROUP`/`QUEUE` fields, not instead of them.
+- **Dictionary table names** &mdash; bare-prefix completion now also suggests table names from the dictionary (e.g. `Cus` &rarr; `Customers`).
+- **Richer variable detail** &mdash; completion for locals, module-scope variables, and cross-file CodeGraph globals now shows the actual declared type (`STRING(30)`, `DECIMAL(13,2)`, ...), a `!`-comment description when present, and local/global scope &mdash; instead of a generic "variable" label.
+
+Requires a SchemaGraph source to be added and indexed once via the **Schema Sources** panel (Solution Settings &rarr; Schema Sources &rarr; Add Source).
+
+---
+
 ## What's New in v5.3
 
 v5.3 is a refinement release &mdash; it sharpens the Monaco editor, Smart Formatter, and completion that landed in v5.1/v5.2, adds editor personalization and one-click surface toggles, and folds in a round of community fixes.


### PR DESCRIPTION
Closes #98

## Summary
- Wires SchemaGraph into the CA Embeditor's completion pipeline: dictionary **fields and keys** via a table's `PRE:` qualifier, and bare-prefix **table name** completion — both additive, shown alongside (not instead of) same-named in-buffer `GROUP`/`QUEUE` fields.
- Fixes CodeGraph-global variable completion showing the literal word "variable" instead of the declared type (`Params` was never read).
- Normalizes variable scope wording to local/global across all four variable-completion sources, and surfaces a trailing `!` comment as description.
- Dictionary field completion now shows the declared `TYPE(size[,places])`, not the picture (which is a display mask, not a size — e.g. a `DECIMAL(13,2)` with picture `@n$4.2` was showing `@n$4.2` as if it were the size).
- Long completion text (descriptions, key composition) moved from `Detail` (single line, truncates) to `Documentation` (Monaco's expandable, wrapping docs panel).

## Test plan
- [ ] Add + index a Schema Source (dictionary) via Solution Settings → Schema Sources
- [ ] In the CA Embeditor, type `<TablePrefix>:` → dictionary fields and keys appear, with type/description/composition in the docs panel
- [ ] Confirm a same-named local `GROUP,PRE(...)` still shows its own fields alongside the dictionary ones
- [ ] Type a table-name prefix bare (no `:`) → table name suggested
- [ ] Confirm local/module/global variable completion shows declared type + scope, and a `!` comment shows as description in the docs panel