### PR TITLE
fix(editor): open_file lands on wrong line; add view centering.

### DIFF
--- a/ClarionAssistant/Services/EditorService.cs
+++ b/ClarionAssistant/Services/EditorService.cs
@@ -475,6 +475,31 @@ namespace ClarionAssistant.Services
                 var fileServiceType = sharpDevelopAsm.GetType("ICSharpCode.SharpDevelop.FileService");
                 if (fileServiceType == null) return;
 
+                // Prefer JumpToFilePosition — it opens the file (which restores the last
+                // remembered caret/scroll position via the workbench's memento mechanism)
+                // and then explicitly overrides the caret to the requested line, in one
+                // synchronous call. Calling OpenFile + setting the caret ourselves afterward
+                // raced against that memento restore and lost.
+                var jumpMethod = fileServiceType.GetMethod("JumpToFilePosition",
+                    BindingFlags.Public | BindingFlags.Static, null,
+                    new[] { typeof(string), typeof(int), typeof(int) }, null);
+
+                if (jumpMethod != null)
+                {
+                    // JumpTo takes 0-based line/column in this SharpDevelop version
+                    // (Math.Max(0, ...) internally) — lineNumber here is 1-based.
+                    // A newer SharpDevelop source diff describes IPositionable.JumpTo also centering
+                    // the view itself via a deferred SafeThreadAsyncCall -> CenterViewOn. Tested directly
+                    // against THIS build (2.1.0.2447), including a deliberate 800ms wait before checking:
+                    // no such centering ever happens here — the view stays pinned exactly at the jump
+                    // target. So that behavior either isn't present in this exact build or isn't reachable
+                    // through this call path; we can't rely on it and must center ourselves.
+                    jumpMethod.Invoke(null, new object[] { filePath, lineNumber - 1, 0 });
+                    DeferCenterViewOnLine(lineNumber - 1);
+                    return;
+                }
+
+                // Fallback for versions where JumpToFilePosition isn't found this way.
                 var openFileMethod = fileServiceType.GetMethod("OpenFile",
                     BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(string) }, null);
                 if (openFileMethod != null)
@@ -489,8 +514,81 @@ namespace ClarionAssistant.Services
                             SetProperty(caret, "Line", lineNumber - 1);
                             SetProperty(caret, "Column", 0);
                         }
+                        DeferCenterViewOnLine(lineNumber - 1);
                     }
                 }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Run CenterViewOnLine after a short delay instead of immediately. A brand-new tab's text
+        /// area doesn't have a valid height/VisibleLineCount until its layout pass completes, and
+        /// something (native "ensure caret visible" handling, tied to the new control settling in)
+        /// resets an immediate scroll attempt — confirmed by testing: a single queued BeginInvoke
+        /// (next UI-thread message-loop turn) was NOT enough to land after that reset, producing an
+        /// inconsistent, partially-reset scroll position. A short real-time Timer delay reliably runs
+        /// after the new tab has finished settling. Re-fetches the active text area at invocation
+        /// time rather than capturing it now, since the active view could change before this runs.
+        /// </summary>
+        private void DeferCenterViewOnLine(int lineNumber0Based)
+        {
+            var timer = new Timer { Interval = 150 };
+            timer.Tick += (s, e) =>
+            {
+                timer.Stop();
+                timer.Dispose();
+                CenterViewOnLine(GetActiveTextArea(), lineNumber0Based);
+            };
+            timer.Start();
+        }
+
+        /// <summary>
+        /// Open a file WITHOUT navigating anywhere — leaves the workbench's own memento restore
+        /// (last remembered caret/scroll position for this file, if any) in effect.
+        /// </summary>
+        public void OpenFileOnly(string filePath)
+        {
+            try
+            {
+                var sharpDevelopAsm = Assembly.Load("ICSharpCode.SharpDevelop");
+                if (sharpDevelopAsm == null) return;
+
+                var fileServiceType = sharpDevelopAsm.GetType("ICSharpCode.SharpDevelop.FileService");
+                if (fileServiceType == null) return;
+
+                var openFileMethod = fileServiceType.GetMethod("OpenFile",
+                    BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(string) }, null);
+                openFileMethod?.Invoke(null, new object[] { filePath });
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Scroll a SPECIFIC text area so the given 0-based line sits roughly centered in the
+        /// viewport, instead of pinned to the very top. Computes the target first-visible line
+        /// from TextView.VisibleLineCount, but always applies it via the TextArea's own ScrollTo
+        /// method — setting TextView.FirstVisibleLine directly gets silently overridden (it's a
+        /// cache synced FROM the scrollbar, not the other way around).
+        /// </summary>
+        private void CenterViewOnLine(object textArea, int lineNumber0Based)
+        {
+            try
+            {
+                if (textArea == null) return;
+
+                int firstVisible = lineNumber0Based;
+                var textView = GetProperty(textArea, "TextView");
+                object visibleLineCountObj = textView != null ? GetProperty(textView, "VisibleLineCount") : null;
+                if (visibleLineCountObj is int)
+                {
+                    int visibleLineCount = (int)visibleLineCountObj;
+                    if (visibleLineCount > 0)
+                        firstVisible = Math.Max(0, lineNumber0Based - visibleLineCount / 2);
+                }
+
+                var scrollToMethod = textArea.GetType().GetMethod("ScrollTo", new[] { typeof(int) });
+                scrollToMethod?.Invoke(textArea, new object[] { firstVisible });
             }
             catch { }
         }
@@ -565,15 +663,7 @@ namespace ClarionAssistant.Services
                 SetProperty(caret, "Line", lineNumber - 1); // 0-based internally
                 SetProperty(caret, "Column", 0);
 
-                // Scroll to make the line visible
-                try
-                {
-                    var scrollToMethod = textArea.GetType().GetMethod("ScrollTo",
-                        new[] { typeof(int) });
-                    if (scrollToMethod != null)
-                        scrollToMethod.Invoke(textArea, new object[] { lineNumber - 1 });
-                }
-                catch { }
+                CenterViewOnLine(textArea, lineNumber - 1);
 
                 return true;
             }

--- a/ClarionAssistant/Services/EditorService.cs
+++ b/ClarionAssistant/Services/EditorService.cs
@@ -475,48 +475,26 @@ namespace ClarionAssistant.Services
                 var fileServiceType = sharpDevelopAsm.GetType("ICSharpCode.SharpDevelop.FileService");
                 if (fileServiceType == null) return;
 
-                // Prefer JumpToFilePosition — it opens the file (which restores the last
-                // remembered caret/scroll position via the workbench's memento mechanism)
-                // and then explicitly overrides the caret to the requested line, in one
-                // synchronous call. Calling OpenFile + setting the caret ourselves afterward
-                // raced against that memento restore and lost.
+                // JumpToFilePosition opens the file (which restores the last remembered caret/
+                // scroll position via the workbench's memento mechanism) and then explicitly
+                // overrides the caret to the requested line, in one synchronous call, in the
+                // correct order. Calling OpenFile + setting the caret ourselves afterward raced
+                // against that memento restore and lost.
                 var jumpMethod = fileServiceType.GetMethod("JumpToFilePosition",
                     BindingFlags.Public | BindingFlags.Static, null,
                     new[] { typeof(string), typeof(int), typeof(int) }, null);
+                if (jumpMethod == null) return;
 
-                if (jumpMethod != null)
-                {
-                    // JumpTo takes 0-based line/column in this SharpDevelop version
-                    // (Math.Max(0, ...) internally) — lineNumber here is 1-based.
-                    // A newer SharpDevelop source diff describes IPositionable.JumpTo also centering
-                    // the view itself via a deferred SafeThreadAsyncCall -> CenterViewOn. Tested directly
-                    // against THIS build (2.1.0.2447), including a deliberate 800ms wait before checking:
-                    // no such centering ever happens here — the view stays pinned exactly at the jump
-                    // target. So that behavior either isn't present in this exact build or isn't reachable
-                    // through this call path; we can't rely on it and must center ourselves.
-                    jumpMethod.Invoke(null, new object[] { filePath, lineNumber - 1, 0 });
-                    DeferCenterViewOnLine(lineNumber - 1);
-                    return;
-                }
-
-                // Fallback for versions where JumpToFilePosition isn't found this way.
-                var openFileMethod = fileServiceType.GetMethod("OpenFile",
-                    BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(string) }, null);
-                if (openFileMethod != null)
-                {
-                    openFileMethod.Invoke(null, new object[] { filePath });
-                    if (lineNumber > 0)
-                    {
-                        var textArea = GetActiveTextArea();
-                        if (textArea != null)
-                        {
-                            var caret = GetProperty(textArea, "Caret");
-                            SetProperty(caret, "Line", lineNumber - 1);
-                            SetProperty(caret, "Column", 0);
-                        }
-                        DeferCenterViewOnLine(lineNumber - 1);
-                    }
-                }
+                // JumpTo takes 0-based line/column in this SharpDevelop version
+                // (Math.Max(0, ...) internally) — lineNumber here is 1-based.
+                // A newer SharpDevelop source diff describes IPositionable.JumpTo also centering
+                // the view itself via a deferred SafeThreadAsyncCall -> CenterViewOn. Tested directly
+                // against THIS build (2.1.0.2447), including a deliberate 800ms wait before checking:
+                // no such centering ever happens here — the view stays pinned exactly at the jump
+                // target. So that behavior either isn't present in this exact build or isn't reachable
+                // through this call path; we can't rely on it and must center ourselves.
+                jumpMethod.Invoke(null, new object[] { filePath, lineNumber - 1, 0 });
+                DeferCenterViewOnLine(lineNumber - 1);
             }
             catch { }
         }

--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -1131,21 +1131,31 @@ Use this tool to discover IDE APIs and understand what's available for automatio
             Register(new McpTool
             {
                 Name = "open_file",
-                Description = "Open a file in the Clarion IDE editor and optionally navigate to a specific line number",
+                Description = "Open a file in the Clarion IDE editor and optionally navigate to a specific line number. " +
+                              "If 'line' is omitted entirely, the file opens at whatever position the IDE last remembered for it " +
+                              "(its own memento/reopen behavior) instead of being forced to line 1.",
                 InputSchema = McpJsonRpc.BuildSchema(
                     new Dictionary<string, string>
                     {
                         { "path", "Absolute path to the file to open" },
-                        { "line", "Line number to navigate to (optional, 1-based)" }
+                        { "line", "Line number to navigate to (optional, 1-based). Omit to leave the IDE's remembered last position untouched." }
                     },
                     new[] { "path" }),
                 RequiresUiThread = true,
                 Handler = args =>
                 {
                     string path = McpJsonRpc.GetString(args, "path");
-                    int line = McpJsonRpc.GetInt(args, "line", 1);
                     if (!File.Exists(path))
                         return "Error: file not found: " + path;
+
+                    bool lineProvided = args != null && args.ContainsKey("line") && args["line"] != null;
+                    if (!lineProvided)
+                    {
+                        _editorService.OpenFileOnly(path);
+                        return "Opened " + path;
+                    }
+
+                    int line = McpJsonRpc.GetInt(args, "line", 1);
                     _editorService.NavigateToFileAndLine(path, line);
                     return "Opened " + path + " at line " + line;
                 }


### PR DESCRIPTION
## Summary

When asking claude to open a file on a specific line, it did open the file, but on the wrong line. I asked why, and here are the findings and fix.

`open_file`'s `line` parameter unreliably navigated to the wrong line — it would often land on whatever line the file's tab was last at (its remembered/"memento" caret position), not the requested one. Separately, the target line always landed pinned to the very top of the viewport with no context visible above it.

## Root cause

`NavigateToFileAndLine` opened the file via `FileService.OpenFile(filePath)` and then set the caret itself, by separately resolving the active text area and writing `Caret.Line`/`Caret.Column` directly:

```csharp
openFileMethod.Invoke(null, new object[] { filePath });
var textArea = GetActiveTextArea();
var caret = GetProperty(textArea, "Caret");
SetProperty(caret, "Line", lineNumber - 1);
SetProperty(caret, "Column", 0);
```

This races against the workbench's own memento restore — `WpfWorkbench`/`DefaultWorkbench`'s `ShowView` restores the file's last remembered caret/scroll position as part of opening it, synchronously, as the view is shown. Depending on exact timing/object-reference details, our own explicit caret write could get overwritten by that restore, landing on the remembered line instead of the one actually requested.

## Fix

Switched to `FileService.JumpToFilePosition(fileName, line, column)`, which already performs open + memento-restore + caret-override in the correct internal order (confirmed via live reflection against the running IDE — this build is SharpDevelop 2.1.0.2447 — and via source-history comparison against the public SharpDevelop repo). Note this method takes **0-based** line/column here, unlike the 1-based convention this file otherwise uses (`Math.Max(0, line)` internally) — `NavigateToFileAndLine` still exposes a 1-based API and converts at the call site. No fallback path is kept for older SharpDevelop builds where `JumpToFilePosition` might not be found via reflection — only one build is ever bundled/loaded for this addin, so a fallback for a hypothetical version that isn't actually in use would just be unexercised complexity.

Also fixed, found while testing the above:

- **`open_file`'s `line` parameter now distinguishes "omitted" from "1".** Previously it defaulted to `1` when not supplied, which meant `open_file` with no `line` argument would *always* explicitly jump to line 1 — silently overriding the memento-restored position even when the caller never asked for a specific line. Omitting `line` now opens the file and leaves whatever position the IDE remembers for it untouched (verified caret line *and* scroll position both stay exactly as they were).
- **View centering.** Both `open_file` (with an explicit line) and `go_to_line` used to pin the target line to the very top of the viewport (`ScrollTo(line)`), leaving no context visible above it. Both now compute a centered scroll target from `TextView.VisibleLineCount` and apply it via `TextArea.ScrollTo` (setting `TextView.FirstVisibleLine` directly gets silently overridden — it's a read cache synced from the scrollbar, not the other way around). For a brand-new tab, the text area has no valid `VisibleLineCount` until its layout pass completes, and something else resets an immediate scroll attempt regardless — centering there is deferred via a short (150ms) `Timer` rather than applied synchronously; centering on an already-open tab (e.g. `go_to_line`, or `open_file` on an already-open file) applies immediately with no observed issue.

## Verification

All live-tested against the running Clarion 11.1 IDE (redeployed between rounds):

- `open_file` with no `line`: caret line and scroll position (`TextView.FirstVisibleLine`) both confirmed unchanged from a manually-set position.
- `open_file` with a line, on a file already open: caret lands exactly on the requested line, view centered correctly on first try.
- `open_file` with a line, on a brand-new tab: caret lands exactly on the requested line, view centers correctly after the short deferred delay (confirmed across two different files).
- `go_to_line` on an already-active file: caret and centered scroll both correct.
