### PR TITLE
fix(lsp): revert the module shadow when an overlay-mode embeditor closes (#115)

### DIFF
--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -2248,6 +2248,18 @@ namespace ClarionAssistant.Terminal
             if (_overlayDetached) return;
             _overlayDetached = true;
             UnhookOverlayTeardown();
+
+            // #56: while this embed session was up, every LSP request pushed the wrapped embed buffer to the
+            // server under the module's REAL path, overriding the on-disk file in the server's view. There is
+            // no didClose in the transport, so RevertShadow (pushing the on-disk content back) is the only
+            // thing that un-shadows it.
+            //
+            // Dispose() already does this — but overlay mode never GETS Dispose(): it is never ShowView'd, so
+            // the workbench does not own this view and never disposes it. DetachOverlay IS the teardown. Without
+            // this call the server keeps answering hover/definition/references for that .clw from a buffer that
+            // is no longer open, silently, for the rest of the session.
+            try { if (_lspContext != null) _lspContext.RevertShadow(); } catch { }
+
             RestoreNativeChrome();
             RemoveOverlayCover();
             try


### PR DESCRIPTION
Closes #115. One file, twelve lines, branched from master.

`EmbedLspContext.RevertShadow()` had exactly one call site — `Dispose()`. An **overlay-mode** embed session never reaches it, because it is never `ShowView`'d: the workbench doesn't own the view and never disposes it. `DetachOverlay()` is the entire teardown.

## Why it matters

From #56 / PR #74: while an embeditor is open, every LSP request pushes the wrapped embed buffer to the server under the module's **real path**, overriding the on-disk file in the server's view. The transport has no `didClose`, so `RevertShadow` — pushing the on-disk content back — is the only thing that un-shadows it.

Skip it and, after any overlay-mode PWEE close, the server still believes that generated module *is* the embed buffer. Hover, go-to-definition and find-references on that `.clw` keep answering from a buffer that's no longer open — **silently**, since the results look authoritative — for the rest of the session, compounding per procedure closed. That undermines the point of #56.

## The fix

Call `RevertShadow()` from `DetachOverlay()`, mirroring `Dispose()` and its best-effort try/catch. It's already a safe no-op when the LSP isn't running or the file has vanished.

## Integration note

This touches `DetachOverlay()`, which **#114 also touches** — adding the `CaFindBroker.UnregisterHost` that's missing from the same path for the same underlying reason. Expect a trivial conflict at the same anchor; the two additions are independent and both belong there. When both land the order matches `Dispose()`: unregister, then revert.

Deliberately **not** stacked on #114 — a two-line conflict is cheaper to resolve than an unmergeable stack (cf. #110).

## The wider point

Overlay mode never receiving `Dispose()` is a **pattern**, not a one-off: anything placed in `Dispose()` is silently skipped for every overlay embed session. `UnregisterHost` was the first casualty (found via #113, fixed in #114); this is the second. The two paths are now aligned, but it's worth deciding whether they should share one teardown rather than being kept in sync by hand.

Built clean against Clarion 11.1. Not runtime-verified — the failure is silent by nature (stale LSP answers), so I'd want an LSP-level check rather than claiming I watched it work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)