### PR TITLE
fix(lsp): re-root the bundled server when the solution changes (#106)

### DIFF
--- a/ClarionAssistant/LspAutostartCommand.cs
+++ b/ClarionAssistant/LspAutostartCommand.cs
@@ -39,8 +39,9 @@ namespace ClarionAssistant
 
         public event EventHandler OwnerChanged;
 
-        // Rooted so neither the SolutionLoaded delegate nor the fallback timer is GC'd.
+        // Rooted so neither the SolutionLoaded/SolutionClosed delegates nor the fallback timer are GC'd.
         private static Delegate _solutionLoadedHandler;
+        private static Delegate _solutionClosedHandler;
         private static System.Windows.Forms.Timer _fallbackTimer;
 
         public void Run()
@@ -65,6 +66,12 @@ namespace ClarionAssistant
                 SubscribeSolutionLoaded();
             }
             catch (Exception ex) { Debug.WriteLine("[LspAutostart] SolutionLoaded subscribe failed: " + ex.Message); }
+
+            try
+            {
+                SubscribeSolutionClosed();
+            }
+            catch (Exception ex) { Debug.WriteLine("[LspAutostart] SolutionClosed subscribe failed: " + ex.Message); }
 
             try
             {
@@ -106,6 +113,52 @@ namespace ClarionAssistant
         {
             try { LspService.EnsureRunningInBackground(); }
             catch (Exception ex) { Debug.WriteLine("[LspAutostart] OnSolutionLoaded failed: " + ex.Message); }
+        }
+
+        /// <summary>
+        /// Subscribes to ProjectService.SolutionClosed (a static EventHandler) so we STOP the bundled
+        /// server when the current solution closes. Without this the one LspClient.Active process
+        /// survives a solution switch still rooted at the FIRST solution — EnsureRunning is idempotent and
+        /// "starts ONCE" with no live post-start path update, so the next SolutionLoaded can't re-root it.
+        /// Stopping here lets the SolutionLoaded -> EnsureRunning path start a fresh server for the new
+        /// solution (a new process re-initializes cleanly with the new rootUri). (#106)
+        /// </summary>
+        private void SubscribeSolutionClosed()
+        {
+            var sharpDevelopAsm = Assembly.Load("ICSharpCode.SharpDevelop");
+            if (sharpDevelopAsm == null) return;
+
+            var projectServiceType = sharpDevelopAsm.GetType("ICSharpCode.SharpDevelop.Project.ProjectService");
+            if (projectServiceType == null) return;
+
+            var evt = projectServiceType.GetEvent("SolutionClosed",
+                BindingFlags.Public | BindingFlags.Static);
+            if (evt == null) return;
+
+            MethodInfo handlerMethod = typeof(LspAutostartCommand).GetMethod(
+                "OnSolutionClosed", BindingFlags.NonPublic | BindingFlags.Static);
+            if (handlerMethod == null) return;
+
+            _solutionClosedHandler = Delegate.CreateDelegate(evt.EventHandlerType, handlerMethod);
+            evt.AddEventHandler(null, _solutionClosedHandler);
+        }
+
+        // ProjectService.SolutionClosed is a plain EventHandler(object, EventArgs). Stop the bundled
+        // server (only if it's ours and running) so it re-roots on the next solution. Never touch the
+        // shared ClarionLsp addin — it owns its own lifecycle.
+        private static void OnSolutionClosed(object sender, EventArgs e)
+        {
+            try
+            {
+                if (SharedLspBridge.IsSharedActive) return;
+                var c = LspClient.Active;
+                if (c != null && c.IsRunning)
+                {
+                    Debug.WriteLine("[LspAutostart] Solution closed — stopping the bundled LSP so the next solution re-roots it.");
+                    c.Stop();
+                }
+            }
+            catch (Exception ex) { Debug.WriteLine("[LspAutostart] OnSolutionClosed failed: " + ex.Message); }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes #106 — the bundled Clarion LSP now re-roots when the solution changes.

Previously the server `initialize`d once with the **first** solution's `rootUri` and never re-rooted: `LspService.EnsureRunning[InBackground]` is idempotent and "starts ONCE — no live post-start path update" (`LspService.cs:33-35`, `:52-58`, `:179`), and `LspAutostartCommand` only hooked `ProjectService.SolutionLoaded` (start), never a close. So switching solutions in a single IDE session left the one `LspClient.Active` process pointing at the old workspace — hover / go-to-definition / diagnostics (anything depending on the workspace root / redirection resolution) kept resolving against the *previous* solution until an IDE or server restart.

## The fix

One file, `LspAutostartCommand.cs`:

- Subscribe to `ProjectService.SolutionClosed` (a static `EventHandler`) using the same reflection pattern the command already uses for `SolutionLoaded`.
- On close, `LspClient.Active?.Stop()` — **only when it's our bundled server and running**, and gated on `!SharedLspBridge.IsSharedActive` so the shared ClarionLsp addin (which owns its own lifecycle) is never touched.
- The existing `SolutionLoaded -> EnsureRunningInBackground` path then starts a fresh server `initialize`d at the new solution's `rootUri`.

## Why addin-side only

A brand-new server process re-initializes cleanly with the new root, so **nothing is required on the language-server side** — this is purely a lifecycle gap in the addin. Applies to the bundled default (#40); the shared-addin path is unaffected.

## Testing (manual, Clarion 11.1 IDE)

- Open solution A, exercise a root-dependent LSP feature (hover / go-to-definition), then close/switch to solution B and confirm the LSP now resolves against B rather than A.
- Confirm closing a solution with no replacement stops the server, and opening one afterwards starts it fresh.
- Shared ClarionLsp addin installed (`Lsp.ForceLocal=false`): confirm the bundled server is never touched on close.

Closes #106
