### PR TITLE
Fix/show diff of active editor buffer and toolbar title improvements for long titles

### DIFF
--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -2387,16 +2387,18 @@ COMMON QUERIES:
                 Name = "show_diff",
                 Description = "Open a unified diff viewer in the IDE editor panel. Shows color-coded additions/removals with a changes sidebar and inline code review notes. " +
                     "The developer can add severity-tagged notes (BLOCKER/SUGGESTION/NITPICK/QUESTION) on any line. " +
-                    "You can provide text directly via original_text/modified_text, OR provide file paths via original_file/modified_file to load from disk (avoids encoding issues with large files). " +
+                    "You can provide text directly via original_text/modified_text, OR provide file paths via original_file/modified_file to load from disk (avoids encoding issues with large files), " +
+                    "OR set modified_from_active_editor='true' to diff the IDE's current (possibly unsaved) editor buffer directly, in-process — no MCP text transport, so it works regardless of file size and costs no extra tokens. " +
                     "Use ignore_whitespace to suppress trivial whitespace-only differences. Use get_diff_result to check the outcome.",
                 InputSchema = McpJsonRpc.BuildSchema(
                     new Dictionary<string, string>
                     {
                         { "title", "Title for the diff tab (e.g. procedure name or file name)" },
                         { "original_text", "The original (before) text. Not needed if original_file is provided." },
-                        { "modified_text", "The modified (after) text. Not needed if modified_file is provided." },
+                        { "modified_text", "The modified (after) text. Not needed if modified_file or modified_from_active_editor is provided." },
                         { "original_file", "Path to a file to load as the original (left) side. Overrides original_text." },
                         { "modified_file", "Path to a file to load as the modified (right) side. Overrides modified_text. Preferred for large files." },
+                        { "modified_from_active_editor", "Set to 'true' to use the live content of the file currently open in the IDE editor as the modified (right) side — fetched directly in-process, bypassing MCP text transport entirely (no size limit, no extra tokens). Overrides modified_text/modified_file. If original_file is also omitted, defaults to the active document's own path, so a bare modified_from_active_editor='true' diffs \"what's on screen\" against \"what's on disk\" in one call." },
                         { "original_start_line", "First line to include from original_file (1-based, default: 1)" },
                         { "original_end_line", "Last line to include from original_file (1-based, default: end of file)" },
                         { "modified_start_line", "First line to include from modified_file (1-based, default: 1)" },
@@ -2424,6 +2426,28 @@ COMMON QUERIES:
 
                     string originalFile = McpJsonRpc.GetString(args, "original_file");
                     string modifiedFile = McpJsonRpc.GetString(args, "modified_file");
+
+                    // modified_from_active_editor — fetch the live editor buffer in-process (same source
+                    // get_active_file uses) instead of requiring the caller to round-trip the content
+                    // through MCP text transport. Avoids the token-limit dump-to-file dance entirely for
+                    // large unsaved buffers. Defaults original_file to the active document's own disk path
+                    // when the caller doesn't specify one, so callers can diff "what's on screen right now"
+                    // against disk with just this one flag.
+                    if (McpJsonRpc.GetString(args, "modified_from_active_editor") == "true")
+                    {
+                        string activeContent = _editorService.GetActiveDocumentContent();
+                        if (activeContent == null)
+                            return "Error: No active editor content available.";
+
+                        if (string.IsNullOrEmpty(originalFile))
+                            originalFile = _editorService.GetActiveDocumentPath();
+                        if (string.IsNullOrEmpty(originalFile))
+                            return "Error: Could not determine the active document's file path for comparison.";
+
+                        int activeStart = McpJsonRpc.GetInt(args, "original_start_line", 1);
+                        int activeEnd = McpJsonRpc.GetInt(args, "original_end_line", -1);
+                        return _diffService.ShowDiffFromFile(title, originalFile, activeStart, activeEnd, activeContent, language, ignoreWs, useMonaco);
+                    }
 
                     // Both files provided — load both from disk (best path, avoids MCP text encoding issues)
                     if (!string.IsNullOrEmpty(originalFile) && !string.IsNullOrEmpty(modifiedFile))

--- a/ClarionAssistant/Terminal/monaco-diff.html
+++ b/ClarionAssistant/Terminal/monaco-diff.html
@@ -35,9 +35,8 @@
         padding: 6px 12px; background: var(--toolbar-bg); border-bottom: 1px solid var(--toolbar-border);
         height: 38px; flex-shrink: 0;
     }
-    #toolbar .title { font-size: 13px; color: var(--title-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 320px; }
+    #toolbar .title { font-size: 13px; color: var(--title-color); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1 1 0; min-width: 0; }
     #toolbar .title span { color: var(--title-accent); font-weight: 600; }
-    #toolbar .spacer { flex: 1; }
     #toolbar .sep { color: var(--toolbar-border); user-select: none; }
     #toolbar button {
         padding: 3px 10px; border: 1px solid var(--btn-border); border-radius: 4px;
@@ -98,7 +97,6 @@
 <!-- Toolbar -->
 <div id="toolbar">
     <div class="title">Diff: <span id="diff-title">…</span></div>
-    <div class="spacer"></div>
     <button onclick="goPrev()" title="Previous change (Shift+F7)">&#x25B2; Prev</button>
     <span id="diff-counter">--</span>
     <button onclick="goNext()" title="Next change (F7)">Next &#x25BC;</button>
@@ -387,7 +385,10 @@
     // ===== Apply incoming diff data =====
     // Host sends raw original + modified text via virtual-host files; Monaco computes the diff.
     function applyDiff(msg) {
-        document.getElementById('diff-title').textContent = msg.title || 'Untitled';
+        var titleText = msg.title || 'Untitled';
+        document.getElementById('diff-title').textContent = titleText;
+        // Native tooltip so the full title is still readable when the toolbar ellipsis-truncates it.
+        document.querySelector('#toolbar .title').title = 'Diff: ' + titleText;
         var lang = msg.language || 'clarion';
 
         // Theme from message is authoritative, else fall back to persisted preference.


### PR DESCRIPTION
# show_diff can diff the live editor buffer directly, without a get_active_file round-trip

## Summary

Comparing "what's currently in the editor (possibly unsaved)" against the file on disk previously required: call `get_active_file`, hit its size limit on anything but small files (dumped to a temp file with an error), parse that dump externally, write the extracted text to a scratch file, then call `show_diff` with that scratch file as `modified_file`. Slow (the size-limit path plus external parsing added real latency) and wasteful (the full buffer text had to round-trip through MCP's JSON/text transport at least once).

This isn't a narrow use case. ClarionAssistant's own design already treats "show the diff before committing to disk" as a first-class workflow — its guidance is explicit that an AI assistant driving the IDE should never write to `.clw`/`.inc`/embeds without the developer reviewing the change first. `show_diff` is the mechanism that review step is supposed to go through; this PR just makes the most common shape of that review (assistant or developer edits the live buffer, developer wants to confirm exactly what changed before saving) fast and cheap enough to reach for every time instead of only occasionally. It also matters more in shops without a lightweight `git diff` safety net at commit time (e.g. teams still on VSS/SourceSafe) — an in-IDE, pre-save diff is the closest equivalent available, and the accident it catches is a real one: a stray keystroke landing in the wrong window (AI terminal focus vs. editor focus sitting side by side) that's otherwise invisible until it's already saved.

## Fix

Added a `modified_from_active_editor` boolean to `show_diff`. When set to `'true'`, the handler fetches the buffer directly via `EditorService.GetActiveDocumentContent()` — the exact same in-process call `get_active_file` uses — and passes it straight to the existing `DiffService.ShowDiffFromFile`. No MCP text transport, no size limit, no separate parse step. If `original_file` isn't also given, it defaults to `EditorService.GetActiveDocumentPath()`, so `show_diff(title, modified_from_active_editor='true')` alone diffs the active document's live buffer against its own file on disk.

Also touched `monaco-diff.html`'s toolbar while testing this heavily: the title element had a hardcoded `max-width: 320px` with ellipsis truncation, which cut off descriptive titles unnecessarily early. Changed it to `flex: 1 1 0; min-width: 0` so it uses whatever space is actually available in the toolbar (shrinking properly as the panel narrows, since flex items need `min-width: 0` to shrink below their content size), and added a native `title` attribute (tooltip) so the full text is still reachable on hover when it does truncate.

## Verification

Live-tested in a running Clarion 11.1 IDE:
- `show_diff(title, modified_from_active_editor='true')` with no other file params opened the diff viewer near-instantly, correctly resolving the active `.clw` file's own disk path and comparing it against the unsaved buffer.
- Toolbar title: confirmed it now fills available space (using roughly a third of the bar for a normal-length title, most of it for a much longer one), truncates cleanly right before the "Prev" button with no visual collision, reflows correctly when the editor panel is resized via the split bar, and shows the full title as a tooltip on hover when truncated.

