### PR TITLE
Diff viewer tabs enable Save and crash on invoke — set IsViewOnly

### DIFF
--- a/ClarionAssistant/Terminal/DiffViewContent.cs
+++ b/ClarionAssistant/Terminal/DiffViewContent.cs
@@ -58,6 +58,9 @@ namespace ClarionAssistant.Terminal
             _ignoreWhitespace = ignoreWhitespace;
             _isDark = isDark;
             TitleName = "Diff: " + _title;
+            // No Save()/SaveAs() implementation exists for this view — without this, SharpDevelop
+            // treats it as a normal, saveable, filename-less document (enables Save, then throws when invoked).
+            IsViewOnly = true;
 
             _panel = new Panel { Dock = DockStyle.Fill, BackColor = Color.FromArgb(30, 30, 46) };
             _webView = new ZoomableWebView2 { Dock = DockStyle.Fill };

--- a/ClarionAssistant/Terminal/MonacoDiffViewContent.cs
+++ b/ClarionAssistant/Terminal/MonacoDiffViewContent.cs
@@ -61,6 +61,9 @@ namespace ClarionAssistant.Terminal
             _ignoreWhitespace = ignoreWhitespace;
             _isDark = isDark;
             TitleName = "Diff: " + _title;
+            // No Save()/SaveAs() implementation exists for this view — without this, SharpDevelop
+            // treats it as a normal, saveable, filename-less document (enables Save, then throws when invoked).
+            IsViewOnly = true;
 
             _panel = new Panel { Dock = DockStyle.Fill, BackColor = Color.FromArgb(30, 30, 46) };
             _webView = new ZoomableWebView2 { Dock = DockStyle.Fill };

--- a/ClarionAssistant/Terminal/NativeDiffViewContent.cs
+++ b/ClarionAssistant/Terminal/NativeDiffViewContent.cs
@@ -53,6 +53,9 @@ namespace ClarionAssistant.Terminal
             string language = "clarion", bool ignoreWhitespace = false)
         {
             TitleName = "Diff: " + (title ?? "Untitled");
+            // No Save()/SaveAs() implementation exists for this view — without this, SharpDevelop
+            // treats it as a normal, saveable, filename-less document (enables Save, then throws when invoked).
+            IsViewOnly = true;
             _panel = new Panel { Dock = DockStyle.Fill, BackColor = BgColor };
 
             BuildToolbar(title);


### PR DESCRIPTION
## Summary

`DiffViewContent`, `MonacoDiffViewContent`, and `NativeDiffViewContent` never set `IsViewOnly` (or override any `Save`/`SaveAs`), so `AbstractViewContent`'s defaults (`IsViewOnly=false`, `IsReadOnly=false`, `FileName=null`) leave SharpDevelop treating an open diff tab as an ordinary, saveable, filename-less document. The Save toolbar icon becomes enabled for a diff tab, and invoking it throws an exception, since none of these views implement anything a generic save path can actually use.

## Root cause

Confirmed via live reflection (`inspect_ide active_view` in a running session) that an open `DiffViewContent` reports:
```
IsDirty {get;set} = False
IsReadOnly {get} = False
IsUntitled {get} = False
IsViewOnly {get;set} = True   <- after this fix; was False before
```
None of the three diff view classes override any of these, and their only content-related methods are `ApplyTheme`, `Dispose`, `SetDiff` — no `Save`, `SaveAs`, or `Load`. With `IsViewOnly=false`, SharpDevelop's generic Save command is enabled for the tab; since there's no real file backing (`FileName=null`) or save implementation, invoking Save throws.

## Fix

Set `IsViewOnly = true` in each of the three constructors — this disables the Save command for these tabs. (`IsReadOnly` was also tried but is get-only on the base `AbstractViewContent`, not settable — `IsViewOnly` alone is the correct, and sufficient, mechanism.)

## Verification

Live-tested in the running Clarion 11.1 IDE: before the fix, opening a diff via `show_diff` enabled the Save icon and attempting to save threw an exception. After the fix (redeployed), `inspect_ide active_view` confirms `IsViewOnly=True` on the open diff tab, and the developer confirmed visually that the Save icon is no longer enabled.
