### PR TITLE
feat(embeditor): document structure outline fly-out (Phase 1)

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -92,6 +92,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MonacoClarionSourceEditor.cs" />
+    <Compile Include="Services\DocumentOutlineBuilder.cs" />
     <Compile Include="AgentPanelPad.cs" />
     <Compile Include="AgentPanelControl.cs" />
     <Compile Include="ShowAgentPanelCommand.cs" />

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -589,6 +589,28 @@ namespace ClarionAssistant
             });
         }
 
+        // {action:"documentStructure"} — outline tree for the whole source file (this overlay always edits a
+        // real file 1:1, so LSP line 0-based -> Monaco 1-based is simple +1). Feeds the structure fly-out.
+        void IMonacoEditorHost.OnDocumentStructure(MonacoEditorControl editor, string rawJson)
+        {
+            int reqId, line, col; string buffer;
+            if (!ParseLspRequest(rawJson, out reqId, out line, out col, out buffer)) return;
+            System.Threading.Tasks.Task.Run(() =>
+            {
+                var symbols = new List<Dictionary<string, object>>();
+                try
+                {
+                    EnsureLsp();
+                    var resp = SharedLspBridge.GetDocumentSymbols(_filePath, buffer);
+                    object res = (resp != null && resp.ContainsKey("result")) ? resp["result"] : null;
+                    symbols = DocumentOutlineBuilder.Build(res, lsp0 => lsp0 + 1);
+                }
+                catch (Exception ex) { MonacoSpikeLog.Write("overlay documentStructure error: " + ex.Message); }
+                try { editor.PostResponse(reqId, new Dictionary<string, object> { { "symbols", symbols }, { "fileMode", true } }); }
+                catch { }
+            });
+        }
+
         /// <summary>Capture the active Clarion IDE theme's toolbar gradient (SerenityBlue/OfficeXP/Win10Blue/…)
         /// into _chromeBg1/_chromeBg2/_chromeFg so our overlay toolbar chrome follows it — the same colors the
         /// embeditor reads off its native ToolStrip, but sourced from the global ToolStripManager.Renderer (the IDE

--- a/ClarionAssistant/Services/DocumentOutlineBuilder.cs
+++ b/ClarionAssistant/Services/DocumentOutlineBuilder.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Turns an LSP textDocument/documentSymbol result (hierarchical DocumentSymbol[] OR flat
+    /// SymbolInformation[]) into the JSON-ready outline tree the Monaco page renders:
+    /// each node = { name, kind, detail, line, children:[...] }.
+    ///
+    /// `line` is a 1-based Monaco line produced by the caller's lsp0-&gt;monaco1 mapper — identity+1 for
+    /// whole-file editors, embed-aware in the slot embeditor (which prepends a MEMBER header). Hierarchy
+    /// is preserved from DocumentSymbol.children; SymbolInformation (no children) yields a flat list.
+    /// (Prototype for the document-structure fly-out — Phase 1, pull-based.)
+    /// </summary>
+    public static class DocumentOutlineBuilder
+    {
+        public static List<Dictionary<string, object>> Build(object symbolsResult, Func<int, int> lspLine0ToMonaco1)
+        {
+            var into = new List<Dictionary<string, object>>();
+            Walk(symbolsResult, into, lspLine0ToMonaco1);
+            return into;
+        }
+
+        private static void Walk(object node, List<Dictionary<string, object>> into, Func<int, int> map)
+        {
+            var list = node as IEnumerable;
+            if (list == null) return;
+            foreach (var item in list)
+            {
+                var d = item as Dictionary<string, object>;
+                if (d == null) continue;
+
+                string name = d.ContainsKey("name") ? d["name"] as string : null;
+                if (string.IsNullOrEmpty(name))
+                {
+                    if (d.ContainsKey("children")) Walk(d["children"], into, map);   // skip an unnamed group, keep its kids
+                    continue;
+                }
+
+                int kind = 0;
+                if (d.ContainsKey("kind")) { try { kind = Convert.ToInt32(d["kind"]); } catch { } }
+                string detail = d.ContainsKey("detail") ? d["detail"] as string : null;
+
+                var entry = new Dictionary<string, object>
+                {
+                    { "name", name }, { "kind", kind }, { "detail", detail }, { "line", ExtractLine1(d, map) }
+                };
+
+                if (d.ContainsKey("children"))
+                {
+                    var kids = new List<Dictionary<string, object>>();
+                    Walk(d["children"], kids, map);
+                    if (kids.Count > 0) entry["children"] = kids;
+                }
+                into.Add(entry);
+            }
+        }
+
+        // DocumentSymbol carries range.start.line; SymbolInformation carries location.range.start.line.
+        // Both are 0-based LSP lines; map to a 1-based Monaco line (fall back to 1 on any shape surprise).
+        private static int ExtractLine1(Dictionary<string, object> d, Func<int, int> map)
+        {
+            try
+            {
+                var range = d.ContainsKey("range") ? d["range"] as Dictionary<string, object> : null;
+                if (range == null && d.ContainsKey("location"))
+                {
+                    var loc = d["location"] as Dictionary<string, object>;
+                    if (loc != null && loc.ContainsKey("range")) range = loc["range"] as Dictionary<string, object>;
+                }
+                if (range != null && range.ContainsKey("start"))
+                {
+                    var start = range["start"] as Dictionary<string, object>;
+                    if (start != null && start.ContainsKey("line"))
+                    {
+                        int lsp0 = Convert.ToInt32(start["line"]);
+                        return map != null ? map(lsp0) : lsp0 + 1;
+                    }
+                }
+            }
+            catch { }
+            return 1;
+        }
+    }
+}

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -897,6 +897,24 @@ namespace ClarionAssistant.Services
                     if (rng != null) loc["range"] = rng;
                     sym["location"] = loc;
                 }
+                // Detail + Children come from a NEWER ClarionLsp.Contracts SymbolResult (hierarchical outline).
+                // Read via REFLECTION so CA still compiles/loads against the older vendored contract — the
+                // outline stays flat when these are absent and becomes a tree once the newer addin + contract
+                // are deployed (first-load-wins binds whichever ClarionLsp.Contracts.dll is present).
+                var t = s.GetType();
+                var detailProp = t.GetProperty("Detail");
+                if (detailProp != null) { var dv = detailProp.GetValue(s) as string; if (!string.IsNullOrEmpty(dv)) sym["detail"] = dv; }
+                var childrenProp = t.GetProperty("Children");
+                if (childrenProp != null)
+                {
+                    var kidsEnum = childrenProp.GetValue(s) as System.Collections.IEnumerable;
+                    if (kidsEnum != null)
+                    {
+                        var kids = new List<LspModels.SymbolResult>();
+                        foreach (var k in kidsEnum) { var ks = k as LspModels.SymbolResult; if (ks != null) kids.Add(ks); }
+                        if (kids.Count > 0) sym["children"] = SymbolsToList(kids.ToArray());
+                    }
+                }
                 list.Add(sym);
             }
             return list;

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -218,6 +218,27 @@ namespace ClarionAssistant.Terminal
             return result;
         }
 
+        // {action:"documentStructure"} — outline tree for the current buffer, for the structure fly-out.
+        // In file mode this is the whole module (reliable). In embed/slot mode the buffer is a procedure
+        // slice with a MEMBER header, so the outline is partial — the page decides what to show via fileMode.
+        private void HandleDocumentStructure(string json)
+        {
+            int reqId, line, column; string buffer;
+            if (!ParseRequest(json, out reqId, out line, out column, out buffer)) return;
+            System.Threading.Tasks.Task.Run(() =>
+            {
+                var symbols = new List<Dictionary<string, object>>();
+                try
+                {
+                    var resp = SharedLspBridge.GetDocumentSymbols(_lspFileName, LspBuffer(buffer));
+                    object res = (resp != null && resp.ContainsKey("result")) ? resp["result"] : null;
+                    symbols = DocumentOutlineBuilder.Build(res, MonacoLine1);
+                }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] HandleDocumentStructure: " + ex.Message); }
+                PostResponse(reqId, new Dictionary<string, object> { { "symbols", symbols }, { "fileMode", _fileMode } });
+            });
+        }
+
         // LSP documentSymbol returns either DocumentSymbol[] (hierarchical, has children) or
         // SymbolInformation[] (flat). Collect leaf names + kinds from either shape.
         private static void CollectSymbols(object node, List<Dictionary<string, object>> into)
@@ -1134,6 +1155,7 @@ namespace ClarionAssistant.Terminal
         void IMonacoEditorHost.OnDiagnostics(MonacoEditorControl editor, string rawJson) { HandleDiagnostics(rawJson); }
         void IMonacoEditorHost.OnSignatureHelp(MonacoEditorControl editor, string rawJson) { HandleSignatureHelp(rawJson); }
         void IMonacoEditorHost.OnImplementation(MonacoEditorControl editor, string rawJson) { HandleImplementation(rawJson); }
+        void IMonacoEditorHost.OnDocumentStructure(MonacoEditorControl editor, string rawJson) { HandleDocumentStructure(rawJson); }
         void IMonacoEditorHost.OnSaveSettings(MonacoEditorControl editor, string rawJson) { HandleSaveSettings(rawJson); }
         void IMonacoEditorHost.OnSaveHistory(MonacoEditorControl editor, string rawJson) { HandleSaveHistory(rawJson); }
         void IMonacoEditorHost.OnSnippetCommand(MonacoEditorControl editor, string rawJson)

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -373,6 +373,35 @@ namespace ClarionAssistant.Terminal
             catch { }
         }
 
+        // ── Keep editor accelerators inside Monaco (issue #66 / native-find leak) ────────────────
+        // OVERLAY REALITY: this Monaco WebView2 is docked FILL on top of Clarion's still-open native
+        // embeditor (ClaGenEditor) — its chrome is only hidden (ModernEmbeditorViewContent.HideNativeChrome),
+        // the native text editor is alive underneath as the write-back target. With
+        // AreBrowserAcceleratorKeysEnabled=false the WebView still delivers Ctrl+F to the DOM (our page
+        // opens Monaco's own find), but it ALSO forwards the accelerator up to the host. SharpDevelop's
+        // form-level ProcessCmdKey (DefaultWorkbench) then runs its Find menu-shortcut against the ACTIVE
+        // view content — the hidden native editor — so its search bottom-bar leaks up on top of Monaco's.
+        // This control sits BELOW the workbench form in the parent chain, so returning true here consumes
+        // the forwarded key before the form can dispatch. The DOM keydown already reached the page, so we
+        // only swallow the host-side leak; we don't re-trigger the find here.
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (_webView != null && _webView.ContainsFocus)
+            {
+                switch (keyData)
+                {
+                    case Keys.Control | Keys.F:                 // Find
+                    case Keys.Control | Keys.Shift | Keys.F:    // Find All (Ctrl+Shift+F) — else it leaks to Find-in-Files
+                    case Keys.Control | Keys.H:                 // Replace
+                    case Keys.Control | Keys.Shift | Keys.H:    // Find All + Replace (Ctrl+Shift+H) — else leaks to Replace-in-Files
+                    case Keys.F3:                               // Find next
+                    case Keys.Shift | Keys.F3:                  // Find previous
+                        return true;               // handled — don't let the workbench run its native Find
+                }
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
         /// <summary>Reply to an LSP/request message: {type:"response", reqId, data}.</summary>
         public void PostResponse(int reqId, IDictionary<string, object> data)
         {

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -76,6 +76,10 @@ namespace ClarionAssistant.Terminal
         /// host navigates (same- or cross-file) then replies via PostResponse with {navigated:bool}.</summary>
         void OnImplementation(MonacoEditorControl editor, string rawJson);
 
+        /// <summary>{action:"documentStructure"} — outline/document-symbol tree for the current buffer;
+        /// host replies via PostResponse with {symbols:[{name,kind,detail,line,children}], fileMode}.</summary>
+        void OnDocumentStructure(MonacoEditorControl editor, string rawJson);
+
         /// <summary>{action:"saveSettings"} — persist gear-panel settings + broadcast to all tabs.</summary>
         void OnSaveSettings(MonacoEditorControl editor, string rawJson);
 
@@ -256,6 +260,7 @@ namespace ClarionAssistant.Terminal
                     case "diagnostics":       h.OnDiagnostics(this, json); break;
                     case "signatureHelp":     h.OnSignatureHelp(this, json); break;
                     case "implementation":    h.OnImplementation(this, json); break;
+                    case "documentStructure": h.OnDocumentStructure(this, json); break;
                     case "saveSettings":      h.OnSaveSettings(this, json); break;
                     case "saveHistory":       h.OnSaveHistory(this, json); break;
                     case "snippetCommand":    h.OnSnippetCommand(this, json); break;

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -338,6 +338,27 @@
     #findCount { font-size: 11px; color: var(--title-color); padding: 1px 4px 0; }
     #findCount:empty { display: none; }
     /* FIND-ALL mode: re-dock as a left column, full editor height, results grid visible; reserves width. */
+    /* ===== Document structure fly-out (left column, same left-inset mechanism as Find-All) ===== */
+    #outlinePanel {
+        position: absolute; left: 0; right: auto; bottom: var(--status-bar-h); z-index: 16;
+        width: 260px; max-width: 60%; display: flex; flex-direction: column; overflow: hidden; box-sizing: border-box;
+        background: var(--toolbar-bg); border-right: 2px solid var(--find-accent);
+        box-shadow: 3px 0 14px rgba(0,0,0,0.22); font-size: var(--find-fz); color: var(--fg);
+    }
+    #outlinePanel.hidden { display: none; }
+    #outlinePanel * { box-sizing: border-box; }
+    #outlineHeader { display: flex; align-items: center; gap: 8px; padding: 7px 10px; flex-shrink: 0;
+        border-bottom: 1px solid var(--toolbar-border); }
+    #outlineHeader .ol-title { font-weight: 600; color: var(--title-accent); letter-spacing: .02em; }
+    #outlineHeader .ol-count { font-size: 11px; color: var(--title-color); }
+    #outlineList { flex: 1; overflow: auto; padding: 4px 0; }
+    .ol-row { display: flex; align-items: center; gap: 6px; padding: 2px 8px; cursor: pointer; white-space: nowrap; }
+    .ol-row:hover { background: rgba(127,127,127,0.14); }
+    .ol-row .ol-kind { width: 15px; flex-shrink: 0; text-align: center; color: var(--find-accent); font-size: 11px; }
+    .ol-row .ol-name { overflow: hidden; text-overflow: ellipsis; }
+    .ol-row .ol-detail { color: var(--title-color); opacity: .65; overflow: hidden; text-overflow: ellipsis; }
+    .ol-empty { padding: 16px 12px; text-align: center; color: var(--title-color); }
+
     #findPanel.findall {
         left: 0; right: auto; bottom: var(--status-bar-h); z-index: 15;
         width: 340px; max-width: 60%;
@@ -519,6 +540,7 @@
         <button id="navFwdBtn" class="embed-nav" title="Navigate Forward (Alt+Right)"><svg class="fico-sm" viewBox="0 0 20 20" fill="none" stroke="#475569" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 10 H15"/><path d="M10.5 5 L15.5 10 L10.5 15"/></svg></button>
         <span class="tb-sep"></span>
         <button id="findBtn" title="Find &amp; Replace"><svg class="fico-sm" viewBox="0 0 20 20" fill="none" stroke="#2563eb" stroke-width="2.2" stroke-linecap="round"><circle cx="8.5" cy="8.5" r="5"/><path d="M12.6 12.6 L17 17"/></svg></button>
+        <button id="outlineBtn" title="Document structure (outline)"><svg class="fico-sm" viewBox="0 0 20 20" fill="none" stroke="#2563eb" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M7 5 H16 M7 10 H16 M7 15 H16"/><circle cx="3.6" cy="5" r="1.1" fill="#2563eb" stroke="none"/><circle cx="3.6" cy="10" r="1.1" fill="#2563eb" stroke="none"/><circle cx="3.6" cy="15" r="1.1" fill="#2563eb" stroke="none"/></svg></button>
         <button id="splitBtn" title="Split editor — two panes of the same file (compare/copy between areas)"><svg class="fico-sm" viewBox="0 0 20 20"><rect x="3" y="4" width="14" height="12" rx="1.6" fill="none" stroke="#475569" stroke-width="2"/><rect x="10" y="4" width="7" height="12" fill="#475569" opacity="0.22"/><path d="M10 4 V16" stroke="#475569" stroke-width="2"/></svg></button>
         <button id="settingsBtn" title="Editor settings"><svg class="fico-sm" viewBox="0 0 24 24" fill="#475569"><path d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7 7 0 0 0-1.62-.94l-.36-2.54A.5.5 0 0 0 13.9 2h-3.8a.5.5 0 0 0-.5.42l-.36 2.54a7 7 0 0 0-1.62.94l-2.39-.96a.5.5 0 0 0-.6.22L2.31 8.48a.5.5 0 0 0 .12.64l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.12.64l1.92 3.32a.5.5 0 0 0 .6.22l2.39-.96a7 7 0 0 0 1.62.94l.36 2.54a.5.5 0 0 0 .5.42h3.8a.5.5 0 0 0 .5-.42l.36-2.54a7 7 0 0 0 1.62-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64z" /><circle cx="12" cy="12" r="3.1" fill="#fff"/></svg></button>
         <button id="themeBtn" class="theme-toggle" title="Toggle light / dark"><svg class="tgl" width="34" height="16" viewBox="0 0 34 16"><rect x="0.5" y="0.5" width="33" height="15" rx="7.5" fill="#9aa5b5" stroke="rgba(0,0,0,0.3)"/><circle class="tgl-knob" cx="25" cy="8" r="6"/></svg></button>
@@ -645,6 +667,16 @@
     <div id="editor"></div>
     <div id="editor2"></div>
     <div id="statusBar"></div>
+    <!-- Document structure fly-out (left column, Phase-1 outline prototype). -->
+    <div id="outlinePanel" class="hidden">
+        <div id="outlineHeader">
+            <span class="ol-title">Structure</span>
+            <span class="ol-count" id="outlineCount"></span>
+            <span class="find-spacer"></span>
+            <button class="find-icon" id="outlineClose" title="Close">&#10005;</button>
+        </div>
+        <div id="outlineList"><div class="ol-empty">No structure.</div></div>
+    </div>
     <div id="findPanel" class="hidden">
         <div id="findGrip" title="Drag to resize"></div>
         <div id="findTabs"></div>
@@ -966,6 +998,11 @@
                 var _redoBtn = document.getElementById('redoBtn');
                 if (_redoBtn) _redoBtn.addEventListener('click', function () { var e = activeEd(); e.focus(); e.trigger('toolbar', 'redo', null); updateUndoRedo(); });
                 editor.onDidChangeModelContent(updateUndoRedo);   // keep Undo/Redo enabled-state in sync with the edit stack
+                // Refresh the structure outline (debounced) while it's open — Phase-1 pull-on-change.
+                editor.onDidChangeModelContent(function () {
+                    var op = document.getElementById('outlinePanel');
+                    if (op && !op.classList.contains('hidden')) { clearTimeout(_outlineDebounce); _outlineDebounce = setTimeout(refreshOutline, 600); }
+                });
                 updateUndoRedo();
                 var _embHeader = document.getElementById('embHeader');
                 if (_embHeader) _embHeader.addEventListener('click', function () { postToHost({ action: 'openSource' }); });
@@ -4024,12 +4061,104 @@
         setEditorInsets();
     }
     function setEditorInsets() {
-        var panel = document.getElementById('findPanel');
-        var findAll = panel && !panel.classList.contains('hidden') && panel.classList.contains('findall');
-        var left = findAll ? (panel.offsetWidth + 'px') : '0px';
+        var fp = document.getElementById('findPanel');
+        var op = document.getElementById('outlinePanel');
+        var findAll = fp && !fp.classList.contains('hidden') && fp.classList.contains('findall');
+        var outline = op && !op.classList.contains('hidden');
+        // Both are left columns; the outline takes precedence if somehow both are open.
+        var left = outline ? (op.offsetWidth + 'px') : (findAll ? (fp.offsetWidth + 'px') : '0px');
         var ed = document.getElementById('editor'); if (ed) ed.style.left = left;
         var e2 = document.getElementById('editor2'); if (e2) e2.style.left = left;
     }
+    // ---- Document structure fly-out (Phase-1 outline prototype) ----
+    var outlineSeq = 0;
+    var _outlineDebounce = null;
+    function positionOutline() {
+        var op = document.getElementById('outlinePanel'), ed = document.getElementById('editor');
+        if (!op || !ed) return;
+        op.style.top = ed.offsetTop + 'px';   // sit under the toolbar, aligned to the editor
+        setEditorInsets();
+    }
+    function openOutline() {
+        var fp = document.getElementById('findPanel');
+        if (fp && !fp.classList.contains('hidden') && fp.classList.contains('findall')) closeFindPanel();  // never two left columns
+        var op = document.getElementById('outlinePanel');
+        if (!op) return;
+        op.classList.remove('hidden');
+        positionOutline();
+        refreshOutline();
+    }
+    function closeOutline() {
+        var op = document.getElementById('outlinePanel');
+        if (op) op.classList.add('hidden');
+        setEditorInsets();
+        if (editor) editor.focus();
+    }
+    function toggleOutline() {
+        var op = document.getElementById('outlinePanel');
+        if (!op) return;
+        if (op.classList.contains('hidden')) openOutline(); else closeOutline();
+    }
+    function refreshOutline() {
+        var op = document.getElementById('outlinePanel');
+        if (!op || op.classList.contains('hidden') || !editor) return;
+        var mySeq = ++outlineSeq;
+        requestFromHost('documentStructure', { buffer: editor.getModel().getValue() })
+            .then(function (data) {
+                if (mySeq !== outlineSeq) return;   // a newer refresh superseded this one
+                renderOutline((data && data.symbols) ? data.symbols : []);
+            })
+            .catch(function () {});
+    }
+    // LSP SymbolKind (1-based) -> a compact glyph for the row.
+    function outlineGlyph(kind) {
+        switch (kind) {
+            case 2:  return 'M';    // Module (root)
+            case 5:  return 'C';    // Class
+            case 6:  return 'm';    // Method (ROUTINE / class method)
+            case 8:  return '·';    // Field
+            case 10: return 'e';    // Enum (MENU)
+            case 11: return '▢'; // Interface (WINDOW/APPLICATION)
+            case 12: return 'ƒ'; // Function (PROCEDURE)
+            case 13: return 'v';    // Variable
+            case 18: return '[]';   // Array (QUEUE/VIEW/LIST)
+            case 23: return '{}';   // Struct (GROUP/RECORD/FILE)
+            default: return '•';
+        }
+    }
+    function renderOutline(symbols) {
+        var list = document.getElementById('outlineList');
+        var countEl = document.getElementById('outlineCount');
+        if (!list) return;
+        list.innerHTML = '';
+        var n = 0;
+        function add(nodes, depth) {
+            for (var i = 0; i < nodes.length; i++) {
+                var s = nodes[i]; n++;
+                var row = document.createElement('div');
+                row.className = 'ol-row';
+                row.style.paddingLeft = (8 + depth * 14) + 'px';
+                var k = document.createElement('span'); k.className = 'ol-kind'; k.textContent = outlineGlyph(s.kind);
+                var nm = document.createElement('span'); nm.className = 'ol-name'; nm.textContent = s.name || '';
+                row.appendChild(k); row.appendChild(nm);
+                if (s.detail) { var dt = document.createElement('span'); dt.className = 'ol-detail'; dt.textContent = ' ' + s.detail; row.appendChild(dt); }
+                (function (ln) {
+                    row.addEventListener('click', function () {
+                        if (!ln || !editor) return;
+                        editor.revealLineInCenter(ln);
+                        editor.setPosition({ lineNumber: ln, column: 1 });
+                        editor.focus();
+                    });
+                })(s.line);
+                list.appendChild(row);
+                if (s.children && s.children.length) add(s.children, depth + 1);
+            }
+        }
+        if (!symbols || !symbols.length) { list.innerHTML = '<div class="ol-empty">No structure.</div>'; }
+        else add(symbols, 0);
+        if (countEl) countEl.textContent = n ? (n + (n === 1 ? ' symbol' : ' symbols')) : '';
+    }
+
     // Header result count for the Find-All column (short form; the in-row count is hidden there).
     function setFaCount() {
         var el = document.getElementById('faCount');
@@ -4078,6 +4207,8 @@
     // Find-All: reveal the left results column, reusing the existing grid/tabs machinery. focusReplace
     // (Ctrl+Shift+H) opens it with the replace row expanded + focused.
     function openFindAll(focusReplace) {
+        var op = document.getElementById('outlinePanel');
+        if (op && !op.classList.contains('hidden')) closeOutline();   // never two left columns
         var panel = document.getElementById('findPanel');
         var wasFindAll = !panel.classList.contains('hidden') && panel.classList.contains('findall');
         if (panel.classList.contains('hidden')) openFindPanel(false);
@@ -4659,6 +4790,12 @@
     function wireFindPanel() {
         // Toolbar buttons: Find & Replace + theme toggle + embed-slot navigation.
         document.getElementById('findBtn').addEventListener('click', function () { openFindPanel(false); });
+        document.getElementById('outlineBtn').addEventListener('click', toggleOutline);
+        document.getElementById('outlineClose').addEventListener('click', closeOutline);
+        window.addEventListener('resize', function () {
+            var op = document.getElementById('outlinePanel');
+            if (op && !op.classList.contains('hidden')) positionOutline();
+        });
         document.getElementById('themeBtn').addEventListener('click', toggleTheme);
         document.getElementById('prevEmbedBtn').addEventListener('click', function () { navEmbed(-1, false); });
         document.getElementById('nextEmbedBtn').addEventListener('click', function () { navEmbed(1, false); });

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -304,30 +304,116 @@
     :root { --find-accent: #89b4fa; --find-hit: rgba(137,180,250,0.35); --find-hit-border: #89b4fa; --on-fg: #1e1e2e; --find-fz: 12px; }
     body.light { --find-accent: #1e66f5; --find-hit: rgba(30,102,245,0.22); --find-hit-border: #1e66f5; --on-fg: #eff1f5; }
 
+    /* QUICK-FIND mode (default when open): compact overlay pinned to the editor's top-right corner,
+       reserves NO editor space — it floats over the code (VS Code-style). `top` is set in JS
+       (positionFindPanel) to sit just under the toolbar; the rest is CSS. */
     #findPanel {
-        position: absolute; left: 0; right: 0; bottom: var(--status-bar-h); z-index: 15;
-        height: 300px; display: flex; flex-direction: column;
-        background: var(--toolbar-bg); border-top: 2px solid var(--find-accent);
+        position: absolute; right: 20px; left: auto; bottom: auto; z-index: 50;
+        width: auto; max-width: 94%; display: flex; flex-direction: column;
+        background: var(--toolbar-bg); border: 1px solid var(--find-accent); border-radius: 7px;
+        box-shadow: 0 4px 16px rgba(0,0,0,0.32);
         font-size: var(--find-fz); color: var(--fg);
     }
     #findPanel.hidden { display: none; }
-    #findGrip { height: 5px; cursor: ns-resize; background: var(--toolbar-border); flex-shrink: 0; }
+    /* Quick mode hides the results-grid machinery, the row labels and the standalone Find button. */
+    #findPanel:not(.findall) #findGrip,
+    #findPanel:not(.findall) #findTabs,
+    #findPanel:not(.findall) #findGrid,
+    #findPanel:not(.findall) .find-restools,
+    #findPanel:not(.findall) .find-row > label,
+    #findPanel:not(.findall) #findGo,
+    #findPanel:not(.findall) #findHistClear,
+    #findPanel:not(.findall) #replSel,
+    #findPanel:not(.findall) .find-spacer { display: none; }
+    /* Deterministic compact layout: fixed-width input, every control content-sized, panel auto-fits its
+       contents. Nothing grows or shrinks, so the nav buttons can never be pushed out or clipped. */
+    #findPanel:not(.findall) { width: auto; }
+    #findPanel:not(.findall) .find-rows { padding: 6px 8px; gap: 5px; flex: 0 0 auto; }
+    #findPanel:not(.findall) .find-row > * { flex-shrink: 0; }
+    #findPanel:not(.findall) .combo { flex: 0 0 auto; max-width: none; }
+    #findPanel:not(.findall) .combo input { flex: 0 0 150px; width: 150px; }
+    /* Quick overlay: the match count drops onto its own line UNDER the search box, keeping the row compact. */
+    /* Count is a sibling BLOCK under the control row (not a wrapped flex item), so the control row stays
+       single-line and never wraps the nav buttons. Hidden until a search produces text. */
+    #findCount { font-size: 11px; color: var(--title-color); padding: 1px 4px 0; }
+    #findCount:empty { display: none; }
+    /* FIND-ALL mode: re-dock as a left column, full editor height, results grid visible; reserves width. */
+    #findPanel.findall {
+        left: 0; right: auto; bottom: var(--status-bar-h); z-index: 15;
+        width: 340px; max-width: 60%;
+        border: none; border-right: 2px solid var(--find-accent); border-radius: 0;
+        box-shadow: 3px 0 14px rgba(0,0,0,0.22);
+    }
+    /* ===== Find-All column: vertical VS Code Search-view layout; content can't spill past the panel ===== */
+    #findPanel.findall, #findPanel.findall * { box-sizing: border-box; }
+    #findPanel.findall { overflow: hidden; }
+    /* slim header (title · count · close) */
+    #findAllHeader { display: none; }
+    #findPanel.findall #findAllHeader {
+        display: flex; align-items: center; gap: 8px; padding: 7px 10px; flex-shrink: 0;
+        border-bottom: 1px solid var(--toolbar-border);
+    }
+    #findAllHeader .fa-title { font-weight: 600; color: var(--title-accent); letter-spacing: .02em; }
+    #findAllHeader .fa-count { font-size: 11px; color: var(--title-color); }
+    /* search + replace: full-width, stacked; toggles wrap onto their own line */
+    #findPanel.findall .find-head { align-items: stretch; }
+    #findPanel.findall .find-rows { padding: 8px 10px; gap: 8px; width: 100%; min-width: 0; }
+    #findPanel.findall .find-row { flex-wrap: wrap; gap: 6px; width: 100%; min-width: 0; }
+    #findPanel.findall .combo { flex: 1 1 100%; max-width: 100%; min-width: 0; }
+    #findPanel.findall .find-btn { flex: 0 0 auto; }
+    /* hide overlay-only chrome that doesn't belong in the column */
+    #findPanel.findall #findGo,
+    #findPanel.findall #findPrev,
+    #findPanel.findall #findNext,
+    #findPanel.findall #findAllToggle,
+    #findPanel.findall #findClose,
+    #findPanel.findall #findHistClear,
+    #findPanel.findall #replHistClear,
+    #findPanel.findall #replSel,
+    #findPanel.findall #findCount,
+    #findPanel.findall #findTabs,
+    #findPanel.findall .find-restools,
+    #findPanel.findall .find-row > label,
+    #findPanel.findall .find-row .find-spacer,
+    #findPanel.findall .find-grid .c-chk { display: none; }
+    /* results list: fixed layout + ellipsis so a long line never widens the panel */
+    #findPanel.findall .find-grid { flex: 1; border-top: 1px solid var(--toolbar-border); }
+    #findPanel.findall .find-grid table { table-layout: fixed; width: 100%; }
+    #findPanel.findall .find-grid .c-line { width: 40px; }
+    #findPanel.findall .find-grid .c-lock { width: 20px; }
+    #findPanel.findall .find-grid tbody td:last-child {
+        overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--mono, monospace);
+    }
+    #findPanel.findall .find-grid tbody tr { line-height: 1.7; }
+    #findGrip { display: none; }   /* obsolete: the old bottom-dock resize handle (quick overlay / left column don't use it) */
     .find-rows { padding: 8px 10px 6px; display: flex; flex-direction: column; gap: 6px; flex-shrink: 0; }
     .find-row { display: flex; align-items: center; gap: 8px; }
+    /* VS Code-style replace expander: a chevron on the LEFT that shows/hides the replace row. It rotates
+       to point down when expanded. Replace is hidden unless #findPanel has .show-replace. */
+    .find-head { display: flex; align-items: stretch; }
+    .find-head .find-rows { flex: 1; }
+    .repl-toggle { width: 16px; flex-shrink: 0; border: none; background: transparent; cursor: pointer;
+        color: var(--title-color); display: flex; align-items: center; justify-content: center; padding: 0; }
+    .repl-toggle:hover { background: rgba(127,127,127,0.18); }
+    .repl-toggle .chev { font-size: 10px; line-height: 1; transition: transform 0.12s ease; }
+    #findPanel.show-replace .repl-toggle .chev { transform: rotate(90deg); }
+    #findPanel:not(.show-replace) #replRow { display: none; }
     .find-row > label { width: 80px; color: var(--title-color); flex-shrink: 0; }
     .find-spacer { flex: 1; }
 
-    .combo { position: relative; flex: 1; max-width: 520px; }
-    .combo input { width: 100%; background: var(--bg); color: var(--fg);
-        border: 1px solid var(--toolbar-border); border-radius: 4px; padding: 4px 26px 4px 8px;
-        font-family: inherit; font-size: var(--find-fz); }
-    .combo input:focus { outline: none; border-color: var(--find-accent); }
-    .combo .combo-caret { position: absolute; right: 2px; top: 2px; width: 20px; height: 22px;
+    /* The combo IS the boxed input control (VS Code-style): text field + inline toggles + history caret. */
+    .combo { position: relative; flex: 1; max-width: 520px; display: flex; align-items: center;
+        background: var(--bg); border: 1px solid var(--toolbar-border); border-radius: 4px; }
+    .combo:focus-within { border-color: var(--find-accent); }
+    .combo input { flex: 1; min-width: 0; background: transparent; color: var(--fg);
+        border: none; outline: none; padding: 4px 4px 4px 8px; font-family: inherit; font-size: var(--find-fz); }
+    .combo .toggles { flex-shrink: 0; }
+    .combo .combo-caret { width: 18px; height: 22px; flex-shrink: 0;
         display: flex; align-items: center; justify-content: center; color: var(--title-color);
         cursor: pointer; border-left: 1px solid var(--toolbar-border); user-select: none; font-size: 10px; }
-    .combo-hist { position: absolute; left: 0; right: 0; bottom: 100%; z-index: 40;
+    .combo-hist { position: absolute; left: 0; right: 0; top: 100%; z-index: 40;
         background: var(--toolbar-bg); border: 1px solid var(--toolbar-border);
-        border-radius: 4px 4px 0 0; box-shadow: 0 -6px 16px rgba(0,0,0,0.4); max-height: 180px; overflow: auto; }
+        border-radius: 0 0 4px 4px; box-shadow: 0 6px 16px rgba(0,0,0,0.4); max-height: 180px; overflow: auto; }
     .combo-hist.hidden { display: none; }
     .combo-hist div { padding: 4px 10px; cursor: pointer; display: flex; justify-content: space-between; gap: 10px; }
     .combo-hist div:hover { background: rgba(127,127,127,0.18); }
@@ -338,12 +424,12 @@
         text-transform: uppercase; letter-spacing: .5px; padding: 4px 10px 2px; opacity: .85; }
     .combo-hist .hist-header:hover { background: transparent; }
 
-    .toggles { display: flex; gap: 3px; }
-    .tg { width: 26px; height: 26px; border: 1px solid var(--toolbar-border); background: transparent;
-        color: var(--fg); border-radius: 4px; cursor: pointer; font-size: 11px; font-family: inherit;
+    .toggles { display: flex; gap: 1px; align-items: center; }
+    .tg { width: 22px; height: 20px; border: 1px solid transparent; background: transparent;
+        color: var(--title-color); border-radius: 3px; cursor: pointer; font-size: 11px; font-family: inherit;
         display: flex; align-items: center; justify-content: center; }
     .tg:hover { background: rgba(127,127,127,0.18); }
-    .tg.on { background: var(--find-accent); border-color: var(--find-accent); color: var(--on-fg); }
+    .tg.on { background: var(--find-hit); border-color: var(--find-hit-border); color: var(--fg); }
 
     .find-icon { width: 28px; height: 28px; border: 1px solid var(--toolbar-border); background: transparent;
         color: var(--fg); border-radius: 4px; cursor: pointer; font-size: 13px;
@@ -409,7 +495,7 @@
     body.light .find-rows,
     body.light .find-grid thead th,
     body.light #ftabMenu { background: #ffffff; }
-    body.light .combo input { background: #ffffff; }
+    body.light .combo { background: #ffffff; }
     body.light .find-grid tbody tr:hover { background: #eef2fb; }
     body.light .ftab { background: #f3f5f9; }            /* inactive tabs: a hair off-white so they read as tabs */
     body.light .ftab.active { background: #ffffff; }
@@ -562,27 +648,38 @@
     <div id="findPanel" class="hidden">
         <div id="findGrip" title="Drag to resize"></div>
         <div id="findTabs"></div>
+        <div id="findAllHeader">
+            <span class="fa-title">Find All</span>
+            <span class="fa-count" id="faCount"></span>
+            <span class="find-spacer"></span>
+            <button class="find-icon" id="faClose" title="Close (Esc)">&#10005;</button>
+        </div>
+        <div class="find-head">
+        <button id="replToggle" class="repl-toggle" title="Toggle Replace (Ctrl+H)" aria-expanded="false"><span class="chev">&#10095;</span></button>
         <div class="find-rows">
             <div class="find-row">
                 <label>Find what</label>
                 <div class="combo">
                     <input id="findInput" type="text" autocomplete="off" spellcheck="false" placeholder="Find…">
+                    <div class="toggles">
+                        <button class="tg" id="tgCase" title="Match case">Aa</button>
+                        <button class="tg" id="tgWord" title="Whole word">ab</button>
+                        <button class="tg" id="tgRegex" title="Use regular expression">.*</button>
+                        <button class="tg on" id="tgRo" title="Include read-only (generated) blocks in results">&#128274;</button>
+                    </div>
                     <span class="combo-caret" id="findCaret" title="Search history">&#9662;</span>
                     <div class="combo-hist hidden" id="findHist"></div>
                 </div>
                 <button class="find-icon search" id="findGo" title="Find (Enter)">&#128269;</button>
-                <div class="toggles">
-                    <button class="tg" id="tgCase" title="Match case">Aa</button>
-                    <button class="tg" id="tgWord" title="Whole word">ab</button>
-                    <button class="tg" id="tgRegex" title="Use regular expression">.*</button>
-                    <button class="tg on" id="tgRo" title="Include read-only (generated) blocks in results">&#128274;</button>
-                </div>
-                <span class="find-count" id="findCount"></span>
+                <button class="find-icon" id="findPrev" title="Previous match (Shift+Enter)">&#8249;</button>
+                <button class="find-icon" id="findNext" title="Next match (Enter)">&#8250;</button>
+                <button class="find-icon" id="findAllToggle" title="List all matches (Find All)">&#9776;</button>
                 <span class="find-spacer"></span>
                 <button class="find-icon" id="findHistClear" title="Clear search history">&#129529;</button>
                 <button class="find-icon" id="findClose" title="Close (Esc)">&#10005;</button>
             </div>
-            <div class="find-row">
+            <span class="find-count" id="findCount"></span>
+            <div class="find-row" id="replRow">
                 <label>Replace with</label>
                 <div class="combo">
                     <input id="replInput" type="text" autocomplete="off" spellcheck="false" placeholder="Replace…">
@@ -594,6 +691,7 @@
                 <span class="find-spacer"></span>
                 <button class="find-icon" id="replHistClear" title="Clear replace history">&#129529;</button>
             </div>
+        </div>
         </div>
         <div class="find-restools">
             <span class="find-link" id="selAll" title="Check every replaceable row">&#9638; Select All</span>
@@ -681,6 +779,7 @@
     var findHistory = [];         // solution-wide search terms, most-recent first
     var replHistory = [];         // solution-wide replace terms, most-recent first
     var procFindHistory = [];     // THIS procedure's recent search terms (layered dropdown top group)
+    var findHistIdx = -1;         // ↑/↓ cursor into findHistory while the find box is focused (-1 = live text)
     var findCurrentIdx = -1;      // index into findResults of the active (revealed) match
     var lastFindQuery = null;     // the query that produced findResults (for Enter = next)
     var findModelVersion = -1;    // model version findResults was last synced against (GitHub #65)
@@ -910,6 +1009,10 @@
         embedRanges = msg.editableRanges || [];
         saveEnabled = !!msg.saveEnabled;
         fileMode = !!msg.fileMode;
+        // The "include read-only (generated) blocks" find toggle only means something in PWEE/slot mode.
+        // In file mode the whole buffer is editable — there are no read-only regions — so hide it.
+        var tgRo = document.getElementById('tgRo');
+        if (tgRo) tgRo.style.display = fileMode ? 'none' : '';
         currentFilePath = msg.filePath || '';
         breakpointsEnabled = !!msg.breakpointsEnabled;   // overlay: gutter-click toggles a breakpoint (not a bookmark)
         designerEnabled = !!msg.designerEnabled;         // overlay: Ctrl+D designs structures in plain source files
@@ -2579,9 +2682,33 @@
                 if (!isEditableRange(e.changes[i].range)) { illegal = true; break; }
             }
             if (illegal) {
+                // Monaco applied the whole event atomically. A batch that touches even one read-only
+                // line used to be reverted WHOLESALE — which silently dropped the legal replacements in
+                // a mixed batch. The native find widget's "Replace All" is exactly that: one event whose
+                // matches land in BOTH editable slots and generated code, so it appeared to do nothing.
+                // Revert the atomic edit, then re-apply only the changes that fell inside editable slots.
+                // e.changes carry pre-edit coordinates in reverse-document order, so they stay valid
+                // against the buffer the undo just restored. (Same guard now also salvages multi-cursor
+                // edits that straddle a read-only boundary.)
+                var legal = [];
+                for (var k = 0; k < e.changes.length; k++) {
+                    if (isEditableRange(e.changes[k].range))
+                        legal.push({ range: e.changes[k].range, text: e.changes[k].text });
+                }
                 guarding = true;
                 editor.trigger('readonly-guard', 'undo', null);
+                if (legal.length) {
+                    editor.executeEdits('readonly-guard-reapply', legal);
+                    applyChangesToRanges(legal);
+                    applyEmbedDecorations();
+                }
                 guarding = false;
+                if (legal.length) {
+                    setDirty(true);
+                    if (fileMode) { editSeq++; pushFileState(); }
+                    if (bookmarkDecos.length) scheduleBookmarkPersist();
+                    scheduleDiagnostics();
+                }
                 return;
             }
             // A legal user edit happened (this handler returned early for programmatic loads via
@@ -3467,7 +3594,13 @@
         document.addEventListener('keydown', function (ev) {
             if (capturingKey || snippetPickerOpen) return;   // rebind-capture / snippet picker owns the keyboard
             var ctrl = ev.ctrlKey || ev.metaKey;
-            if (ctrl && (ev.keyCode === 70 || ev.key === 'f' || ev.key === 'F')) {         // Ctrl+F
+            if (ctrl && ev.shiftKey && (ev.keyCode === 70 || ev.key === 'f' || ev.key === 'F')) {   // Ctrl+Shift+F → Find All
+                // Shift branches MUST precede the plain Ctrl+F/Ctrl+H (they also match ctrl+F / ctrl+H). The C#
+                // ProcessCmdKey guard swallows these chords too, so they can't leak to the IDE's Find/Replace-in-Files.
+                ev.preventDefault(); ev.stopImmediatePropagation(); openFindAll(false);
+            } else if (ctrl && ev.shiftKey && (ev.keyCode === 72 || ev.key === 'h' || ev.key === 'H')) {   // Ctrl+Shift+H → Find All + Replace
+                ev.preventDefault(); ev.stopImmediatePropagation(); openFindAll(true);
+            } else if (ctrl && (ev.keyCode === 70 || ev.key === 'f' || ev.key === 'F')) {         // Ctrl+F
                 ev.preventDefault(); ev.stopImmediatePropagation(); openFindPanel(false);
             } else if (ctrl && (ev.keyCode === 72 || ev.key === 'h' || ev.key === 'H')) {   // Ctrl+H
                 ev.preventDefault(); ev.stopImmediatePropagation(); openFindPanel(true);
@@ -3879,12 +4012,100 @@
         return '';
     }
 
+    // ---- Layout: quick-find overlay vs. Find-All left column ----
+    // Pin the panel to the editor's top edge (just under the toolbar). Quick mode floats top-right and
+    // reserves no editor space; Find-All mode is a left column that pushes the editor right by its width.
+    function positionFindPanel() {
+        var panel = document.getElementById('findPanel');
+        var ed = document.getElementById('editor');
+        if (!panel || !ed) return;
+        var top = ed.offsetTop;
+        panel.style.top = (panel.classList.contains('findall') ? top : top + 6) + 'px';
+        setEditorInsets();
+    }
+    function setEditorInsets() {
+        var panel = document.getElementById('findPanel');
+        var findAll = panel && !panel.classList.contains('hidden') && panel.classList.contains('findall');
+        var left = findAll ? (panel.offsetWidth + 'px') : '0px';
+        var ed = document.getElementById('editor'); if (ed) ed.style.left = left;
+        var e2 = document.getElementById('editor2'); if (e2) e2.style.left = left;
+    }
+    // Header result count for the Find-All column (short form; the in-row count is hidden there).
+    function setFaCount() {
+        var el = document.getElementById('faCount');
+        if (!el) return;
+        var n = findResults.length;
+        if (!n) { el.textContent = document.getElementById('findInput').value ? 'No matches' : ''; return; }
+        var ro = 0;
+        for (var i = 0; i < n; i++) if (!findResults[i].editable) ro++;
+        el.textContent = n + (n === 1 ? ' match' : ' matches') + (ro ? ' · ' + ro + ' read-only' : '');
+    }
+    // Incremental find lands on the first match at/after the caret; wraps to the first if none follow.
+    function firstIdxFromCursor() {
+        if (!editor || !findResults.length) return 0;
+        var pos = editor.getPosition(); if (!pos) return 0;
+        for (var i = 0; i < findResults.length; i++) {
+            var r = findResults[i];
+            if (r.line > pos.lineNumber || (r.line === pos.lineNumber && r.startCol >= pos.column)) return i;
+        }
+        return 0;
+    }
+    // Commit the current term to the persisted, cross-tab history (runFind no longer does — it's incremental).
+    function commitFindHistory() {
+        var q = document.getElementById('findInput').value;
+        if (!q) return;
+        addHistory(findHistory, q); addHistory(procFindHistory, q, 10); persistHistory();
+    }
+    // ↑/↓ in the find box walk the PERSISTED history — survives tab close / reopen (the whole point).
+    function cycleFindHistory(dir) {
+        if (!findHistory.length) return;
+        findHistIdx += dir;
+        var el = document.getElementById('findInput');
+        if (findHistIdx < 0) { findHistIdx = -1; el.value = ''; runFind(); return; }
+        if (findHistIdx >= findHistory.length) findHistIdx = findHistory.length - 1;
+        el.value = findHistory[findHistIdx]; el.select(); runFind();
+    }
+    // Show / hide the replace row (VS Code left chevron). Only the replace chords (Ctrl+H / Ctrl+Shift+H)
+    // and the chevron itself expand it; the find chords leave it collapsed on a fresh open.
+    function setReplaceVisible(show) {
+        var panel = document.getElementById('findPanel');
+        if (!panel) return;
+        panel.classList.toggle('show-replace', show);
+        var t = document.getElementById('replToggle');
+        if (t) t.setAttribute('aria-expanded', show ? 'true' : 'false');
+        positionFindPanel();   // panel height changed
+    }
+    // Find-All: reveal the left results column, reusing the existing grid/tabs machinery. focusReplace
+    // (Ctrl+Shift+H) opens it with the replace row expanded + focused.
+    function openFindAll(focusReplace) {
+        var panel = document.getElementById('findPanel');
+        var wasFindAll = !panel.classList.contains('hidden') && panel.classList.contains('findall');
+        if (panel.classList.contains('hidden')) openFindPanel(false);
+        panel.classList.add('findall');
+        if (!wasFindAll) setReplaceVisible(!!focusReplace);
+        else if (focusReplace) setReplaceVisible(true);
+        positionFindPanel();
+        if (!findTabs.length) createTab(null);
+        if (document.getElementById('findInput').value) runFind();
+        renderResults();
+        (focusReplace ? document.getElementById('replInput') : document.getElementById('findInput')).focus();
+    }
+    function toggleFindAll() {
+        var panel = document.getElementById('findPanel');
+        if (panel.classList.contains('hidden') || !panel.classList.contains('findall')) { openFindAll(false); return; }
+        panel.classList.remove('findall'); positionFindPanel();
+        document.getElementById('findInput').focus();
+    }
+
     function openFindPanel(focusReplace) {
         var panel = document.getElementById('findPanel');
         if (!panel) return;
         var wasHidden = panel.classList.contains('hidden');
         panel.classList.remove('hidden');
-        setEditorBottom(panel.offsetHeight);
+        panel.classList.remove('findall');    // open compact (quick-find); Find-All is an explicit toggle
+        if (wasHidden) setReplaceVisible(!!focusReplace);   // fresh open: replace only on Ctrl+H
+        else if (focusReplace) setReplaceVisible(true);     // already open + Ctrl+H expands; else keep manual state
+        positionFindPanel();                  // pin under the toolbar; reserves no editor space
         if (!findTabs.length) createTab(null);   // always have at least one tab
 
         var input = document.getElementById('findInput');
@@ -3910,9 +4131,11 @@
     function closeFindPanel() {
         var panel = document.getElementById('findPanel');
         if (!panel) return;
+        commitFindHistory();              // record the search term on close (runFind no longer does)
         saveActiveTab();                  // persist the active tab's query/replace/opts for reopen
         panel.classList.add('hidden');
-        setEditorBottom(0);
+        panel.classList.remove('findall');
+        setEditorInsets();                // release any Find-All left-column width
         clearFindHighlights();
         hideHist('findHist'); hideHist('replHist'); hideTabMenu();
         if (editor) editor.focus();
@@ -3929,7 +4152,7 @@
         var countEl = document.getElementById('findCount');
         if (!q) {
             findResults = []; lastFindQuery = null; findCurrentIdx = -1;
-            renderResults(); clearFindHighlights(); countEl.textContent = '';
+            renderResults(); clearFindHighlights(); countEl.textContent = ''; setFaCount();
             if (activeTab >= 0 && findTabs[activeTab]) { findTabs[activeTab].query = ''; refreshTabLabels(); }
             return;
         }
@@ -3958,8 +4181,10 @@
         }
         lastFindQuery = q;
         findModelVersion = model.getAlternativeVersionId();   // results are fresh against THIS buffer state
-        findCurrentIdx = findResults.length ? 0 : -1;
-        addHistory(findHistory, q); addHistory(procFindHistory, q, 10); persistHistory();
+        // Incremental find: land on the first match at/after the caret (VS Code-style), not always #0.
+        findCurrentIdx = findResults.length ? firstIdxFromCursor() : -1;
+        // History is NOT recorded here — runFind fires on every keystroke now (incremental). A term is
+        // committed to the persisted, cross-tab history on Enter / close instead (commitFindHistory).
         renderResults();
         paintHighlights();
         var lines = countLines(findResults);
@@ -3969,7 +4194,8 @@
                ' · ' + lines + ' line' + (lines === 1 ? '' : 's') + (ro ? ' · ' + ro + ' read-only' : ''))
             : 'No matches';
         if (activeTab >= 0 && findTabs[activeTab]) { findTabs[activeTab].query = q; refreshTabLabels(); }
-        if (findResults.length) revealMatch(0, false);
+        setFaCount();
+        if (findResults.length) revealMatch(findCurrentIdx, false);
     }
 
     function countLines(arr) {
@@ -4083,7 +4309,7 @@
         findCurrentIdx = idx;
         var r = findResults[idx];
         var range = new monaco.Range(r.line, r.startCol, r.endLine, r.endCol);
-        editor.revealRangeInCenter(range);
+        editor.revealRangeInCenterIfOutsideViewport(range);   // gentle: only scrolls when off-screen (incremental)
         editor.setSelection(range);
         paintHighlights();
         var rows = document.querySelectorAll('#findResults tr');
@@ -4441,18 +4667,39 @@
 
         var fi = document.getElementById('findInput');
         document.getElementById('findGo').addEventListener('click', runFind);
+        // Incremental: search as you type (debounced), landing on the first match after the caret.
+        fi.addEventListener('input', function () {
+            findHistIdx = -1;
+            clearTimeout(fi._incT); fi._incT = setTimeout(runFind, 120);
+        });
         fi.addEventListener('keydown', function (ev) {
             if (ev.key === 'Enter') {
                 ev.preventDefault();
                 if (ev.target.value === lastFindQuery && findResults.length) gotoMatch(ev.shiftKey ? -1 : 1);
                 else runFind();
+                commitFindHistory();
             } else if (ev.key === 'Escape') { ev.preventDefault(); closeFindPanel(); }
+            else if (ev.key === 'ArrowUp') { ev.preventDefault(); cycleFindHistory(1); }
+            else if (ev.key === 'ArrowDown') { ev.preventDefault(); cycleFindHistory(-1); }
+        });
+        document.getElementById('findPrev').addEventListener('click', function () { gotoMatch(-1); });
+        document.getElementById('findNext').addEventListener('click', function () { gotoMatch(1); });
+        document.getElementById('findAllToggle').addEventListener('click', toggleFindAll);
+        window.addEventListener('resize', function () {
+            var p = document.getElementById('findPanel');
+            if (p && !p.classList.contains('hidden')) positionFindPanel();
         });
         document.getElementById('replInput').addEventListener('keydown', function (ev) {
             if (ev.key === 'Enter') { ev.preventDefault(); doReplace(true); }
             else if (ev.key === 'Escape') { ev.preventDefault(); closeFindPanel(); }
         });
         document.getElementById('findClose').addEventListener('click', closeFindPanel);
+        document.getElementById('replToggle').addEventListener('click', function () {
+            var show = !document.getElementById('findPanel').classList.contains('show-replace');
+            setReplaceVisible(show);
+            (show ? document.getElementById('replInput') : document.getElementById('findInput')).focus();
+        });
+        document.getElementById('faClose').addEventListener('click', closeFindPanel);
 
         function tg(id, key) {
             document.getElementById(id).addEventListener('click', function () {

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -4176,8 +4176,10 @@
         }
         return acc;
     }
-    function outlineExpandAll() { outlineCollapsed = {}; renderOutlineCurrent(); }
-    function outlineCollapseAll() {
+    // NB: names must NOT match the button element ids (outlineExpandAll/outlineCollapseAll) — a named
+    // element global shadows the function, so addEventListener would silently bind the DOM node instead.
+    function expandOutlineAll() { outlineCollapsed = {}; renderOutlineCurrent(); }
+    function collapseOutlineAll() {
         var paths = outlineContainerPaths(outlineSymbols, '', []);
         for (var i = 0; i < paths.length; i++) outlineCollapsed[paths[i]] = true;
         renderOutlineCurrent();
@@ -4975,8 +4977,8 @@
         document.getElementById('findBtn').addEventListener('click', function () { openFindPanel(false); });
         document.getElementById('outlineBtn').addEventListener('click', toggleOutline);
         document.getElementById('outlineClose').addEventListener('click', closeOutline);
-        document.getElementById('outlineExpandAll').addEventListener('click', outlineExpandAll);
-        document.getElementById('outlineCollapseAll').addEventListener('click', outlineCollapseAll);
+        document.getElementById('outlineExpandAll').addEventListener('click', expandOutlineAll);
+        document.getElementById('outlineCollapseAll').addEventListener('click', collapseOutlineAll);
         document.getElementById('outlineFilterBtn').addEventListener('click', toggleOutlineFilter);
         document.getElementById('outlineFilterClear').addEventListener('click', function () {
             var inp = document.getElementById('outlineFilterInput'); inp.value = ''; outlineFilter = ''; renderOutlineCurrent(); inp.focus();

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -365,7 +365,10 @@
         border-radius: 4px; padding: 3px 6px; font-family: inherit; font-size: var(--find-fz); outline: none; }
     #outlineFilterInput:focus { border-color: var(--find-accent); }
     #outlineList { flex: 1; overflow: auto; padding: 4px 0; }
-    .ol-row { display: flex; align-items: center; gap: 6px; padding: 2px 8px; cursor: pointer; white-space: nowrap; }
+    /* Let the tree scroll horizontally instead of clipping names: nodes/rows size to their content. */
+    #outlineList .ol-node, #outlineList .ol-children { min-width: max-content; }
+    .ol-row { display: flex; align-items: center; gap: 6px; padding: 2px 8px; cursor: pointer; white-space: nowrap;
+        min-width: 100%; }
     .ol-row:hover { background: rgba(127,127,127,0.14); }
     .ol-row .ol-kind { width: 18px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; color: var(--find-accent); }
     #outlineList .ol-kind.codicon { font-size: 15px; }
@@ -381,8 +384,8 @@
         font-size: 14px; color: var(--title-color); cursor: pointer; }
     .ol-row .ol-twisty.ol-leaf { cursor: default; }
     .ol-row .ol-twisty:not(.ol-leaf):hover { color: var(--find-accent); }
-    .ol-row .ol-name { overflow: hidden; text-overflow: ellipsis; }
-    .ol-row .ol-detail { color: var(--title-color); opacity: .65; overflow: hidden; text-overflow: ellipsis; }
+    .ol-row .ol-name { flex-shrink: 0; }
+    .ol-row .ol-detail { color: var(--title-color); opacity: .65; flex-shrink: 0; }
     .ol-empty { padding: 16px 12px; text-align: center; color: var(--title-color); }
 
     #findPanel.findall {
@@ -4109,6 +4112,7 @@
     var outlineCollapsed = {};   // path -> true when collapsed; survives refreshes so typing doesn't reset the tree
     var outlineSymbols = [];     // last regrouped (unfiltered) tree — filter/expand-all re-render off this
     var outlineFilter = '';      // active filter text ('' = none)
+    var outlineRenderedPaths = [];   // exact container paths from the last render (single source of truth for collapse-all)
     function positionOutline() {
         var op = document.getElementById('outlinePanel'), ed = document.getElementById('editor');
         if (!op || !ed) return;
@@ -4167,21 +4171,11 @@
         if (self || kids.length) return { name: node.name, detail: node.detail, kind: node.kind, line: node.line, children: kids };
         return null;
     }
-    // Every container's collapse-path (mirrors renderOutline's path key) — for collapse-all.
-    function outlineContainerPaths(nodes, prefix, acc) {
-        acc = acc || [];
-        for (var i = 0; i < nodes.length; i++) {
-            var s = nodes[i], path = (prefix || '') + (s.name || '') + '#' + s.kind;
-            if (s.children && s.children.length) { acc.push(path); outlineContainerPaths(s.children, path, acc); }
-        }
-        return acc;
-    }
     // NB: names must NOT match the button element ids (outlineExpandAll/outlineCollapseAll) — a named
     // element global shadows the function, so addEventListener would silently bind the DOM node instead.
     function expandOutlineAll() { outlineCollapsed = {}; renderOutlineCurrent(); }
     function collapseOutlineAll() {
-        var paths = outlineContainerPaths(outlineSymbols, '', []);
-        for (var i = 0; i < paths.length; i++) outlineCollapsed[paths[i]] = true;
+        for (var i = 0; i < outlineRenderedPaths.length; i++) outlineCollapsed[outlineRenderedPaths[i]] = true;
         renderOutlineCurrent();
     }
     function toggleOutlineFilter() {
@@ -4281,6 +4275,7 @@
         if (!list) return;
         list.innerHTML = '';
         var n = 0;
+        outlineRenderedPaths = [];
 
         function buildNode(s, depth, pathPrefix) {
             n++;
@@ -4318,6 +4313,7 @@
             node.appendChild(row);
 
             if (hasKids) {
+                outlineRenderedPaths.push(path);   // record the exact key this render uses
                 var kidsBox = document.createElement('div');
                 kidsBox.className = 'ol-children';
                 for (var i = 0; i < s.children.length; i++) kidsBox.appendChild(buildNode(s.children[i], depth + 1, path));

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -347,10 +347,23 @@
     }
     #outlinePanel.hidden { display: none; }
     #outlinePanel * { box-sizing: border-box; }
-    #outlineHeader { display: flex; align-items: center; gap: 8px; padding: 7px 10px; flex-shrink: 0;
+    #outlineHeader { display: flex; align-items: center; gap: 2px; padding: 4px 6px; flex-shrink: 0;
         border-bottom: 1px solid var(--toolbar-border); }
-    #outlineHeader .ol-title { font-weight: 600; color: var(--title-accent); letter-spacing: .02em; }
-    #outlineHeader .ol-count { font-size: 11px; color: var(--title-color); }
+    #outlineHeader .ol-count { font-size: 11px; color: var(--title-color); padding: 0 4px; }
+    /* outline toolbar buttons (codicon icons) */
+    .ol-tbtn { width: 24px; height: 22px; border: 1px solid transparent; background: transparent; color: var(--title-color);
+        border-radius: 3px; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; padding: 0; }
+    .ol-tbtn .codicon { font-size: 15px; }
+    .ol-tbtn:hover { background: rgba(127,127,127,0.18); }
+    .ol-tbtn.active { background: var(--find-hit); border-color: var(--find-hit-border); color: var(--fg); }
+    /* filter row */
+    #outlineFilterRow { display: flex; align-items: center; gap: 5px; padding: 5px 8px; flex-shrink: 0;
+        border-bottom: 1px solid var(--toolbar-border); }
+    #outlineFilterRow.hidden { display: none; }
+    #outlineFilterRow .ol-filter-ico { color: var(--title-color); font-size: 13px; flex-shrink: 0; }
+    #outlineFilterInput { flex: 1; min-width: 0; background: var(--bg); color: var(--fg); border: 1px solid var(--toolbar-border);
+        border-radius: 4px; padding: 3px 6px; font-family: inherit; font-size: var(--find-fz); outline: none; }
+    #outlineFilterInput:focus { border-color: var(--find-accent); }
     #outlineList { flex: 1; overflow: auto; padding: 4px 0; }
     .ol-row { display: flex; align-items: center; gap: 6px; padding: 2px 8px; cursor: pointer; white-space: nowrap; }
     .ol-row:hover { background: rgba(127,127,127,0.14); }
@@ -683,10 +696,17 @@
     <!-- Document structure fly-out (left column, Phase-1 outline prototype). -->
     <div id="outlinePanel" class="hidden">
         <div id="outlineHeader">
-            <span class="ol-title">Structure</span>
-            <span class="ol-count" id="outlineCount"></span>
+            <button class="ol-tbtn" id="outlineExpandAll" title="Expand all"><span class="codicon codicon-expand-all"></span></button>
+            <button class="ol-tbtn" id="outlineCollapseAll" title="Collapse all"><span class="codicon codicon-collapse-all"></span></button>
+            <button class="ol-tbtn" id="outlineFilterBtn" title="Filter symbols"><span class="codicon codicon-filter"></span></button>
             <span class="find-spacer"></span>
-            <button class="find-icon" id="outlineClose" title="Close">&#10005;</button>
+            <span class="ol-count" id="outlineCount"></span>
+            <button class="ol-tbtn" id="outlineClose" title="Close"><span class="codicon codicon-close"></span></button>
+        </div>
+        <div id="outlineFilterRow" class="hidden">
+            <span class="codicon codicon-filter ol-filter-ico"></span>
+            <input id="outlineFilterInput" type="text" placeholder="Filter… (e.g. ThisWindow)" autocomplete="off" spellcheck="false">
+            <button class="ol-tbtn" id="outlineFilterClear" title="Clear filter (Esc)"><span class="codicon codicon-close"></span></button>
         </div>
         <div id="outlineList"><div class="ol-empty">No structure.</div></div>
     </div>
@@ -4087,6 +4107,8 @@
     var outlineSeq = 0;
     var _outlineDebounce = null;
     var outlineCollapsed = {};   // path -> true when collapsed; survives refreshes so typing doesn't reset the tree
+    var outlineSymbols = [];     // last regrouped (unfiltered) tree — filter/expand-all re-render off this
+    var outlineFilter = '';      // active filter text ('' = none)
     function positionOutline() {
         var op = document.getElementById('outlinePanel'), ed = document.getElementById('editor');
         if (!op || !ed) return;
@@ -4120,9 +4142,54 @@
         requestFromHost('documentStructure', { buffer: editor.getModel().getValue() })
             .then(function (data) {
                 if (mySeq !== outlineSeq) return;   // a newer refresh superseded this one
-                renderOutline(regroupSymbols((data && data.symbols) ? data.symbols : []));
+                outlineSymbols = regroupSymbols((data && data.symbols) ? data.symbols : []);
+                renderOutlineCurrent();
             })
             .catch(function () {});
+    }
+    // Render the cached tree, applying the active filter (force-expanded so matches are visible).
+    function renderOutlineCurrent() {
+        var f = (outlineFilter || '').trim().toLowerCase();
+        if (f) renderOutline(filterOutline(outlineSymbols, f), true);
+        else renderOutline(outlineSymbols, false);
+    }
+    // Keep a node if it (or an ancestor) matches — then its whole subtree rides along — or if a descendant
+    // matches (kept as a path node). Returns a filtered copy or null.
+    function filterOutline(nodes, f) {
+        var out = [];
+        for (var i = 0; i < nodes.length; i++) { var k = filterNode(nodes[i], f, false); if (k) out.push(k); }
+        return out;
+    }
+    function filterNode(node, f, ancestorMatch) {
+        var self = ancestorMatch || (node.name || '').toLowerCase().indexOf(f) >= 0;
+        var kids = [];
+        if (node.children) for (var i = 0; i < node.children.length; i++) { var kc = filterNode(node.children[i], f, self); if (kc) kids.push(kc); }
+        if (self || kids.length) return { name: node.name, detail: node.detail, kind: node.kind, line: node.line, children: kids };
+        return null;
+    }
+    // Every container's collapse-path (mirrors renderOutline's path key) — for collapse-all.
+    function outlineContainerPaths(nodes, prefix, acc) {
+        acc = acc || [];
+        for (var i = 0; i < nodes.length; i++) {
+            var s = nodes[i], path = (prefix || '') + (s.name || '') + '#' + s.kind;
+            if (s.children && s.children.length) { acc.push(path); outlineContainerPaths(s.children, path, acc); }
+        }
+        return acc;
+    }
+    function outlineExpandAll() { outlineCollapsed = {}; renderOutlineCurrent(); }
+    function outlineCollapseAll() {
+        var paths = outlineContainerPaths(outlineSymbols, '', []);
+        for (var i = 0; i < paths.length; i++) outlineCollapsed[paths[i]] = true;
+        renderOutlineCurrent();
+    }
+    function toggleOutlineFilter() {
+        var row = document.getElementById('outlineFilterRow');
+        var btn = document.getElementById('outlineFilterBtn');
+        var nowHidden = row.classList.toggle('hidden');
+        var visible = !nowHidden;
+        btn.classList.toggle('active', visible);
+        if (visible) { var inp = document.getElementById('outlineFilterInput'); inp.focus(); inp.select(); }
+        else if (outlineFilter) { outlineFilter = ''; document.getElementById('outlineFilterInput').value = ''; renderOutlineCurrent(); }
     }
     // LSP SymbolKind (1-based) -> a VS Code codicon symbol name. Monaco already loads the codicon font
     // (its suggest/find widgets use it), so `codicon codicon-symbol-<name>` renders the exact icons VS Code
@@ -4206,7 +4273,7 @@
         return result;
     }
 
-    function renderOutline(symbols) {
+    function renderOutline(symbols, forceExpand) {
         var list = document.getElementById('outlineList');
         var countEl = document.getElementById('outlineCount');
         if (!list) return;
@@ -4259,7 +4326,7 @@
                     tw.classList.toggle('codicon-chevron-right', collapsed);
                     tw.classList.toggle('codicon-chevron-down', !collapsed);
                 };
-                if (outlineCollapsed[path]) apply(true);
+                if (!forceExpand && outlineCollapsed[path]) apply(true);
                 tw.addEventListener('click', function (ev) {
                     ev.stopPropagation();   // toggle only — don't navigate
                     var collapsed = !node.classList.contains('collapsed');
@@ -4908,6 +4975,16 @@
         document.getElementById('findBtn').addEventListener('click', function () { openFindPanel(false); });
         document.getElementById('outlineBtn').addEventListener('click', toggleOutline);
         document.getElementById('outlineClose').addEventListener('click', closeOutline);
+        document.getElementById('outlineExpandAll').addEventListener('click', outlineExpandAll);
+        document.getElementById('outlineCollapseAll').addEventListener('click', outlineCollapseAll);
+        document.getElementById('outlineFilterBtn').addEventListener('click', toggleOutlineFilter);
+        document.getElementById('outlineFilterClear').addEventListener('click', function () {
+            var inp = document.getElementById('outlineFilterInput'); inp.value = ''; outlineFilter = ''; renderOutlineCurrent(); inp.focus();
+        });
+        document.getElementById('outlineFilterInput').addEventListener('input', function () { outlineFilter = this.value; renderOutlineCurrent(); });
+        document.getElementById('outlineFilterInput').addEventListener('keydown', function (ev) {
+            if (ev.key === 'Escape') { ev.preventDefault(); toggleOutlineFilter(); }
+        });
         window.addEventListener('resize', function () {
             var op = document.getElementById('outlinePanel');
             if (op && !op.classList.contains('hidden')) positionOutline();

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -4120,7 +4120,7 @@
         requestFromHost('documentStructure', { buffer: editor.getModel().getValue() })
             .then(function (data) {
                 if (mySeq !== outlineSeq) return;   // a newer refresh superseded this one
-                renderOutline((data && data.symbols) ? data.symbols : []);
+                renderOutline(regroupSymbols((data && data.symbols) ? data.symbols : []));
             })
             .catch(function () {});
     }
@@ -4155,6 +4155,57 @@
             default: return 'misc';
         }
     }
+    // Port of the VS Code extension's StructureViewProvider.regroupFlatSymbols: dotted method
+    // implementations (Class.Method, or Class.Interface.Method) are lifted out of the flat root list and
+    // nested under a faux Class > Methods (or Class > Interface) tree, merged INTO the class' declaration
+    // node when one exists so declarations + implementations sit together. The impl's own children (its
+    // local data) ride along.
+    function regroupSymbols(symbols) {
+        if (!symbols || !symbols.length) return symbols || [];
+        var result = [], classByKey = {};
+        function key(n) { return (n || '').toLowerCase(); }
+        function bareClassName(node) {
+            var m = /class\s*\(\s*([^)]+?)\s*\)/i.exec(node.name || '');
+            return (m ? m[1] : (node.name || '')).trim();
+        }
+        function isImpl(s) {
+            return s.name && s.name.indexOf('.') >= 0
+                && (s.kind === 6 || s.kind === 11 || s.kind === 12)     // Method / Interface / Function
+                && !/STRING\('[^']*\./i.test(s.name);                    // ignore a dot inside a string literal
+        }
+        function childByName(parent, name) {
+            parent.children = parent.children || [];
+            for (var i = 0; i < parent.children.length; i++) if (parent.children[i].name === name) return parent.children[i];
+            return null;
+        }
+        function addChild(parent, name, kind, detail, line) {
+            var e = childByName(parent, name);
+            if (!e) { e = { name: name, detail: detail || '', kind: kind, line: line, children: [] }; parent.children.push(e); }
+            return e;
+        }
+        // Pass 1: index real CLASS declaration nodes so impls merge into them.
+        for (var i = 0; i < symbols.length; i++) if (symbols[i].kind === 5) { var bk = key(bareClassName(symbols[i])); if (!classByKey[bk]) classByKey[bk] = symbols[i]; }
+        // Pass 2: emit in order; route impls into their class' Methods/interface faux node.
+        for (var j = 0; j < symbols.length; j++) {
+            var sym = symbols[j];
+            if (isImpl(sym)) {
+                var parts = sym.name.split('.'), ck = key(parts[0]);
+                var cls = classByKey[ck];
+                if (!cls) { cls = { name: parts[0], detail: 'Class', kind: 5, line: sym.line, children: [] }; classByKey[ck] = cls; result.push(cls); }
+                else if (result.indexOf(cls) < 0) result.push(cls);
+                cls.children = cls.children || [];
+                var method = { name: parts.slice(parts.length >= 3 ? 2 : 1).join('.'), detail: sym.detail || 'Method Implementation', kind: sym.kind, line: sym.line, children: sym.children || [] };
+                if (parts.length >= 3) addChild(cls, parts[1], 11, 'Interface', sym.line).children.push(method);
+                else addChild(cls, 'Methods', 6, '', sym.line).children.push(method);
+            } else if (sym.kind === 5 && classByKey[key(bareClassName(sym))] === sym) {
+                if (result.indexOf(sym) < 0) result.push(sym);   // class decl node — emit once
+            } else {
+                result.push(sym);
+            }
+        }
+        return result;
+    }
+
     function renderOutline(symbols) {
         var list = document.getElementById('outlineList');
         var countEl = document.getElementById('outlineCount');

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -362,6 +362,12 @@
     #outlineList .codicon-symbol-class, #outlineList .codicon-symbol-struct, #outlineList .codicon-symbol-interface,
     #outlineList .codicon-symbol-enum, #outlineList .codicon-symbol-enum-member { color: #ee9d28; }
     #outlineList .codicon-symbol-namespace { color: #cccccc; }
+    /* collapsible tree */
+    .ol-node.collapsed > .ol-children { display: none; }
+    .ol-row .ol-twisty { width: 14px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center;
+        font-size: 14px; color: var(--title-color); cursor: pointer; }
+    .ol-row .ol-twisty.ol-leaf { cursor: default; }
+    .ol-row .ol-twisty:not(.ol-leaf):hover { color: var(--find-accent); }
     .ol-row .ol-name { overflow: hidden; text-overflow: ellipsis; }
     .ol-row .ol-detail { color: var(--title-color); opacity: .65; overflow: hidden; text-overflow: ellipsis; }
     .ol-empty { padding: 16px 12px; text-align: center; color: var(--title-color); }
@@ -4080,6 +4086,7 @@
     // ---- Document structure fly-out (Phase-1 outline prototype) ----
     var outlineSeq = 0;
     var _outlineDebounce = null;
+    var outlineCollapsed = {};   // path -> true when collapsed; survives refreshes so typing doesn't reset the tree
     function positionOutline() {
         var op = document.getElementById('outlinePanel'), ed = document.getElementById('editor');
         if (!op || !ed) return;
@@ -4154,30 +4161,66 @@
         if (!list) return;
         list.innerHTML = '';
         var n = 0;
-        function add(nodes, depth) {
-            for (var i = 0; i < nodes.length; i++) {
-                var s = nodes[i]; n++;
-                var row = document.createElement('div');
-                row.className = 'ol-row';
-                row.style.paddingLeft = (8 + depth * 14) + 'px';
-                var k = document.createElement('span'); k.className = 'ol-kind codicon codicon-symbol-' + outlineIcon(s.kind);
-                var nm = document.createElement('span'); nm.className = 'ol-name'; nm.textContent = s.name || '';
-                row.appendChild(k); row.appendChild(nm);
-                if (s.detail) { var dt = document.createElement('span'); dt.className = 'ol-detail'; dt.textContent = ' ' + s.detail; row.appendChild(dt); }
-                (function (ln) {
-                    row.addEventListener('click', function () {
-                        if (!ln || !editor) return;
-                        editor.revealLineInCenter(ln);
-                        editor.setPosition({ lineNumber: ln, column: 1 });
-                        editor.focus();
-                    });
-                })(s.line);
-                list.appendChild(row);
-                if (s.children && s.children.length) add(s.children, depth + 1);
+
+        function buildNode(s, depth, pathPrefix) {
+            n++;
+            var path = pathPrefix + '' + (s.name || '') + '#' + s.kind;
+            var hasKids = s.children && s.children.length;
+
+            var node = document.createElement('div');
+            node.className = 'ol-node';
+
+            var row = document.createElement('div');
+            row.className = 'ol-row';
+            row.style.paddingLeft = (6 + depth * 14) + 'px';
+
+            var tw = document.createElement('span');
+            tw.className = hasKids ? 'ol-twisty codicon codicon-chevron-down' : 'ol-twisty ol-leaf';
+            row.appendChild(tw);
+
+            var k = document.createElement('span');
+            k.className = 'ol-kind codicon codicon-symbol-' + outlineIcon(s.kind);
+            row.appendChild(k);
+
+            var nm = document.createElement('span');
+            nm.className = 'ol-name'; nm.textContent = s.name || '';
+            row.appendChild(nm);
+            if (s.detail) { var dt = document.createElement('span'); dt.className = 'ol-detail'; dt.textContent = ' ' + s.detail; row.appendChild(dt); }
+
+            (function (ln) {
+                row.addEventListener('click', function () {
+                    if (!ln || !editor) return;
+                    editor.revealLineInCenter(ln);
+                    editor.setPosition({ lineNumber: ln, column: 1 });
+                    editor.focus();
+                });
+            })(s.line);
+            node.appendChild(row);
+
+            if (hasKids) {
+                var kidsBox = document.createElement('div');
+                kidsBox.className = 'ol-children';
+                for (var i = 0; i < s.children.length; i++) kidsBox.appendChild(buildNode(s.children[i], depth + 1, path));
+                node.appendChild(kidsBox);
+
+                var apply = function (collapsed) {
+                    node.classList.toggle('collapsed', collapsed);
+                    tw.classList.toggle('codicon-chevron-right', collapsed);
+                    tw.classList.toggle('codicon-chevron-down', !collapsed);
+                };
+                if (outlineCollapsed[path]) apply(true);
+                tw.addEventListener('click', function (ev) {
+                    ev.stopPropagation();   // toggle only — don't navigate
+                    var collapsed = !node.classList.contains('collapsed');
+                    if (collapsed) outlineCollapsed[path] = true; else delete outlineCollapsed[path];
+                    apply(collapsed);
+                });
             }
+            return node;
         }
+
         if (!symbols || !symbols.length) { list.innerHTML = '<div class="ol-empty">No structure.</div>'; }
-        else add(symbols, 0);
+        else for (var i = 0; i < symbols.length; i++) list.appendChild(buildNode(symbols[i], 0, ''));
         if (countEl) countEl.textContent = n ? (n + (n === 1 ? ' symbol' : ' symbols')) : '';
     }
 

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -354,7 +354,14 @@
     #outlineList { flex: 1; overflow: auto; padding: 4px 0; }
     .ol-row { display: flex; align-items: center; gap: 6px; padding: 2px 8px; cursor: pointer; white-space: nowrap; }
     .ol-row:hover { background: rgba(127,127,127,0.14); }
-    .ol-row .ol-kind { width: 15px; flex-shrink: 0; text-align: center; color: var(--find-accent); font-size: 11px; }
+    .ol-row .ol-kind { width: 18px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; color: var(--find-accent); }
+    #outlineList .ol-kind.codicon { font-size: 15px; }
+    /* VS Code symbol colours (dark-theme palette; readable in light too) */
+    #outlineList .codicon-symbol-method, #outlineList .codicon-symbol-constructor { color: #b180d7; }
+    #outlineList .codicon-symbol-field, #outlineList .codicon-symbol-property, #outlineList .codicon-symbol-variable { color: #75beff; }
+    #outlineList .codicon-symbol-class, #outlineList .codicon-symbol-struct, #outlineList .codicon-symbol-interface,
+    #outlineList .codicon-symbol-enum, #outlineList .codicon-symbol-enum-member { color: #ee9d28; }
+    #outlineList .codicon-symbol-namespace { color: #cccccc; }
     .ol-row .ol-name { overflow: hidden; text-overflow: ellipsis; }
     .ol-row .ol-detail { color: var(--title-color); opacity: .65; overflow: hidden; text-overflow: ellipsis; }
     .ol-empty { padding: 16px 12px; text-align: center; color: var(--title-color); }
@@ -4110,20 +4117,35 @@
             })
             .catch(function () {});
     }
-    // LSP SymbolKind (1-based) -> a compact glyph for the row.
-    function outlineGlyph(kind) {
+    // LSP SymbolKind (1-based) -> a VS Code codicon symbol name. Monaco already loads the codicon font
+    // (its suggest/find widgets use it), so `codicon codicon-symbol-<name>` renders the exact icons VS Code
+    // shows in its Outline — no extra assets. Unknown kinds fall back to codicon-symbol-misc.
+    function outlineIcon(kind) {
         switch (kind) {
-            case 2:  return 'M';    // Module (root)
-            case 5:  return 'C';    // Class
-            case 6:  return 'm';    // Method (ROUTINE / class method)
-            case 8:  return '·';    // Field
-            case 10: return 'e';    // Enum (MENU)
-            case 11: return '▢'; // Interface (WINDOW/APPLICATION)
-            case 12: return 'ƒ'; // Function (PROCEDURE)
-            case 13: return 'v';    // Variable
-            case 18: return '[]';   // Array (QUEUE/VIEW/LIST)
-            case 23: return '{}';   // Struct (GROUP/RECORD/FILE)
-            default: return '•';
+            case 1:  return 'file';
+            case 2:  case 3: case 4: return 'namespace';   // Module / Namespace / Package
+            case 5:  return 'class';
+            case 6:  return 'method';                      // Method / ROUTINE
+            case 7:  return 'property';
+            case 8:  return 'field';
+            case 9:  return 'constructor';
+            case 10: return 'enum';                        // MENU
+            case 11: return 'interface';                   // WINDOW / APPLICATION
+            case 12: return 'method';                      // Function / PROCEDURE
+            case 13: return 'variable';
+            case 14: return 'constant';
+            case 15: return 'string';
+            case 16: return 'number';
+            case 17: return 'boolean';
+            case 18: return 'array';                       // QUEUE / VIEW / LIST
+            case 19: return 'object';
+            case 20: return 'key';
+            case 22: return 'enum-member';                 // TAB / ITEM
+            case 23: return 'struct';                      // GROUP / RECORD / FILE
+            case 24: return 'event';
+            case 25: return 'operator';
+            case 26: return 'type-parameter';
+            default: return 'misc';
         }
     }
     function renderOutline(symbols) {
@@ -4138,7 +4160,7 @@
                 var row = document.createElement('div');
                 row.className = 'ol-row';
                 row.style.paddingLeft = (8 + depth * 14) + 'px';
-                var k = document.createElement('span'); k.className = 'ol-kind'; k.textContent = outlineGlyph(s.kind);
+                var k = document.createElement('span'); k.className = 'ol-kind codicon codicon-symbol-' + outlineIcon(s.kind);
                 var nm = document.createElement('span'); nm.className = 'ol-name'; nm.textContent = s.name || '';
                 row.appendChild(k); row.appendChild(nm);
                 if (s.detail) { var dt = document.createElement('span'); dt.className = 'ol-detail'; dt.textContent = ' ' + s.detail; row.appendChild(dt); }


### PR DESCRIPTION
## ⚠️ Stacked on #104

This branch is based on `feat/embeditor-in-editor-find` (#104) — it reuses that PR's left-column fly-out mechanism (`setEditorInsets` / the docked column). Until #104 merges, **this PR's diff includes #104's commits**; once #104 lands in `master` the diff reduces to just the outline work below. **Review #104 first.** The outline-specific commits are `f6f0c7f`…`e24e5a0` (files: `DocumentOutlineBuilder.cs`, `MonacoEditorControl.cs`, `ModernEmbeditorViewContent.cs`, `MonacoClarionSourceEditor.cs`, `SharedLspBridge.cs`, `ClarionAssistant.csproj`, and the outline section of `monaco-embeditor.html`).

## Summary

A **Document Structure outline** for the Monaco embeditor — a VS Code-style Outline shown as a left-column fly-out, driven by the LSP's `textDocument/documentSymbol`. First version (pull-based).

Toggle it from the new toolbar button (bulleted-list icon). It works in both host surfaces (the Modern embeditor and the source overlay); it's most useful in **file/source mode** (whole module, reliable symbols).

## What it does

- **Fly-out**: left column reusing #104's inset mechanism; opening it excludes the Find-All column and vice-versa.
- **Tree**: collapsible nodes (codicon chevron twisties); collapse state is keyed by node path and survives the debounced refreshes.
- **Class ▸ Methods regrouping**: a port of the extension's `StructureViewProvider.regroupFlatSymbols` — dotted method implementations (`Class.Method`, or `Class.Interface.Method`) are lifted from the flat root into a faux `Class ▸ Methods` (or `Class ▸ Interface`) tree, merged into the class' declaration node so declarations and implementations sit together, with each method's locals as children.
- **Icons**: VS Code **codicons** — Monaco already loads that font, so `codicon-symbol-<kind>` renders the exact Outline icons, with VS Code's symbol colours (method=purple, field/variable=blue, class/struct/enum=orange).
- **Toolbar** (replaces the title): **expand all**, **collapse all**, and a **live filter** (type e.g. `ThisWindow` to narrow to matching symbols + their ancestor path, force-expanded).
- **Horizontal scroll** instead of clipping — long names/signatures are fully readable.
- **Refresh**: on open and on a debounced buffer change (superseded-request-guarded). Pull-based; a server-push refresh is a Phase-2 follow-up.

## How the data gets here — LSP addin changes (ClarionLsp / clarion-lsp)

The outline needs the **hierarchical** `documentSymbol` tree. Two problems were fixed to deliver it through the C# path:

1. **`clarion-lsp` addin — flattening bug (released as v1.4.1).** `ClarionLspService.ParseDocumentSymbols` only read the top-level `result` array and dropped `children`, so a hierarchical `DocumentSymbol` (procedures with nested `WINDOW`/controls, classes with methods, routines with data) collapsed to just the root callables. It now **recurses `children`** and captures **`detail`** (control `USE(...)`, method signatures), reading the range from either `DocumentSymbol.range` or `SymbolInformation.location.range`. `SymbolResult` gained **`Children`** and **`Detail`**.
   - **First-load-safety**: `ClarionLsp.Contracts` stays `AssemblyVersion 1.0.0.0` and consumers ship a vendored copy, so the new fields are **written via reflection** in the addin (and read via reflection here). If an older contract wins the first-load race the addin degrades to a flat result rather than faulting — so **v1.4.1 is safe to install ahead of this CA change**.
   - Released as **[clarion-lsp v1.4.1](https://github.com/msarson/clarion-lsp/releases/tag/v1.4.1)**; the addin registry entry was bumped `1.4.0 → 1.4.1`.

2. **CA bridge — `SharedLspBridge.SymbolsToList`.** Now propagates the new `Children`/`Detail` into the dict tree the outline consumes, **read via reflection** so CA still compiles/loads against the older vendored contract — flat when absent, a full tree once the newer addin + contract are deployed. (The *bundled* LSP path already preserved the hierarchy; this fixes the *shared-addin* path, the common config.)

## Implementation (CA side)

- New **`documentStructure`** request action, modelled on the existing completion/definition handlers: `IMonacoEditorHost.OnDocumentStructure` → `MonacoEditorControl` dispatch → handlers in both hosts → `PostResponse({symbols, fileMode})`.
- **`Services/DocumentOutlineBuilder`** turns `DocumentSymbol[]`/`SymbolInformation[]` into `{name, kind, detail, line, children}`, mapping LSP 0-based lines → Monaco 1-based (embed-aware in slot mode, `+1` for whole-file source).
- All new host code is guarded and no-ops when the LSP isn't running.

## Scope / follow-ups

- **File/source mode** is the sweet spot. **Embed/slot mode** shows a partial outline by nature (the buffer is a procedure slice) — a dedicated slot navigator is a later phase.
- **Follow-cursor** (auto-select the symbol at the caret) and a **server-push refresh** (`clarion/symbolsRefreshed` already exists server-side) are natural next steps.

## Testing (manual, Clarion 11.1)

- Outline on a source file with classes/windows/routines: tree renders, method implementations grouped under `Class ▸ Methods` with their locals, icons + colours correct.
- Verified on the **shared addin path** (`Lsp.ForceLocal=false`) with the v1.4.1 addin — full hierarchy (previously flat); and confirmed the flat→tree difference isolates to the addin's `children` handling.
- Collapse/expand-all, filter (`ThisWindow`, a method name), click-to-navigate, horizontal scroll for long names, and refresh-on-edit while open.
