### PR TITLE
fix(codegraph): resolve SELF.Member.Method() calls when Member is inherited

### DIFF
--- a/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
@@ -637,6 +637,21 @@ namespace ClarionCodeGraph.Graph
             int totalVarCount = allVarDt.Rows.Count;
             ReportProgress(string.Format("  Loaded {0} variable symbols for reference tracking", totalVarCount));
 
+            // Class name -> immediate parent class name (from parent_name on the class's own
+            // symbol row), used below to walk the inheritance chain when a class data member
+            // is declared on a BASE class but accessed via SELF.Member from a DERIVED class's
+            // method (inherited-member gap: the member is only ever stored as
+            // "<DeclaringClass>.<MemberName>" in variablesByName, never re-keyed per subclass).
+            // Deliberately a separate query from the later "Insert inheritance relationships"
+            // block below (which needs symbol ids, not names) -- not a duplicate to dedupe.
+            var classParentByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var classParentDt = _db.ExecuteQuery(
+                "SELECT name, parent_name FROM symbols WHERE type = 'class' AND parent_name IS NOT NULL");
+            foreach (System.Data.DataRow row in classParentDt.Rows)
+            {
+                classParentByName[row["name"].ToString()] = row["parent_name"].ToString();
+            }
+
             // Program symbols (one per PROGRAM file) own the calls made in the main file's
             // global CODE section. Deliberately kept OUT of symbolNameToId/procNames: the
             // program's name is the file name (e.g. "Worker"), and letting it act as a
@@ -1083,8 +1098,26 @@ namespace ClarionCodeGraph.Graph
                                 }
                                 if (ownerClassName != null)
                                 {
-                                    VariableInfo memberVar;
-                                    if (variablesByName.TryGetValue(ownerClassName + "." + objName, out memberVar))
+                                    // Walk the inheritance chain: try the current class first, then
+                                    // each ancestor in turn, since the member may be declared on a
+                                    // base class rather than the derived class doing the calling.
+                                    // Hop limit guards against bad/cyclic parent_name data.
+                                    VariableInfo memberVar = null;
+                                    string searchClassName = ownerClassName;
+                                    int hops = 0;
+                                    while (searchClassName != null && hops < 25)
+                                    {
+                                        if (variablesByName.TryGetValue(searchClassName + "." + objName, out memberVar))
+                                            break;
+                                        memberVar = null;
+                                        string parentClassName;
+                                        if (!classParentByName.TryGetValue(searchClassName, out parentClassName) ||
+                                            string.Equals(parentClassName, searchClassName, StringComparison.OrdinalIgnoreCase))
+                                            break;
+                                        searchClassName = parentClassName;
+                                        hops++;
+                                    }
+                                    if (memberVar != null)
                                     {
                                         string varTypeName;
                                         if (TryResolveVariableClassType(memberVar.Params, out varTypeName))

--- a/ClarionAssistant/indexer/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/indexer/Graph/CodeGraphIndexer.cs
@@ -633,6 +633,21 @@ namespace ClarionCodeGraph.Graph
             int totalVarCount = allVarDt.Rows.Count;
             ReportProgress(string.Format("  Loaded {0} variable symbols for reference tracking", totalVarCount));
 
+            // Class name -> immediate parent class name (from parent_name on the class's own
+            // symbol row), used below to walk the inheritance chain when a class data member
+            // is declared on a BASE class but accessed via SELF.Member from a DERIVED class's
+            // method (inherited-member gap: the member is only ever stored as
+            // "<DeclaringClass>.<MemberName>" in variablesByName, never re-keyed per subclass).
+            // Deliberately a separate query from the later "Insert inheritance relationships"
+            // block below (which needs symbol ids, not names) -- not a duplicate to dedupe.
+            var classParentByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var classParentDt = _db.ExecuteQuery(
+                "SELECT name, parent_name FROM symbols WHERE type = 'class' AND parent_name IS NOT NULL");
+            foreach (System.Data.DataRow row in classParentDt.Rows)
+            {
+                classParentByName[row["name"].ToString()] = row["parent_name"].ToString();
+            }
+
             // Program symbols (one per PROGRAM file) own the calls made in the main file's
             // global CODE section. Deliberately kept OUT of symbolNameToId/procNames: the
             // program's name is the file name (e.g. "Worker"), and letting it act as a
@@ -1079,8 +1094,26 @@ namespace ClarionCodeGraph.Graph
                                 }
                                 if (ownerClassName != null)
                                 {
-                                    VariableInfo memberVar;
-                                    if (variablesByName.TryGetValue(ownerClassName + "." + objName, out memberVar))
+                                    // Walk the inheritance chain: try the current class first, then
+                                    // each ancestor in turn, since the member may be declared on a
+                                    // base class rather than the derived class doing the calling.
+                                    // Hop limit guards against bad/cyclic parent_name data.
+                                    VariableInfo memberVar = null;
+                                    string searchClassName = ownerClassName;
+                                    int hops = 0;
+                                    while (searchClassName != null && hops < 25)
+                                    {
+                                        if (variablesByName.TryGetValue(searchClassName + "." + objName, out memberVar))
+                                            break;
+                                        memberVar = null;
+                                        string parentClassName;
+                                        if (!classParentByName.TryGetValue(searchClassName, out parentClassName) ||
+                                            string.Equals(parentClassName, searchClassName, StringComparison.OrdinalIgnoreCase))
+                                            break;
+                                        searchClassName = parentClassName;
+                                        hops++;
+                                    }
+                                    if (memberVar != null)
                                     {
                                         string varTypeName;
                                         if (TryResolveVariableClassType(memberVar.Params, out varTypeName))

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -1,11 +1,11 @@
 # CodeGraph parser regression fixture
 
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
-the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92) and the GROUP-typed CLASS-member fix
-(PR #93) — a single compiling Clarion solution whose procedures each exercise one historical
-parser/indexer bug. This is currently the only regression coverage the CodeGraph parser has; run
-it after ANY change to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced
-copy).
+the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92), the GROUP-typed CLASS-member fix
+(PR #93), and the inherited-CLASS-member dotted-call resolution fix (PR TBD) — a single
+compiling Clarion solution whose procedures each exercise one historical parser/indexer bug.
+This is currently the only regression coverage the CodeGraph parser has; run it after ANY change
+to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
 
 ## Run
 
@@ -13,9 +13,10 @@ copy).
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-15 with all #79–#90 fixes applied, plus #92 and #93)
+## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, and the
+inherited-CLASS-member dotted-call resolution fix)
 
-### Callers of `WorkerClass.Sign` — exactly 19 `calls` rows
+### Callers of `WorkerClass.Sign` — exactly 20 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
@@ -24,7 +25,7 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | ParameterTest | 31 | #87 (call through PROCEDURE parameter) |
 | ReturnTest | 40 | baseline (inline RETURN call shape) |
 | OwnerClass.CallViaMember | 51 | #84+#86 (.inc member, cross-file type) |
-| MainHelperProc | 60 | #81 (procedure in main PROGRAM file) |
+| MainHelperProc | 62 | #81 (procedure in main PROGRAM file) |
 | OwnerClass.CallViaCommentedMember | 67 | #85+#86 (trailing-comment member) |
 | CommentedLocalTest | 83 | #85 (trailing-comment DATA local) |
 | GroupBugClass.CallViaAfterGroupMember | 101 | #88 (member after inline GROUP END) |
@@ -38,13 +39,14 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | LocalDerivedClassTest | 254 | #90 (attribution after local CLASS(Parent)) |
 | LikeMemberBugClass.CallViaPlainInstanceMember | 271 | #92 (call through a reference CLASS member, unaffected control) |
 | MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 289 | #93 (member after multi-line GROUP with its own extra field) |
+| DerivedWorkerClass.CallViaInheritedMember | 300 | this PR (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
 
 ### Symbols
 
-- 8 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
+- 10 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
   AfterBugClass (#84: sourced from the `.inc` despite `<None Include>`; #88: the last two
   vanished entirely before the depth-leak fix), LikeMemberBugClass (#92),
-  MultiLineGroupBugClass (#93).
+  MultiLineGroupBugClass (#93), BaseWorkerClass and DerivedWorkerClass (this PR).
 - `LocalDerived` is a **local variable** of LocalDerivedClassTest typed `DERIVABLECLASS` —
   NOT a global class (#90).
 - `pWorker`: `scope='parameter'`, parent `ParameterTest`, params `&WorkerClass` (#87).
@@ -78,6 +80,15 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
   that, `classEndDepth` leaks and every member/class after them vanishes.
   `CallViaAfterMultiLineGroupMember` still appearing in the callers table above proves no leak.
 
+- `BaseWorkerClass.BaseWorker` (`&WorkerClass`, `scope='class'`): declared once, on the BASE
+  class. `DerivedWorkerClass` (`parent_name='BaseWorkerClass'`) never redeclares it. This is
+  distinct from the earlier `OwnerClass.MyWorker` case (#84/#86, a member accessed from a method
+  on the SAME class that declares it) and from the `LocalDerived` case (#90, a class declared
+  and overridden entirely inside one procedure's own DATA section) — here the member and the
+  calling method live on two different, both top-level, `.inc`-declared classes joined only by
+  `CLASS(BaseClass)` inheritance. Proves the dotted-call resolver's class-member fallback walks
+  the `inherits` chain instead of only ever checking the calling method's own class name.
+
 ### Program symbol (#81)
 
 - `Worker` (`type='program'`) has `calls` rows to every procedure invoked from the global
@@ -92,5 +103,5 @@ JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
-OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','GenCertData','SomeHandle','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember','AttrTermGroup','AttrTermGroupPeriod');
+OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','GenCertData','SomeHandle','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember','AttrTermGroup','AttrTermGroupPeriod','BaseWorker');
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
@@ -25,6 +25,7 @@ periodBug    PeriodBugClass
 afterBug     AfterBugClass
 likeMemberBug LikeMemberBugClass
 multiLineGroupBug MultiLineGroupBugClass
+derivedWorker DerivedWorkerClass
 
  CODE
     r# = TestSignatureFlow()
@@ -45,6 +46,7 @@ multiLineGroupBug MultiLineGroupBugClass
     r# = LocalDerivedClassTest()
     r# = likeMemberBug.CallViaPlainInstanceMember()
     r# = multiLineGroupBug.CallViaAfterMultiLineGroupMember()
+    r# = derivedWorker.CallViaInheritedMember()
 
 ! Bug A repro: this procedure is implemented directly in the PROGRAM file itself,
 ! rather than in a MEMBER file. ParseMainFile only scans the file's PROGRAM marker,

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -289,3 +289,15 @@ result   LONG
   result = SELF.AfterMultiLineGroupMember.Sign( 60 )
   RETURN result
 
+! Bug M repro: see WorkerLib.inc for the full root-cause writeup. BaseWorker is declared on
+! BaseWorkerClass; DerivedWorkerClass inherits it without redeclaring it. This method lives on
+! DerivedWorkerClass itself, so the resolver must walk DerivedWorkerClass -> BaseWorkerClass to
+! find BaseWorker's declared type before it can resolve BaseWorker.Sign(...) to WorkerClass.Sign.
+DerivedWorkerClass.CallViaInheritedMember PROCEDURE( )
+result   LONG
+  CODE
+  SELF.BaseWorker &= NEW(WorkerClass)
+  result = SELF.BaseWorker.Sign( 70 )
+  DISPOSE( SELF.BaseWorker )
+  RETURN result
+

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -92,3 +92,24 @@ AttrTermGroupPeriod    GROUP(SmallGroupType),DIM(2).
 AfterMultiLineGroupMember &WorkerClass
 CallViaAfterMultiLineGroupMember PROCEDURE( ), LONG
             END
+
+! Bug M repro (inherited-member gap): BaseWorker is a CLASS data member declared here, on
+! this BASE class, never redeclared on DerivedWorkerClass below. variablesByName only ever
+! stores it as "BaseWorkerClass.BaseWorker" (keyed by the DECLARING class), and the
+! dotted-call resolver's class-member fallback only ever tried "<currentClass>.<objName>" --
+! i.e. "DerivedWorkerClass.BaseWorker" for a call made from DerivedWorkerClass's own method --
+! which never exists, so the lookup silently missed. Expected before the fix:
+! SELF.BaseWorker.Sign(...) in DerivedWorkerClass.CallViaInheritedMember (WorkerLib.clw) is
+! invisible to CodeGraph, even though BaseWorker is a perfectly ordinary inherited member from
+! Clarion's own point of view (the class already compiles and runs correctly). Expected after
+! the fix: the resolver walks the inherits chain (DerivedWorkerClass -> BaseWorkerClass) when
+! the direct same-class lookup misses, and the call resolves.
+BaseWorkerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
+
+BaseWorker    &WorkerClass
+            END
+
+DerivedWorkerClass CLASS(BaseWorkerClass),TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
+
+CallViaInheritedMember PROCEDURE( ), LONG
+            END


### PR DESCRIPTION
## Summary

CodeGraph's "who calls X" resolution missed calls made through an **inherited** CLASS data
member. `SELF.Member.Method(...)` resolved correctly when `Member` was declared on the same
class as the calling method, but silently produced no `calls` relationship at all when `Member`
was declared on a *base* class and the calling method lived on a *derived* class that never
redeclared it — even though the member is a perfectly ordinary, correctly-typed inherited field
from Clarion's own point of view, and the class already compiles and runs fine.

This was found and confirmed against a real production solution, a class member declared on a
base "service" class was accessed via `SELF.<member>` from several methods on a derived
subclass, and none of those calls ever appeared in `relationships`, while sibling calls through a
different, non-inherited member on the same subclass resolved correctly. That asymmetry is what
narrowed this down to inheritance specifically, not a general dotted-call regression.

## Root cause

`ResolveRelationships`'s dotted-call resolver (`CodeGraph/Graph/CodeGraphIndexer.cs` /
`indexer/Graph/CodeGraphIndexer.cs`, the "Detect dotted method calls" block) has a fallback path
for `SELF.Member.Method(...)` when `Member` isn't a local/module variable in the current file: it
derives the *current* class (the class that owns the procedure being scanned) and looks up
`variablesByName["<CurrentClass>.<Member>"]`.

This was already a known, explicitly documented limitation from an earlier fix (the one that
introduced this fallback path in the first place): *"this does not walk the inherits chain. A
member declared in a base class and accessed via SELF. in a subclass method still won't
resolve... out of scope for this fix."* This PR closes exactly that gap.

Concretely: if `DerivedClass CLASS(BaseClass)` doesn't redeclare `Member`, then
`variablesByName` only ever has the key `"BaseClass.Member"` — never `"DerivedClass.Member"` —
so the direct lookup always misses for any method implemented on `DerivedClass` itself. The
member's type is silently never resolved, `lookupOwner` falls back to the literal token
(`"Member"`), the final symbol lookup fails too, and the call disappears with no error or trace.

The class-to-parent-class data needed to fix this was already present and already correct
(`symbols.parent_name` on `type='class'` rows, populated from parsing `CLASS(ParentClass)` —
already used elsewhere in the same file to build `inherits` relationships) — it just wasn't
consulted by this specific resolution path.

## Fix

- Added a `classParentByName` dictionary (class name → immediate parent class name), built once
  from `SELECT name, parent_name FROM symbols WHERE type = 'class' AND parent_name IS NOT NULL`,
  loaded early alongside the existing `variablesByName` index.
- In the class-member fallback: instead of a single lookup against the current class, walk the
  chain — try the current class first, then each ancestor in turn via `classParentByName`, until
  the member is found or the chain is exhausted. A hop limit (25) guards against bad/cyclic
  `parent_name` data; the self-reference check (`parent == current`) catches the trivial cycle
  case directly.
- The non-inherited case is unchanged: the first loop iteration is identical to the old single
  lookup, so existing resolution behavior for members declared directly on the calling class is
  untouched.
- Applied identically to both synced copies of `CodeGraphIndexer.cs`
  (`CodeGraph/Graph/` and `indexer/Graph/`).

## Minimal reproduction

Extended the shared `test-fixtures/codegraph-repro/` fixture with `BaseWorkerClass` (declares
`BaseWorker &WorkerClass`) and `DerivedWorkerClass CLASS(BaseWorkerClass)` (does not redeclare
it), plus a new method on the derived class:

```clarion
BaseWorkerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )

BaseWorker    &WorkerClass
            END

DerivedWorkerClass CLASS(BaseWorkerClass),TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )

CallViaInheritedMember PROCEDURE( ), LONG
            END
```

```clarion
DerivedWorkerClass.CallViaInheritedMember PROCEDURE( )
result   LONG
  CODE
  SELF.BaseWorker &= NEW(WorkerClass)
  result = SELF.BaseWorker.Sign( 70 )
  DISPOSE( SELF.BaseWorker )
  RETURN result
```

**Before this fix**: `BaseWorkerClass.BaseWorker` exists as a correctly-typed member symbol
(proving the member itself is parsed fine), yet `relationships` has zero `calls` rows from
`DerivedWorkerClass.CallViaInheritedMember` to `WorkerClass.Sign`.

**After this fix** (verified via the standalone `clarion-indexer.exe`): the call resolves
correctly. Total confirmed callers of `WorkerClass.Sign` in the repro: **20** (up from 19),
covering every prior fixture case plus this one.

**Regression-checked**: all 19 pre-existing callers in the fixture still resolve exactly as
before — including calls through non-inherited members (e.g. `OwnerClass.MyWorker`) and the
unrelated procedure-local-derived-class case (`LocalDerived`, a different construct: a class
declared and overridden entirely inside one procedure's own DATA section, not an `.inc`-level
`CLASS(Parent)` relationship between two top-level classes).

**Also verified against the real production solution** — the original motivating case: multiple
previously-invisible `SELF.<member>.<Method>(...)` call sites through an inherited member,
spanning several methods on one subclass, all now resolve correctly, with zero change to
previously-working calls through non-inherited members on the same class.

## Scope note

A second, independent gap was found in the same investigation and is **not** addressed by this
PR: a call through a directly-declared (non-inherited) member can still fail to resolve if the
*called method's name* is itself identical across multiple unrelated classes (e.g. `Open`/`Close`
implemented the same way on several different classes) — the resolver picks a name-based target
without disambiguating by the member's actual declared type in that case. That failure occurs
independently of inheritance (reproduces even through a uniquely-named, directly-declared member)
and needs a separate fix in the final symbol-name lookup, not the class-member type-resolution
fallback this PR changes.
