### PR TITLE
feat(embeditor): open Find-All results in an editor tab — context, click-through, filtering (#113)

### DIFF
--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -1974,6 +1974,7 @@ namespace ClarionAssistant
             }
             Terminal.DiffViewContent.ApplyThemeToAll(_isDarkTheme);
             Terminal.MonacoDiffViewContent.ApplyThemeToAll(_isDarkTheme);
+            Terminal.SearchResultsViewContent.ApplyThemeToAll(_isDarkTheme);
             _diffService?.SetTheme(_isDarkTheme);
         }
 

--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Terminal\TabManager.cs" />
     <Compile Include="Terminal\DiffViewContent.cs" />
     <Compile Include="Terminal\MonacoDiffViewContent.cs" />
+    <Compile Include="Terminal\SearchResultsViewContent.cs" />
     <Compile Include="Terminal\NativeDiffViewContent.cs" />
     <Compile Include="Terminal\ModernEmbeditorViewContent.cs" />
     <Compile Include="Terminal\MonacoEditorControl.cs" />
@@ -242,6 +243,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Terminal\monaco-diff.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Terminal\search-results.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Terminal\monaco-embeditor.html">

--- a/ClarionAssistant/Services/CaFindBroker.cs
+++ b/ClarionAssistant/Services/CaFindBroker.cs
@@ -116,6 +116,20 @@ namespace ClarionAssistant.Services
             try
             {
                 if (action == "caFindActivity") { NotifyActivity(host); return; }
+                if (action == "caFindOpenDoc")
+                {
+                    // "Open results in editor": the page has already built the full payload (matches +
+                    // context lines) from the engine's findResults. This never reaches the pad — it opens
+                    // a SearchResultsViewContent TAB instead. Both surfaces route here: the overlay's
+                    // button posts it directly, the pad's button forwards caFind op:'openInDoc' which the
+                    // engine turns into this same post. The origin editor's KEY is stamped into the view so
+                    // its row clicks come back to THIS buffer, not whatever is active later (see ForwardTo).
+                    HostEntry oe;
+                    lock (_lock) { oe = FindLocked(host); }
+                    if (oe == null) return;
+                    Terminal.SearchResultsViewContent.ShowFor(SafeKey(oe), SafeCall(oe.Title), oe.Kind, rawJson);
+                    return;
+                }
                 if (action == "caFindOpen")
                 {
                     NotifyActivity(host);
@@ -157,6 +171,45 @@ namespace ClarionAssistant.Services
                 return true;
             }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[CaFindBroker] FromPad: " + ex.Message); return false; }
+        }
+
+        /// <summary>
+        /// Post a page-bound message to a SPECIFIC host by session key, regardless of what is active.
+        ///
+        /// This is deliberately NOT <see cref="FromPad"/>. The pad follows focus, so posting to _active is
+        /// correct for it. A search-results TAB is the opposite: it is a snapshot of one search against one
+        /// buffer, so its row clicks must reveal in the editor it was opened FROM. Routing those through
+        /// _active would reveal match #7 of the embeditor's search inside whatever file the user happened to
+        /// click into afterwards. Returns false when that editor is gone (its tab was closed) — callers
+        /// surface that as a stale/orphaned results tab rather than silently doing nothing.
+        /// </summary>
+        public static bool ForwardTo(string key, string json)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(json)) return false;
+                HostEntry target = null;
+                lock (_lock)
+                {
+                    // Newest-first, skipping disposed controls. A session key is NOT unique over time: close and
+                    // re-open the same procedure's embed and you get a second live host under the same
+                    // "embed::<proc>" key. Taking the first forward match would hand back whichever registered
+                    // EARLIEST — i.e. the one most likely to be dead. Registration order is our recency proxy;
+                    // the IsDisposed test is the belt to that braces, since a host whose teardown path forgets to
+                    // unregister would otherwise swallow traffic silently forever.
+                    for (int i = _hosts.Count - 1; i >= 0; i--)
+                    {
+                        var h = _hosts[i];
+                        if (!string.Equals(SafeKey(h), key, StringComparison.OrdinalIgnoreCase)) continue;
+                        if (h.Control == null || h.Control.IsDisposed) continue;
+                        target = h; break;
+                    }
+                }
+                if (target == null || target.Control == null) return false;
+                target.Control.PostJson(json);
+                return true;
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[CaFindBroker] ForwardTo: " + ex.Message); return false; }
         }
 
         /// <summary>Tell the pad which editor it is targeting now (key=null -> idle). Sent on activity

--- a/ClarionAssistant/Services/ShutdownService.cs
+++ b/ClarionAssistant/Services/ShutdownService.cs
@@ -116,6 +116,7 @@ namespace ClarionAssistant.Services
             DisposeWebView2("embeditor", ModernEmbeditorViewContent.DisposeAllForShutdown);
             DisposeWebView2("diff", DiffViewContent.DisposeAllForShutdown);
             DisposeWebView2("monaco diff", MonacoDiffViewContent.DisposeAllForShutdown);
+            DisposeWebView2("search results", SearchResultsViewContent.DisposeAllForShutdown);   // Find-All results tab
             DisposeWebView2("board", TaskLifecycleBoardForm.DisposeAllForShutdown);
             DisposeWebView2("data pad", ModernDataPad.DisposeAllForShutdown);   // Explorer pad (GAP 2)
             DisposeWebView2("find pad", CaFindPad.DisposeAllForShutdown);       // CA Find/Replace pad (#66)

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -830,6 +830,55 @@ namespace ClarionAssistant.Terminal
             _panel?.GotoRoutine(name);
         }
 
+        /// <summary>
+        /// Raise the workbench TAB this embed session actually lives in, for this procedure. Returns true if a
+        /// session was found.
+        ///
+        /// Distinct from <see cref="TryFocusExisting"/> on purpose. That one ends in BringToFront, which in
+        /// OVERLAY mode only re-asserts Monaco's z-order inside the native embeditor's host panel — correct when
+        /// the embed document is already the foreground tab (its original caller is the save path), useless to a
+        /// caller sitting on a DIFFERENT document, who sees nothing happen. Search results are exactly that
+        /// caller: the user is on the results tab and expects the click to take them to the code.
+        /// </summary>
+        public static bool TryFocusOwningTab(string procName)
+        {
+            if (string.IsNullOrWhiteSpace(procName)) return false;
+            ModernEmbeditorViewContent found = null;
+            lock (_instances)
+            {
+                foreach (var inst in _instances)
+                    if (string.Equals(inst._procedureName, procName, StringComparison.OrdinalIgnoreCase)) { found = inst; break; }
+            }
+            if (found == null) return false;
+            found.FocusOwningTab();
+            return true;
+        }
+
+        /// <summary>Raise whichever tab owns this session: our own view content in tab mode, or the NATIVE gen
+        /// editor we are docked over in overlay mode (we aren't a tab at all there).</summary>
+        private void FocusOwningTab()
+        {
+            // Tab mode: our own view IS the tab, and BringToFront already defers the SelectWindow safely.
+            if (!_embedOverlay) { BringToFront(); return; }
+
+            var ed = _overlayGenEditor;
+            if (ed == null) { BringToFront(); return; }   // nothing better available — z-order at least
+            Action raise = () =>
+            {
+                try
+                {
+                    var ww = ed.GetType().GetProperty("WorkbenchWindow")?.GetValue(ed, null);
+                    if (ww != null) ww.GetType().GetMethod("SelectWindow", Type.EmptyTypes)?.Invoke(ww, null);
+                    try { if (_panel != null) _panel.BringToFront(); } catch { }   // Monaco back on top inside that host
+                }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] FocusOwningTab: " + ex.Message); }
+            };
+            // Same deferral posture as BringToFront: re-activating a WebView2-bearing document synchronously on a
+            // reentrant stack is the deadlock we guard against everywhere else here.
+            var ctx = System.Threading.SynchronizationContext.Current;
+            if (ctx != null) ctx.Post(_ => raise(), null); else raise();
+        }
+
         /// <summary>If a Modern Embeditor tab for this procedure is already open, focus it. Returns true if found.</summary>
         public static bool TryFocusExisting(string procName)
         {
@@ -2248,6 +2297,13 @@ namespace ClarionAssistant.Terminal
             if (_overlayDetached) return;
             _overlayDetached = true;
             UnhookOverlayTeardown();
+            // Overlay mode is never ShowView'd, so the workbench never calls our Dispose() — this IS the
+            // teardown. Without unregistering here, the broker keeps a DEAD entry under this session's key
+            // (embed::<proc>) forever; re-opening the same procedure then registers a second, live entry
+            // under the SAME key and any key-based lookup can pick the corpse and post into a disposed
+            // control. FromPad never saw it (it routes via _active, which focus refreshes), but the search
+            // results tab routes by key and lands on the dead one — click does nothing. (#66 / results tab)
+            try { Services.CaFindBroker.UnregisterHost(this); } catch { }
             RestoreNativeChrome();
             RemoveOverlayCover();
             try

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -118,9 +118,11 @@ namespace ClarionAssistant.Terminal
         /// <summary>{action:"activateDesigner"} — 'Show designer' on the modal lock overlay.</summary>
         void OnActivateDesigner(MonacoEditorControl editor);
 
-        /// <summary>{action:"caFindUpdate"|"caFindOpen"|"caFindActivity"} — CA Find pad protocol
-        /// (GitHub #66): results push / Ctrl+F open request / editor-focus activity. Hosts forward to
-        /// <c>CaFindBroker.FromEditor</c> with their own identity; the broker routes to the pad.</summary>
+        /// <summary>{action:"caFindUpdate"|"caFindOpen"|"caFindOpenDoc"|"caFindActivity"} — CA Find pad
+        /// protocol (GitHub #66): results push / Ctrl+F open request / open-results-in-editor / editor-focus
+        /// activity. Hosts forward to <c>CaFindBroker.FromEditor</c> with their own identity; the broker
+        /// routes to the pad — except caFindOpenDoc, which it turns into a SearchResultsViewContent tab
+        /// stamped with the sending host's key. Hosts stay identical for all four; no per-host logic.</summary>
         void OnCaFind(MonacoEditorControl editor, string action, string rawJson);
 
         /// <summary>Navigation to the Monaco page completed (IsSuccess). Optional liveness hook.</summary>
@@ -280,6 +282,7 @@ namespace ClarionAssistant.Terminal
                     case "activateDesigner":  h.OnActivateDesigner(this); break;
                     case "caFindUpdate":
                     case "caFindOpen":
+                    case "caFindOpenDoc":
                     case "caFindActivity":    h.OnCaFind(this, action, json); break;
                     default:                  h.OnUnknownAction(this, action, json); break;
                 }

--- a/ClarionAssistant/Terminal/SearchResultsViewContent.cs
+++ b/ClarionAssistant/Terminal/SearchResultsViewContent.cs
@@ -1,0 +1,443 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Windows.Forms;
+using ICSharpCode.SharpDevelop.Gui;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+
+namespace ClarionAssistant.Terminal
+{
+    /// <summary>
+    /// "Open search results in editor" — a read-only TAB listing every match of one Find-All, with context
+    /// lines around each hit and click-through back to the source (VS Code's search editor).
+    ///
+    /// A TAB, not a pad, on purpose: the IDE's docking layer (WeifenLuo DockPanel Suite v1, vendored into
+    /// this SharpDevelop fork) misplaces its dock guides whenever a monitor sits above or left of the
+    /// primary, so anything pad-shaped is unusable on those setups. An editor tab never touches that code.
+    ///
+    /// This view holds NO position state. Rows carry the engine's array index and nothing else; a click
+    /// forwards {op:'reveal', idx} to the ORIGIN editor page, which resolves the index against its live
+    /// Monaco decorations (syncFindMatches, #65). That is exactly how the CA Find pad works, and it is why
+    /// buffer edits can't make this tab point at the wrong line: the numbers shown may age, but navigation
+    /// always goes through the engine's tracked decorations.
+    ///
+    /// Lifecycle mirrors MonacoDiffViewContent: shared WebView2 env cache, per-instance virtual-host temp
+    /// folder for the payload (it can be MBs), ready-handshake send, UI-thread shutdown disposal.
+    /// </summary>
+    public class SearchResultsViewContent : AbstractViewContent
+    {
+        private Panel _panel;
+        private WebView2 _webView;
+        private bool _isInitialized;
+        private bool _isInitializing;
+
+        private string _originKey;     // CaFindBroker session key of the editor this search ran against
+        private string _originTitle;
+        private string _originKind;    // "CA Editor" | "CA Embeditor"
+        private string _payloadJson;   // the page's caFindOpenDoc message, verbatim
+        private string _query;
+        private bool _isDark = true;
+
+        private string _tempDir;
+        private const string VIRTUAL_HOST = "clarion-search-results-data";
+
+        private static readonly List<SearchResultsViewContent> _instances = new List<SearchResultsViewContent>();
+
+        public override Control Control { get { return _panel; } }
+
+        /// <summary>
+        /// Open (or refresh) the results tab for a search. Reuses the tab already showing results for the
+        /// same origin editor rather than stacking a new one per Find-All — re-running a search in the same
+        /// buffer should update the view you're looking at. Deferred onto a clean turn: constructing a
+        /// WebView2 on a reentrant/DoEvents-pumped stack hard-hangs the IDE (see ModernEmbeditorLauncher).
+        /// </summary>
+        public static void ShowFor(string originKey, string originTitle, string originKind, string payloadJson)
+        {
+            try
+            {
+                var ctx = System.Threading.SynchronizationContext.Current;
+                Action open = () =>
+                {
+                    try
+                    {
+                        var existing = FindByOrigin(originKey);
+                        if (existing != null) { existing.SetResults(payloadJson); existing.BringToFront(); return; }
+
+                        var view = new SearchResultsViewContent(originKey, originTitle, originKind, payloadJson);
+                        WorkbenchSingleton.Workbench.ShowView(view);
+                    }
+                    catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SearchResults] ShowFor(open): " + ex.Message); }
+                };
+                if (ctx != null) ctx.Post(_ => open(), null); else open();
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SearchResults] ShowFor: " + ex.Message); }
+        }
+
+        private static SearchResultsViewContent FindByOrigin(string originKey)
+        {
+            lock (_instances)
+            {
+                foreach (var inst in _instances)
+                    if (string.Equals(inst._originKey, originKey, StringComparison.OrdinalIgnoreCase)) return inst;
+            }
+            return null;
+        }
+
+        private SearchResultsViewContent(string originKey, string originTitle, string originKind, string payloadJson)
+        {
+            _originKey = originKey ?? "";
+            _originTitle = originTitle ?? "";
+            _originKind = originKind ?? "";
+            _payloadJson = payloadJson ?? "{}";
+            _query = ExtractJsonValue(_payloadJson, "query") ?? "";
+            // Default dark like every other WebView2 view here; there is no static "is dark" query in this
+            // codebase — theme arrives by broadcast (AssistantChatControl -> ApplyThemeToAll) and corrects us.
+            TitleName = BuildTitle();
+            // No Save()/SaveAs() here — without this, SharpDevelop treats it as a normal saveable
+            // filename-less document (enables Save, then throws when invoked). Same as MonacoDiffViewContent.
+            IsViewOnly = true;
+
+            _panel = new Panel { Dock = DockStyle.Fill, BackColor = Color.FromArgb(30, 30, 46) };
+            _webView = new WebView2 { Dock = DockStyle.Fill };
+            _panel.Controls.Add(_webView);
+
+            lock (_instances) { _instances.Add(this); }
+            _panel.HandleCreated += OnHandleCreated;
+        }
+
+        private string BuildTitle()
+        {
+            string q = _query;
+            if (string.IsNullOrEmpty(q)) q = "(no query)";
+            if (q.Length > 24) q = q.Substring(0, 24) + "…";
+            return "Search: " + q;
+        }
+
+        private async void OnHandleCreated(object sender, EventArgs e)
+        {
+            if (_isInitializing || _isInitialized) return;
+            _isInitializing = true;
+
+            try
+            {
+                var environment = await WebView2EnvironmentCache.GetEnvironmentAsync();
+                await _webView.EnsureCoreWebView2Async(environment);
+
+                _tempDir = Path.Combine(Path.GetTempPath(), "ClarionSearchResults_" + Guid.NewGuid().ToString("N").Substring(0, 8));
+                Directory.CreateDirectory(_tempDir);
+                _webView.CoreWebView2.SetVirtualHostNameToFolderMapping(
+                    VIRTUAL_HOST, _tempDir, CoreWebView2HostResourceAccessKind.Allow);
+
+                var settings = _webView.CoreWebView2.Settings;
+                settings.IsScriptEnabled = true;
+                settings.AreDefaultContextMenusEnabled = false;
+                settings.AreDevToolsEnabled = true;
+                settings.IsStatusBarEnabled = false;
+                settings.IsZoomControlEnabled = false;
+
+                _webView.CoreWebView2.WebMessageReceived += OnWebMessageReceived;
+                _webView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+
+                string htmlPath = GetHtmlPath();
+                if (File.Exists(htmlPath))
+                {
+                    // Same ?v= mtime cache-bust + AbsoluteUri caveat as MonacoDiffViewContent: safe because
+                    // this page resolves no relative resources (payload arrives over the virtual host).
+                    _webView.CoreWebView2.Navigate(new Uri(htmlPath).AbsoluteUri + "?v=" + File.GetLastWriteTimeUtc(htmlPath).Ticks);
+                }
+            }
+            catch (Exception ex)
+            {
+                _isInitializing = false; // allow retry
+                System.Diagnostics.Debug.WriteLine("[SearchResults] Init error: " + ex.Message);
+            }
+        }
+
+        private void OnNavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+        {
+            _isInitialized = e.IsSuccess;
+            _isInitializing = false;
+            // SendResults is driven by the page's "ready" message, not here (avoids the double-send).
+        }
+
+        private void OnWebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)
+        {
+            try
+            {
+                string json = e.TryGetWebMessageAsString();
+                if (json == null || json.Length > 1024 * 1024) return;   // cap inbound, same posture as CaFindPad
+                string action = ExtractJsonValue(json, "action");
+
+                if (action == "ready") { SendResults(); return; }
+
+                if (action == "reveal") { HandleReveal(json); return; }
+
+                if (action == "clipboard")
+                {
+                    // file:// pages can't reach the clipboard themselves — same host-side hop the other views use.
+                    string text = ExtractJsonValue(json, "text") ?? "";
+                    try { if (text.Length > 0) Clipboard.SetText(text); } catch { }
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[SearchResults] Message error: " + ex.Message);
+            }
+        }
+
+        // The origin is a PWEE embed session when its broker key is "embed::<proc>"; anything else is a file
+        // path. Note this is NOT the same test as originKind — a ModernEmbeditorViewContent in FILE mode
+        // registers as kind "CA Editor" with a path key, so the KEY is the honest discriminator.
+        private bool IsEmbedOrigin
+        {
+            get { return _originKey != null && _originKey.StartsWith("embed::", StringComparison.OrdinalIgnoreCase); }
+        }
+
+        private string OriginProcName
+        {
+            get { return IsEmbedOrigin ? _originKey.Substring("embed::".Length) : null; }
+        }
+
+        /// <summary>
+        /// A row was clicked. Three outcomes, in order of fidelity:
+        ///
+        /// 1. Origin editor is open  -> the engine reveals from its LIVE decorations (correct even after the
+        ///    buffer has been edited), and we raise its tab, because the user is looking at THIS one.
+        /// 2. Origin was a PWEE embeditor and it's closed -> nothing to reveal into. PWEE sessions are driven
+        ///    through the app tree and a re-open regenerates the view, so we don't try to be clever: say so.
+        /// 3. Origin was a source file and its tab is closed -> recoverable. SharpDevelop's OpenFile focuses an
+        ///    open tab or opens a closed one, and we navigate by the line/col recorded when the search ran.
+        ///    That's a snapshot rather than a tracked decoration — right unless the file changed on disk since.
+        /// </summary>
+        private void HandleReveal(string json)
+        {
+            // The page builds the complete caFind message (idx + the snapshot coords + the search identity
+            // that produced this document) and we forward it verbatim — the pad's 'fwd' pattern. The engine
+            // decides whether idx is still meaningful; only IT knows what search it is currently holding.
+            string fwd = ExtractJsonValue(json, "fwd");
+            if (string.IsNullOrEmpty(fwd)) return;
+
+            // Routed by ORIGIN KEY, never to the active editor: this tab belongs to the buffer it was opened
+            // from, so a click must not follow whatever the user happened to focus since.
+            bool live = ClarionAssistant.Services.CaFindBroker.ForwardTo(_originKey, fwd);
+            if (live) { FocusOrigin(); return; }
+
+            if (IsEmbedOrigin)
+            {
+                PostToPage("{\"type\":\"originGone\",\"kind\":\"embed\",\"name\":"
+                           + MonacoEditorControl.JsonString(OriginProcName ?? "") + "}");
+                return;
+            }
+
+            int line, col;
+            int.TryParse(ExtractJsonValue(json, "line"), out line);
+            if (!int.TryParse(ExtractJsonValue(json, "col"), out col) || col < 1) col = 1;
+            if (line > 0 && ClarionAssistant.Services.MonacoSourceNavigator.NavigateToFileAndLine(_originKey, line, col))
+                return;
+
+            PostToPage("{\"type\":\"originGone\",\"kind\":\"file\",\"name\":"
+                       + MonacoEditorControl.JsonString(_originKey ?? "") + "}");
+        }
+
+        /// <summary>Raise the origin editor's tab. Clicking a result should take you to the code — leaving the
+        /// user on the results tab while the reveal happens invisibly behind it reads as a dead click.</summary>
+        private void FocusOrigin()
+        {
+            try
+            {
+                // TryFocusOwningTab, NOT TryFocusExisting: in overlay mode the CA Embeditor is a Monaco panel
+                // docked over the NATIVE embeditor rather than a tab of its own, so the tab that needs raising
+                // is the native gen editor's. TryFocusExisting would only re-assert z-order inside a host that
+                // isn't the foreground document — reveal lands correctly but the user never sees it.
+                if (IsEmbedOrigin) { ModernEmbeditorViewContent.TryFocusOwningTab(OriginProcName); return; }
+                // File-backed: OpenFile on an already-open file focuses its tab (SharpDevelop semantics).
+                // The engine's reveal is already in flight; this only brings the tab forward.
+                ICSharpCode.SharpDevelop.FileService.OpenFile(_originKey);
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SearchResults] FocusOrigin: " + ex.Message); }
+        }
+
+        /// <summary>Replace this tab's content with a fresh search (same origin editor).</summary>
+        public void SetResults(string payloadJson)
+        {
+            _payloadJson = payloadJson ?? "{}";
+            _query = ExtractJsonValue(_payloadJson, "query") ?? "";
+            TitleName = BuildTitle();
+            if (_isInitialized) SendResults();
+        }
+
+        private void SendResults()
+        {
+            if (_webView == null || _webView.CoreWebView2 == null) return;
+            try
+            {
+                // The payload carries every match plus its context lines — easily MBs on a broad search, so
+                // it goes over the virtual host as a file rather than through PostWebMessageAsJson.
+                string file = Path.Combine(_tempDir, "results.json");
+                File.WriteAllText(file, _payloadJson ?? "{}", new UTF8Encoding(false));
+
+                string json = "{\"type\":\"setResults\"," +
+                    "\"resultsUrl\":\"https://" + VIRTUAL_HOST + "/results.json?v=" + DateTime.UtcNow.Ticks + "\"," +
+                    "\"originTitle\":" + MonacoEditorControl.JsonString(_originTitle) + "," +
+                    "\"originKind\":" + MonacoEditorControl.JsonString(_originKind) + "," +
+                    "\"isDark\":" + (_isDark ? "true" : "false") + "}";
+                _webView.CoreWebView2.PostWebMessageAsJson(json);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[SearchResults] SendResults error: " + ex.Message);
+            }
+        }
+
+        private void PostToPage(string json)
+        {
+            try { if (_webView != null && _webView.CoreWebView2 != null) _webView.CoreWebView2.PostWebMessageAsJson(json); }
+            catch { }
+        }
+
+        /// <summary>Raise this tab. Deferred: synchronously re-activating a WebView2 tab on a reentrant
+        /// stack risks a focus deadlock (same reasoning as ModernEmbeditorViewContent.BringToFront).</summary>
+        public void BringToFront()
+        {
+            try
+            {
+                var ctx = System.Threading.SynchronizationContext.Current;
+                Action raise = () =>
+                {
+                    try
+                    {
+                        var ww = this.WorkbenchWindow;
+                        if (ww == null) return;
+                        var m = ww.GetType().GetMethod("SelectWindow");
+                        if (m != null) m.Invoke(ww, null);
+                    }
+                    catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SearchResults] BringToFront(raise): " + ex.Message); }
+                };
+                if (ctx != null) ctx.Post(_ => raise(), null); else raise();
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SearchResults] BringToFront: " + ex.Message); }
+        }
+
+        private string GetHtmlPath()
+        {
+            string assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string path = Path.Combine(assemblyDir, "Terminal", "search-results.html");
+            if (File.Exists(path)) return path;
+            path = Path.Combine(assemblyDir, "search-results.html");
+            if (File.Exists(path)) return path;
+            return Path.Combine(assemblyDir, "Terminal", "search-results.html");
+        }
+
+        /// <summary>Apply light or dark theme to this results tab.</summary>
+        public void ApplyTheme(bool isDark)
+        {
+            _isDark = isDark;
+            if (_panel != null)
+                _panel.BackColor = isDark ? Color.FromArgb(30, 30, 46) : Color.FromArgb(239, 241, 245);
+            if (_isInitialized) PostToPage("{\"type\":\"applyTheme\",\"isDark\":" + (isDark ? "true" : "false") + "}");
+        }
+
+        /// <summary>Apply theme to every open results tab.</summary>
+        public static void ApplyThemeToAll(bool isDark)
+        {
+            List<SearchResultsViewContent> snapshot;
+            lock (_instances) { snapshot = new List<SearchResultsViewContent>(_instances); }
+            foreach (var inst in snapshot) { try { inst.ApplyTheme(isDark); } catch { } }
+        }
+
+        public override void Dispose()
+        {
+            lock (_instances) { _instances.Remove(this); }
+            if (_webView != null) { _webView.Dispose(); _webView = null; }
+            if (_panel != null) { _panel.Dispose(); _panel = null; }
+            CleanupTempDir();
+            base.Dispose();
+        }
+
+        /// <summary>Shutdown hook: dispose every open results tab's WebView2 on the UI thread before native
+        /// IDE teardown, to avoid the WebView2 &lt;-&gt; native focus deadlock. Idempotent + best-effort.</summary>
+        public static void DisposeAllForShutdown()
+        {
+            List<SearchResultsViewContent> snapshot;
+            lock (_instances) { snapshot = new List<SearchResultsViewContent>(_instances); }
+            foreach (var inst in snapshot) { try { inst.Dispose(); } catch { } }
+        }
+
+        private void CleanupTempDir()
+        {
+            if (_tempDir != null && Directory.Exists(_tempDir))
+            {
+                try { Directory.Delete(_tempDir, true); } catch { }
+                _tempDir = null;
+            }
+        }
+
+        private static string ExtractJsonValue(string json, string key)
+        {
+            if (string.IsNullOrEmpty(json)) return null;
+            string search = "\"" + key + "\":";
+            int idx = json.IndexOf(search, StringComparison.Ordinal);
+            if (idx < 0) return null;
+            idx += search.Length;
+            while (idx < json.Length && json[idx] == ' ') idx++;
+            if (idx >= json.Length) return null;
+            if (json[idx] == 'n') return null;
+            if (json[idx] == '{')
+            {
+                // Balanced-brace object scan (string-aware), same as CaFindPad's: lets the PAGE build the
+                // complete editor-bound message and us forward it verbatim, instead of rebuilding nested
+                // opts JSON by hand out here.
+                int depth = 0; bool inStr = false;
+                for (int i = idx; i < json.Length; i++)
+                {
+                    char c = json[i];
+                    if (inStr)
+                    {
+                        if (c == '\\') { i++; continue; }
+                        if (c == '"') inStr = false;
+                        continue;
+                    }
+                    if (c == '"') { inStr = true; continue; }
+                    if (c == '{') depth++;
+                    else if (c == '}')
+                    {
+                        depth--;
+                        if (depth == 0) return json.Substring(idx, i - idx + 1);
+                    }
+                }
+                return null;
+            }
+            if (json[idx] == '"')
+            {
+                idx++;
+                var sb = new StringBuilder();
+                while (idx < json.Length)
+                {
+                    char c = json[idx];
+                    if (c == '\\' && idx + 1 < json.Length)
+                    {
+                        char next = json[idx + 1];
+                        if (next == '"') { sb.Append('"'); idx += 2; continue; }
+                        if (next == '\\') { sb.Append('\\'); idx += 2; continue; }
+                        if (next == 'n') { sb.Append('\n'); idx += 2; continue; }
+                        if (next == 'r') { sb.Append('\r'); idx += 2; continue; }
+                        if (next == 't') { sb.Append('\t'); idx += 2; continue; }
+                        sb.Append(c); idx++; continue;
+                    }
+                    if (c == '"') break;
+                    sb.Append(c);
+                    idx++;
+                }
+                return sb.ToString();
+            }
+            int start = idx;
+            while (idx < json.Length && json[idx] != ',' && json[idx] != '}') idx++;
+            return json.Substring(start, idx - start).Trim();
+        }
+    }
+}

--- a/ClarionAssistant/Terminal/ca-find.html
+++ b/ClarionAssistant/Terminal/ca-find.html
@@ -188,6 +188,7 @@
         <span class="find-link" id="selAll" title="Check every replaceable row">&#9638; Select All</span>
         <span class="find-link" id="selNone" title="Uncheck every row">&#9634; Select None</span>
         <span class="find-spacer" style="flex:1"></span>
+        <span class="find-link" id="openInDoc" title="Open all results in an editor tab, with context">&#8663; Open in editor</span>
         <span class="find-link" id="copyRes" title="Copy checked rows (or all if none checked)">&#10697; Copy</span>
         <span class="find-link" id="clearRes" title="Clear results">&#129529; Clear results</span>
     </div>
@@ -483,6 +484,14 @@
         matches = []; currentIdx = -1; lastQuery = null; lastOpts = null;
         renderResults(); byId('findCount').textContent = '';
         fwd({ type: 'caFind', op: 'clear' });
+    }
+
+    // "Open in editor": the pad holds no context lines and no model, so it cannot build the results
+    // document itself — it asks the engine, which posts caFindOpenDoc to ITS host. Same path the overlay
+    // takes, so the tab is identical from either surface (and lands on the right editor either way).
+    function openResultsInDoc() {
+        if (!matches.length) { showToast('No results to open — run a search first', false); return; }
+        fwd({ type: 'caFind', op: 'openInDoc' });
     }
 
     // ───────────────────────────── Tabs ─────────────────────────────
@@ -789,6 +798,7 @@
         byId('replAll').addEventListener('click', function () { doReplace(false); });
         byId('selAll').addEventListener('click', function () { setAllChecked(true); });
         byId('selNone').addEventListener('click', function () { setAllChecked(false); });
+        byId('openInDoc').addEventListener('click', openResultsInDoc);
         byId('copyRes').addEventListener('click', copyResults);
         byId('clearRes').addEventListener('click', clearResults);
 

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -720,6 +720,9 @@
             <span class="fa-title">Find All</span>
             <span class="fa-count" id="faCount"></span>
             <span class="find-spacer"></span>
+            <!-- Lives HERE, not in .find-restools: that row is display:none in BOTH panel modes (see the
+                 :not(.findall) and .findall rules above), so it never renders in the overlay. -->
+            <button class="find-icon" id="openInDoc" title="Open results in an editor tab (with context)">&#8663;</button>
             <button class="find-icon" id="faClose" title="Close (Esc)">&#10005;</button>
         </div>
         <div class="find-head">
@@ -4861,6 +4864,58 @@
         postToHost(payload);
     }
 
+    // ---- "Open results in editor" — the search-results TAB (both surfaces drive this one function) ----
+    // Builds the whole result set for the document: every match plus context lines either side, read from
+    // the LIVE model (only the engine has it — the overlay and the pad both go through here).
+    //
+    // Rows carry the engine's ARRAY INDEX and nothing else navigational. The document never stores a
+    // position: clicking a row sends {op:'reveal', idx} back here, and revealMatch resolves it against the
+    // live decorations (#65). That's the pad's existing contract, so buffer edits can't make the tab jump
+    // to the wrong line — the numbers it PRINTS may age, but its navigation cannot.
+    var FIND_DOC_CONTEXT = 2;     // lines of context either side of a match
+    var FIND_DOC_MAX = 1000;      // payload cap; the page reports the remainder rather than hiding it
+
+    function openResultsInDoc() {
+        if (!editor) return;
+        syncFindMatches();                        // fresh positions/text against the live buffer first (#65)
+        if (!findResults.length) { showToast('No results to open — run a search first', false); return; }
+        var model = editor.getModel(); if (!model) return;
+        var lineCount = model.getLineCount();
+        var n = Math.min(findResults.length, FIND_DOC_MAX);
+        var rows = [];
+        for (var i = 0; i < n; i++) {
+            var r = findResults[i];
+            var before = [], after = [];
+            for (var b = Math.max(1, r.line - FIND_DOC_CONTEXT); b < r.line; b++)
+                before.push({ line: b, text: safeLineContent(model, b) });
+            for (var a = r.endLine + 1; a <= Math.min(lineCount, r.endLine + FIND_DOC_CONTEXT); a++)
+                after.push({ line: a, text: safeLineContent(model, a) });
+            rows.push({
+                idx: i,                           // engine index — the ONLY handle the document navigates by
+                line: r.line, startCol: r.startCol, endLine: r.endLine, endCol: r.endCol,
+                text: r.text, editable: !!r.editable,
+                before: before, after: after
+            });
+        }
+        postToHost({
+            action: 'caFindOpenDoc',
+            query: lastFindQuery || '',
+            opts: { matchCase: !!findOpts.matchCase, wholeWord: !!findOpts.wholeWord,
+                    regex: !!findOpts.regex, includeReadOnly: findOpts.includeReadOnly !== false },
+            total: findResults.length,
+            shown: n,
+            truncated: findResults.length - n,   // >0 → the page says so; a silent cap reads as "that's all of them"
+            lines: countLines(findResults),
+            readOnly: findResults.filter(function (r) { return !r.editable; }).length,
+            context: FIND_DOC_CONTEXT,
+            matches: rows
+        });
+    }
+
+    function safeLineContent(model, n) {
+        try { return model.getLineContent(n); } catch (e) { return ''; }
+    }
+
     // Run a search for the pad: q + findOpts (set by the caFind 'search' op) against the live buffer.
     // navigate === false → passive refresh (highlights + grid only): an AUTOMATIC re-search (pad session
     // restore on retarget) must never move the caret/scroll — only a deliberate user search reveals
@@ -5060,6 +5115,55 @@
         runFind(lastFindQuery, { replaced: replaced, skippedRo: skippedRo });
     }
 
+    // Does THIS engine still hold the search that produced the caller's result set? Same full-identity test
+    // as the pad/overlay replace guard (#66 phase 2): query text AND options, because same-text/different-
+    // options searches are distinct result sets.
+    function sameFindIdentity(q, o) {
+        if ((lastFindQuery || '') !== (q || '')) return false;
+        if (!o) return true;
+        return !!findOpts.matchCase === !!o.matchCase
+            && !!findOpts.wholeWord === !!o.wholeWord
+            && !!findOpts.regex === !!o.regex
+            && (findOpts.includeReadOnly !== false) === (o.includeReadOnly !== false);
+    }
+
+    // Reveal a raw position with no dependence on findResults. Used when an index can't be trusted (see
+    // handleRevealOp) — it only moves the caret/viewport; it never touches the engine's result state.
+    function revealAtLine(line, col, endLine, endCol, focusEditor) {
+        if (!editor) return false;
+        var model = editor.getModel(); if (!model) return false;
+        var max = model.getLineCount();
+        if (!(line > 0)) return false;
+        if (line > max) line = max;
+        if (!(endLine > 0) || endLine > max) endLine = line;
+        var range = new monaco.Range(line, col > 0 ? col : 1, endLine, endCol > 0 ? endCol : (col > 0 ? col : 1));
+        editor.revealRangeInCenterIfOutsideViewport(range);
+        editor.setSelection(range);
+        if (focusEditor) editor.focus();
+        return true;
+    }
+
+    // A reveal request from a SEARCH RESULTS DOCUMENT (op:'reveal' with docQuery/docOpts). Unlike the pad —
+    // which is always in lock-step with the engine — a results tab OUTLIVES its search:
+    //
+    //   * its editor was closed and re-opened  -> same broker key, but a FRESH page whose findResults is empty
+    //     (revealMatch would return silently and the user just sees the reopened buffer sitting at line 1);
+    //   * a different search has been run since -> findResults is full of SOMEONE ELSE'S matches, and idx N
+    //     would jump confidently to the wrong code. That is the desync class the pad/overlay replace guards
+    //     were added for (9e2a617) — silent and wrong is worse than visibly degraded.
+    //
+    // So idx is honoured ONLY while the engine still holds that exact search; otherwise fall back to the
+    // line/col the document recorded. That's a snapshot (right unless the buffer changed since), which is the
+    // same bargain the reopened-source-file path already makes.
+    function handleRevealOp(msg) {
+        var idx = +msg.idx;
+        var identityKnown = (msg.docQuery !== undefined && msg.docQuery !== null);
+        var trustIdx = findResults.length > 0 && idx >= 0 && idx < findResults.length
+                       && (!identityKnown || sameFindIdentity(msg.docQuery, msg.docOpts));
+        if (trustIdx) { revealMatch(idx, !!msg.focus); return; }
+        revealAtLine(+msg.line, +msg.col, +msg.endLine, +msg.endCol, !!msg.focus);
+    }
+
     // ---- CA Find pad commands ({type:'caFind'} from the host router, GitHub #66) ----
     function handleCaFindOp(msg) {
         try {
@@ -5072,7 +5176,8 @@
                     mirrorPadStateIntoOverlay(msg.query || '');
                     runFind(msg.query || '', undefined, msg.navigate !== false);
                     break;
-                case 'reveal':     revealMatch(+msg.idx, !!msg.focus); break;
+                case 'reveal':     handleRevealOp(msg); break;
+                case 'openInDoc':  openResultsInDoc(); break;   // pad's "Open in editor" — same fn as the overlay's
                 case 'nav':        gotoMatch(msg.dir < 0 ? -1 : 1); break;
                 case 'setChecked':
                     if (msg.idx >= 0 && msg.idx < findResults.length && findResults[msg.idx].editable)
@@ -5216,6 +5321,7 @@
 
         document.getElementById('selAll').addEventListener('click', function () { setAllChecked(true); });
         document.getElementById('selNone').addEventListener('click', function () { setAllChecked(false); });
+        document.getElementById('openInDoc').addEventListener('click', openResultsInDoc);
         document.getElementById('copyRes').addEventListener('click', copyResults);
         document.getElementById('clearRes').addEventListener('click', function () {
             findResults = []; findCurrentIdx = -1; lastFindQuery = null;

--- a/ClarionAssistant/Terminal/search-results.html
+++ b/ClarionAssistant/Terminal/search-results.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Search Results</title>
+<style>
+    /* Catppuccin-ish, matching the embeditor/diff views. Both themes; the host pushes applyTheme. */
+    :root {
+        --bg: #1e1e2e; --fg: #cdd6f4; --dim: #6c7086; --line: #313244;
+        --accent: #89b4fa; --hit: #f9e2af; --hit-bg: rgba(249, 226, 175, 0.22);
+        --row: #181825; --row-hover: #313244; --ro: #45475a; --warn: #f38ba8;
+    }
+    body.light {
+        --bg: #eff1f5; --fg: #4c4f69; --dim: #8c8fa1; --line: #ccd0da;
+        --accent: #1e66f5; --hit: #df8e1d; --hit-bg: rgba(223, 142, 29, 0.22);
+        --row: #e6e9ef; --row-hover: #dce0e8; --ro: #bcc0cc; --warn: #d20f39;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+        background: var(--bg); color: var(--fg);
+        font-family: 'Segoe UI', system-ui, sans-serif; font-size: 13px;
+        display: flex; flex-direction: column; overflow: hidden;
+    }
+    #head {
+        padding: 10px 14px; border-bottom: 1px solid var(--line);
+        display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; flex: none;
+    }
+    #title { font-size: 15px; font-weight: 600; }
+    #title .q { color: var(--hit); }
+    #meta { color: var(--dim); font-size: 12px; }
+    #origin { color: var(--dim); font-size: 12px; margin-left: auto; }
+    #opts { display: flex; gap: 5px; }
+    .chip {
+        border: 1px solid var(--line); border-radius: 3px; padding: 1px 6px;
+        font-size: 11px; color: var(--dim);
+    }
+    .chip.on { color: var(--accent); border-color: var(--accent); }
+    /* Filter toolbar. Everything here is client-side over the loaded payload — no host round trip, so it
+       stays instant even on a 1000-row result set. */
+    #tools {
+        padding: 7px 14px; border-bottom: 1px solid var(--line); flex: none;
+        display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    }
+    .fbox { position: relative; display: flex; align-items: center; flex: 1 1 220px; min-width: 180px; }
+    #filter {
+        width: 100%; padding: 4px 74px 4px 8px; font-size: 12px;
+        background: var(--row); color: var(--fg);
+        border: 1px solid var(--line); border-radius: 3px; outline: none;
+    }
+    #filter:focus { border-color: var(--accent); }
+    #filter.bad { border-color: var(--warn); }
+    .ftoggles { position: absolute; right: 3px; display: flex; gap: 2px; }
+    .tg {
+        min-width: 20px; height: 20px; padding: 0 4px; font-size: 11px; line-height: 1;
+        background: transparent; color: var(--dim);
+        border: 1px solid transparent; border-radius: 3px; cursor: pointer;
+    }
+    .tg:hover { background: var(--row-hover); }
+    .tg.on { color: var(--accent); border-color: var(--accent); }
+    .seg { display: flex; }
+    .sg {
+        padding: 3px 9px; font-size: 11px; background: var(--row); color: var(--dim);
+        border: 1px solid var(--line); cursor: pointer;
+    }
+    .sg:first-child { border-radius: 3px 0 0 3px; }
+    .sg:last-child { border-radius: 0 3px 3px 0; }
+    .sg + .sg { border-left: none; }
+    .sg:hover { background: var(--row-hover); }
+    .sg.on { color: var(--bg); background: var(--accent); border-color: var(--accent); }
+    #shown { color: var(--dim); font-size: 12px; margin-left: auto; }
+    #banner {
+        padding: 7px 14px; background: var(--hit-bg); color: var(--fg);
+        border-bottom: 1px solid var(--line); font-size: 12px; flex: none;
+    }
+    #banner.gone { background: var(--warn); color: var(--bg); font-weight: 600; }
+    #banner.hidden { display: none; }
+    #list { flex: 1; overflow: auto; padding: 6px 0 24px; }
+    .hit {
+        margin: 0 10px 8px; border: 1px solid var(--line); border-radius: 4px;
+        background: var(--row); overflow: hidden; cursor: pointer;
+    }
+    .hit:hover { border-color: var(--accent); }
+    .hit:hover .hit-head { background: var(--row-hover); }
+    .hit-head {
+        display: flex; align-items: center; gap: 8px;
+        padding: 4px 9px; border-bottom: 1px solid var(--line); font-size: 11px; color: var(--dim);
+    }
+    .hit-n { color: var(--accent); font-weight: 600; }
+    .lock { color: var(--ro); }
+    .hit-go { margin-left: auto; color: var(--dim); }
+    .hit:hover .hit-go { color: var(--accent); }
+    pre.code {
+        margin: 0; padding: 5px 0;
+        font-family: Consolas, 'Cascadia Mono', monospace; font-size: 12.5px; line-height: 1.5;
+        overflow-x: auto;   /* long generated lines scroll here, never the page */
+    }
+    .cl { display: flex; white-space: pre; }
+    .cl .ln {
+        flex: none; width: 58px; padding-right: 10px; text-align: right;
+        color: var(--dim); user-select: none;
+    }
+    .cl.ctx { opacity: 0.62; }
+    .cl.match .ln { color: var(--hit); font-weight: 600; }
+    .cl .src { flex: 1; padding-right: 12px; }
+    mark { background: var(--hit-bg); color: var(--hit); font-weight: 600; border-radius: 2px; }
+    #empty { padding: 40px; text-align: center; color: var(--dim); }
+    #empty.hidden { display: none; }
+</style>
+</head>
+<body>
+    <div id="head">
+        <span id="title">Search results</span>
+        <span id="meta"></span>
+        <span id="origin"></span>
+    </div>
+    <div id="tools">
+        <div class="fbox">
+            <input id="filter" type="text" autocomplete="off" spellcheck="false" placeholder="Filter these results…">
+            <div class="ftoggles">
+                <button class="tg" id="tgCase" title="Match case">Aa</button>
+                <button class="tg" id="tgRe" title="Regular expression">.*</button>
+                <button class="tg" id="tgInv" title="Invert — show only rows that do NOT match">&#8800;</button>
+            </div>
+        </div>
+        <span class="seg" id="scope">
+            <button class="sg on" data-scope="all" id="sgAll">All</button>
+            <button class="sg" data-scope="editable" id="sgEd">Editable</button>
+            <button class="sg" data-scope="readonly" id="sgRo">Read-only</button>
+        </span>
+        <span id="shown"></span>
+    </div>
+    <div id="banner" class="hidden"></div>
+    <div id="list"></div>
+    <div id="empty" class="hidden">No results.</div>
+
+<script>
+    // Search-results document (VS Code's "open in editor" for Find-All).
+    //
+    // This page is a VIEW ONLY. Every row holds the engine's array index (`idx`) and nothing else
+    // navigational; clicking one posts {action:'reveal', idx} and the HOST forwards it to the origin
+    // editor, whose engine resolves the index against its live Monaco decorations. The line numbers
+    // printed here are a snapshot and may age as the buffer is edited — the navigation cannot, which is
+    // why nothing here ever tries to be clever about positions.
+    var payload = null;
+
+    // Client-side refinement over the loaded payload. Modelled on KSSOpen's Find-and-Delete (filter text +
+    // match/do-NOT-match + simple/regex + case), but NON-destructive: it hides rows and reports the count
+    // instead of deleting them, so narrowing is always reversible.
+    //
+    // Filtering NEVER renumbers anything: rows keep the engine's `idx`, which is the only thing click-through
+    // uses. A filtered view is a view, not a new result set.
+    var view = { filter: '', invert: false, matchCase: false, regex: false, scope: 'all' };
+
+    function byId(id) { return document.getElementById(id); }
+    function postToHost(o) { try { window.chrome.webview.postMessage(JSON.stringify(o)); } catch (e) { } }
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    // Highlight the matched span using the engine's columns (1-based, end exclusive). Multi-line matches
+    // highlight from startCol to end-of-line on the first line — the context lines below carry the rest.
+    function renderMatchLine(m) {
+        var text = m.text == null ? '' : m.text;
+        var s = Math.max(0, (m.startCol || 1) - 1);
+        var e = (m.endLine === m.line) ? Math.max(s, (m.endCol || 1) - 1) : text.length;
+        if (s >= text.length) return esc(text);
+        return esc(text.slice(0, s)) + '<mark>' + esc(text.slice(s, e)) + '</mark>' + esc(text.slice(e));
+    }
+
+    function ctxLine(l) {
+        return '<div class="cl ctx"><span class="ln">' + l.line + '</span><span class="src">' + esc(l.text) + '</span></div>';
+    }
+
+    // Build the filter predicate once per render rather than per row. Returns null when the filter is empty
+    // (i.e. everything passes) and marks the box red on an invalid regex instead of silently showing nothing.
+    function filterPredicate() {
+        var q = view.filter;
+        byId('filter').className = '';
+        if (!q) return null;
+        if (view.regex) {
+            var re;
+            try { re = new RegExp(q, view.matchCase ? '' : 'i'); }
+            catch (e) { byId('filter').className = 'bad'; return null; }   // invalid pattern: don't hide anything
+            return function (t) { return re.test(t || ''); };
+        }
+        var needle = view.matchCase ? q : q.toLowerCase();
+        return function (t) {
+            t = t || '';
+            return (view.matchCase ? t : t.toLowerCase()).indexOf(needle) >= 0;
+        };
+    }
+
+    // Filter on the match's own line only — KSSOpen's "Match In" defaults to the Text column for the same
+    // reason: matching against context lines would surface rows whose own text has nothing to do with the term.
+    function visibleMatches() {
+        if (!payload || !payload.matches) return [];
+        var pred = filterPredicate();
+        var out = [];
+        for (var i = 0; i < payload.matches.length; i++) {
+            var m = payload.matches[i];
+            if (view.scope === 'editable' && !m.editable) continue;
+            if (view.scope === 'readonly' && m.editable) continue;
+            if (pred) {
+                var hit = pred(m.text);
+                if (view.invert ? hit : !hit) continue;
+            }
+            out.push(m);
+        }
+        return out;
+    }
+
+    function matchByIdx(idx) {
+        if (!payload || !payload.matches) return null;
+        // Rows are built in engine order, so matches[idx] is the common hit; fall back to a scan rather than
+        // trusting position (a future filtered/partial payload would break the assumption silently).
+        var m = payload.matches[idx];
+        if (m && m.idx === idx) return m;
+        for (var i = 0; i < payload.matches.length; i++) if (payload.matches[i].idx === idx) return payload.matches[i];
+        return null;
+    }
+
+    function render() {
+        var list = byId('list');
+        if (!payload || !payload.matches || !payload.matches.length) {
+            list.innerHTML = '';
+            byId('empty').textContent = 'No results.';
+            byId('empty').className = '';
+            renderCounts([]);
+            return;
+        }
+
+        var rows = visibleMatches();
+        renderCounts(rows);
+        if (!rows.length) {
+            list.innerHTML = '';
+            // Distinct from "no results": the search DID find things, the filter is hiding them. Saying
+            // "No results" here would send you back to re-run a search that was fine.
+            byId('empty').textContent = 'No rows match this filter — ' + payload.matches.length + ' hidden.';
+            byId('empty').className = '';
+            return;
+        }
+        byId('empty').className = 'hidden';
+
+        var html = [];
+        for (var i = 0; i < rows.length; i++) {
+            var m = rows[i];
+            var body = [];
+            for (var b = 0; b < (m.before || []).length; b++) body.push(ctxLine(m.before[b]));
+            body.push('<div class="cl match"><span class="ln">' + m.line + '</span><span class="src">' +
+                      renderMatchLine(m) + '</span></div>');
+            for (var a = 0; a < (m.after || []).length; a++) body.push(ctxLine(m.after[a]));
+
+            html.push(
+                '<div class="hit" data-idx="' + m.idx + '" title="Click to reveal in the editor">' +
+                    '<div class="hit-head">' +
+                        '<span class="hit-n">#' + (m.idx + 1) + '</span>' +
+                        '<span>line ' + m.line + '</span>' +
+                        (m.editable ? '' : '<span class="lock" title="Generated / read-only code">&#128274; read-only</span>') +
+                        '<span class="hit-go">&#8663;</span>' +
+                    '</div>' +
+                    '<pre class="code">' + body.join('') + '</pre>' +
+                '</div>');
+        }
+        list.innerHTML = html.join('');
+
+        var hits = list.querySelectorAll('.hit');
+        for (var h = 0; h < hits.length; h++) {
+            hits[h].addEventListener('click', function (ev) {
+                var idx = parseInt(ev.currentTarget.getAttribute('data-idx'), 10);
+                if (isNaN(idx) || idx < 0) return;
+                var m = matchByIdx(idx);
+                // We build the complete editor-bound message and the host forwards it verbatim (the pad's
+                // 'fwd' pattern). idx addresses the engine's LIVE result set, so it ships with the search
+                // identity that produced this document — the engine honours idx only while it still holds
+                // that same search, and otherwise falls back to the coords recorded here. Top-level line/col
+                // are for the host's own fallback: reopening a CLOSED source file, where no engine exists yet.
+                postToHost({
+                    action: 'reveal',
+                    line: m ? m.line : 0,
+                    col: m ? m.startCol : 1,
+                    fwd: {
+                        type: 'caFind', op: 'reveal', focus: true,
+                        idx: idx,
+                        line: m ? m.line : 0, col: m ? m.startCol : 1,
+                        endLine: m ? m.endLine : 0, endCol: m ? m.endCol : 0,
+                        docQuery: (payload && payload.query) || '',
+                        docOpts: (payload && payload.opts) || {}
+                    }
+                });
+            });
+        }
+    }
+
+    // Chip counts answer "what would I get if I clicked this?", so the text filter applies to them but the
+    // SCOPE doesn't — otherwise clicking Editable would zero out the other two and you'd lose your way back.
+    //
+    // Counts are over the LOADED rows, not payload.total: with a truncated payload those differ, and the
+    // truncation banner is what tells that story. Putting `total` on the chips would make them lie.
+    function renderCounts(rows) {
+        var all = (payload && payload.matches) ? payload.matches : [];
+        var pred = filterPredicate();
+        var nAll = 0, nEd = 0, nRo = 0;
+        for (var i = 0; i < all.length; i++) {
+            if (pred) {
+                var hit = pred(all[i].text);
+                if (view.invert ? hit : !hit) continue;
+            }
+            nAll++;
+            if (all[i].editable) nEd++; else nRo++;
+        }
+        byId('sgAll').textContent = 'All (' + nAll + ')';
+        byId('sgEd').textContent = 'Editable (' + nEd + ')';
+        byId('sgRo').textContent = 'Read-only (' + nRo + ')';
+        byId('shown').textContent = (rows.length === all.length)
+            ? '' : 'showing ' + rows.length + ' of ' + all.length;
+    }
+
+    function applyView() { render(); }
+
+    function wireTools() {
+        var fi = byId('filter'), t = null;
+        fi.addEventListener('input', function () {
+            // Debounced: re-rendering up to 1000 cards on every keystroke is what would make this feel slow.
+            if (t) clearTimeout(t);
+            t = setTimeout(function () { view.filter = fi.value; applyView(); }, 120);
+        });
+        fi.addEventListener('keydown', function (ev) {
+            if (ev.key === 'Escape') { fi.value = ''; view.filter = ''; applyView(); }
+        });
+
+        function toggle(id, key) {
+            byId(id).addEventListener('click', function () {
+                view[key] = !view[key];
+                byId(id).className = 'tg' + (view[key] ? ' on' : '');
+                applyView();
+            });
+        }
+        toggle('tgCase', 'matchCase');
+        toggle('tgRe', 'regex');
+        toggle('tgInv', 'invert');
+
+        var sgs = byId('scope').querySelectorAll('.sg');
+        for (var i = 0; i < sgs.length; i++) {
+            sgs[i].addEventListener('click', function (ev) {
+                view.scope = ev.currentTarget.getAttribute('data-scope');
+                for (var j = 0; j < sgs.length; j++)
+                    sgs[j].className = 'sg' + (sgs[j] === ev.currentTarget ? ' on' : '');
+                applyView();
+            });
+        }
+    }
+
+    function renderHead() {
+        if (!payload) return;
+        var q = payload.query || '';
+        var t = byId('title');
+        t.innerHTML = 'Results for <span class="q">' + esc(q) + '</span>';
+
+        // The search's options aren't shown as chips (they were visual noise on a line that just needs to say
+        // what you searched for) — but they still identify WHICH search produced this set, so they live in the
+        // title's tooltip rather than being thrown away.
+        var o = payload.opts || {}, on = [];
+        if (o.matchCase) on.push('match case');
+        if (o.wholeWord) on.push('whole word');
+        if (o.regex) on.push('regex');
+        on.push(o.includeReadOnly ? 'incl. read-only' : 'editable only');
+        t.title = 'Searched for "' + q + '" (' + on.join(', ') + ')';
+
+        var total = payload.total || 0;
+        var bits = [total + ' match' + (total === 1 ? '' : 'es')];
+        if (payload.lines) bits.push(payload.lines + ' line' + (payload.lines === 1 ? '' : 's'));
+        if (payload.readOnly) bits.push(payload.readOnly + ' read-only');
+        byId('meta').textContent = bits.join(' · ');
+
+        var kind = payload.originKind ? (payload.originKind + ' · ') : '';
+        byId('origin').textContent = kind + (payload.originTitle || '');
+
+        // Never let a cap read as "that's everything" — say what was dropped.
+        var banner = byId('banner');
+        if (payload.truncated > 0) {
+            banner.className = '';
+            banner.textContent = 'Showing the first ' + payload.shown + ' of ' + total +
+                ' matches — ' + payload.truncated + ' more not listed. Narrow the search to see the rest.';
+        } else {
+            banner.className = 'hidden';
+        }
+    }
+
+    function setTheme(isDark) { document.body.className = isDark ? '' : 'light'; }
+
+    // Reveal had nowhere to land. A click that silently does nothing reads as a broken feature, so say what
+    // happened AND what to do about it. Only reached when recovery already failed host-side: a closed source
+    // file gets reopened instead of ever landing here.
+    function markOriginGone(kind, name) {
+        var banner = byId('banner');
+        banner.className = 'gone';
+        banner.textContent = (kind === 'embed')
+            ? 'The embeditor for ' + (name || 'this procedure') + ' is closed, so results can’t be revealed. '
+              + 'Re-open that procedure’s embeditor and click again — or re-run the search there for a live list.'
+            : 'Couldn’t open ' + (name || 'the source file') + ' — it may have been moved, renamed or deleted. '
+              + 'Re-run the search for a live list.';
+    }
+
+    window.chrome.webview.addEventListener('message', function (ev) {
+        // WebView2 delivers a parsed object here — do NOT JSON.parse.
+        var msg = ev.data;
+        if (!msg || !msg.type) return;
+        if (msg.type === 'applyTheme') { setTheme(!!msg.isDark); return; }
+        if (msg.type === 'originGone') { markOriginGone(msg.kind, msg.name); return; }
+        if (msg.type === 'setResults') {
+            setTheme(msg.isDark !== false);
+            // The payload can be MBs (every match + its context), so it arrives over the virtual host as a
+            // file rather than inside this message.
+            fetch(msg.resultsUrl)
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    payload = data || {};
+                    payload.originTitle = msg.originTitle || '';
+                    payload.originKind = msg.originKind || '';
+                    resetView();      // a fresh search must not arrive pre-filtered by the last one's leftovers
+                    renderHead();
+                    render();
+                })
+                .catch(function (e) {
+                    byId('list').innerHTML = '';
+                    byId('empty').className = '';
+                    byId('empty').textContent = 'Could not load results: ' + e;
+                });
+        }
+    });
+
+    function resetView() {
+        view = { filter: '', invert: false, matchCase: false, regex: false, scope: 'all' };
+        var fi = byId('filter'); if (fi) { fi.value = ''; fi.className = ''; }
+        byId('tgCase').className = 'tg'; byId('tgRe').className = 'tg'; byId('tgInv').className = 'tg';
+        var sgs = byId('scope').querySelectorAll('.sg');
+        for (var i = 0; i < sgs.length; i++)
+            sgs[i].className = 'sg' + (sgs[i].getAttribute('data-scope') === 'all' ? ' on' : '');
+    }
+
+    wireTools();
+    postToHost({ action: 'ready' });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #113.

Adds **⇗ Open in editor** to both find surfaces — the overlay's Find-All header and the CA Find pad's results toolbar — opening a `Search: <query>` document with every match, context lines, click-through, and filtering.

Branched from current master (post-#104/#110 integration), built and deployed against Clarion 11.1, exercised in the IDE from both surfaces.

## Why a tab

The vendored WeifenLuo DockPanel Suite v1 misplaces its dock guides whenever a monitor sits above or left of the primary — `DockIndicator` assigns screen coordinates to child controls whose `.Location` is client space, and the form's origin is only `(0,0)` when nothing extends above/left of the primary. Reported to SoftVelocity; not fixable from an addin. Anything pad-shaped inherits it. An editor tab never touches WinForms docking — and it adds no sixth pad and no sixth `Ctrl+Alt` accelerator.

## Shape

Both surfaces call one engine function (`openResultsInDoc`), which posts `caFindOpenDoc`. That rides the **existing** `OnCaFind` group, so neither host needed a new `IMonacoEditorHost` member or any per-host logic — one `case` in the dispatch switch, and the broker (which already knows each host's key and title) turns it into a `SearchResultsViewContent`.

`SearchResultsViewContent` is modelled on `MonacoDiffViewContent`: `AbstractViewContent` + `IsViewOnly` + WebView2 + virtual-host temp folder for the payload + ready-handshake send + deferred `ctx.Post` on show + `DisposeAllForShutdown` wired into `ShutdownService`.

**The document stores no positions.** Rows carry the engine's array index; a click forwards `{op:'reveal', idx}` to the origin page, which resolves it against its live Monaco decorations (`syncFindMatches`, #65). That's the pad's existing contract, so buffer edits can't make the tab navigate to the wrong line.

## Three decisions worth your eye

**Routed by origin key, not `_active`** (new `CaFindBroker.ForwardTo`). The pad follows focus and should. A results tab is a snapshot of one search against one buffer, so it must forward to the editor it was opened *from* — otherwise clicking match #7 of an embeditor search reveals inside whatever file you'd clicked into since.

**Desync guard.** A results tab outlives its search — the editor gets re-opened, or a new search runs. Clicks ship the search identity that produced the document; the engine honours `idx` only while it still holds that exact query **and** options, else falls back to the recorded coordinates. Same class as your pad/overlay replace guard in `9e2a617`; without it, a re-searched buffer would send a click confidently to the wrong match.

**Degradation is explicit, never silent.** A closed source file is re-opened and navigated by snapshot (`MonacoSourceNavigator`, which is already open-or-focus); a closed PWEE can't be, so the tab says so rather than swallowing the click; the 1000-match payload cap announces itself in a banner rather than reading as "that's all of them".

## Heads-up: this PR contains one non-search fix

**It is a prerequisite, not a drive-by** — the feature is broken without it, and it's a pre-existing bug in the broker.

`DetachOverlay()` never called `CaFindBroker.UnregisterHost`. An overlay-mode embeditor is never `ShowView`'d, so the workbench never calls its `Dispose()` — which is where the unregister lives. `DetachOverlay` **is** the teardown. So every PWEE close left a dead host entry under `embed::<proc>`, and re-opening stacked a live one beside it under the same key.

This was invisible because nothing looked hosts up **by key**: `FromPad` routes via `_active` (refreshed by focus, so it self-corrects) and `FromEditor` matches on host object identity. `ForwardTo` is the first key-based consumer, so it's the first thing that could pick the corpse — posting into a disposed control, where the `try/catch` ate it. Symptom: close and re-open a PWEE, click a result, nothing happens.

Independently of this feature, it also grows `_hosts` unboundedly across a session.

`ForwardTo` additionally scans newest-first and skips disposed controls — a session key isn't unique over time, so a key lookup shouldn't assume it is.

Also new: `TryFocusOwningTab`, distinct from `TryFocusExisting`. The latter ends in `BringToFront`, which in overlay mode only re-asserts Monaco's z-order inside the native embeditor's host panel — right for its existing caller (the save path, where that document is already frontmost), useless for a caller sitting on another document. `TryFocusExisting` is left untouched so the save path is unchanged.

## Filtering

Modelled on KSS/Open's Find-and-Delete (filter text + match/do-NOT-match + simple/regex + case) but **non-destructive** — rows are hidden and counted, never deleted. Scope chips carry live counts and follow the filter, so each answers "what would I get if I clicked this?".

This matters more than it sounds in PWEE. A `Long` search in a NetTalk-heavy procedure is **329 matches, 325 read-only** — nearly all `PROCEDURE(long …)` in generated DERIVED prototypes. `Editable (4)` is one click.

## Deliberately not in scope

Results can show **editable vs read-only** but can't say *"this is in `WebEnroll.PageReceived` @ Priority 5000"*. There's no embed-point model to hang that on: both sides carry a slot as `int[2]`, `MergeRanges` collapses adjacent slots, and `GetEmbeditorSource` strips the `! Start of "…"` / `! [Priority N]` markers. Building it is real work and wants its own issue — Data/Code/Comment classification (KSS's "Location" column) sits on top of it and is the obvious follow-up.

## Two bugs found and deliberately NOT fixed here

Neither is needed for this feature, so neither is in this branch. Happy to file or fix separately, your call:

1. **`.find-restools` is `display:none` in both overlay modes** (`#findPanel:not(.findall)` and `#findPanel.findall`), so Select All / Select None / **Copy** / Clear results are dead markup in the overlay. Panel-era leftovers the pad integration stranded; the pad's copies render fine.
2. **`RevertShadow` is missing from `DetachOverlay`.** Its only call site is `Dispose()` — which overlay mode never gets. So after every overlay PWEE close, the LSP keeps a stale shadow of that generated module for the rest of the session, and hover/definition/references on that `.clw` answer from the embed buffer rather than disk. That undermines #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
