### PR TITLE
fix(codegraph): stop erasing SELF.Method()/Object.Method() calls whose name collides with a Clarion built-in

### DIFF
--- a/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
@@ -985,7 +985,16 @@ namespace ClarionCodeGraph.Graph
                         foreach (System.Text.RegularExpressions.Match spm in selfParentMatches)
                         {
                             string methodName = spm.Groups[2].Value;
-                            if (ClarionBuiltins.IsBuiltInOrKeyword(methodName)) continue;
+                            // Bug N: deliberately do NOT skip built-in/keyword method names here. A
+                            // genuine Clarion built-in statement (e.g. OPEN(SomeFile), ASK()) is always
+                            // a plain, unqualified call -- Clarion has no "object.OPEN(...)" form for the
+                            // language built-in -- so "SELF.Open(...)"/"PARENT.Ask(...)" unambiguously
+                            // means a class method call, even when the method's name collides with a
+                            // built-in keyword (Open/Close/Ask/Delete/Send/Get/... -- ABC itself defines
+                            // methods with these exact names on WindowManager/FileManager/etc.). The
+                            // symbolNameToId lookup below only ever succeeds against a real user-defined
+                            // procedure symbol, so this can't manufacture a false "calls" edge -- it only
+                            // stops erasing real ones.
 
                             // Try to resolve as ClassName.MethodName using the current procedure's class
                             string callerName = null;
@@ -1028,11 +1037,15 @@ namespace ClarionCodeGraph.Graph
                         {
                             string objName = dm.Groups[1].Value;
                             string methodName = dm.Groups[2].Value;
-                            // Skip SELF/PARENT (handled above) and built-ins
+                            // Skip SELF/PARENT (handled above -- see loop 1)
                             if (string.Equals(objName, "SELF", StringComparison.OrdinalIgnoreCase) ||
                                 string.Equals(objName, "PARENT", StringComparison.OrdinalIgnoreCase))
                                 continue;
-                            if (ClarionBuiltins.IsBuiltInOrKeyword(methodName)) continue;
+                            // Bug N: deliberately do NOT skip built-in/keyword method names here either,
+                            // for the same reason as loop 1 above -- "Object.Method(...)" dot notation is
+                            // never how a real Clarion built-in statement is invoked, so this can't be
+                            // confused with one; it only stops erasing real method calls whose name
+                            // happens to collide with a built-in keyword.
 
                             // Resolve the object name through its declared class type when it is a
                             // typed variable (e.g. "Worker.Sign" where Worker is a WorkerClass →

--- a/ClarionAssistant/indexer/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/indexer/Graph/CodeGraphIndexer.cs
@@ -981,7 +981,16 @@ namespace ClarionCodeGraph.Graph
                         foreach (System.Text.RegularExpressions.Match spm in selfParentMatches)
                         {
                             string methodName = spm.Groups[2].Value;
-                            if (ClarionBuiltins.IsBuiltInOrKeyword(methodName)) continue;
+                            // Bug N: deliberately do NOT skip built-in/keyword method names here. A
+                            // genuine Clarion built-in statement (e.g. OPEN(SomeFile), ASK()) is always
+                            // a plain, unqualified call -- Clarion has no "object.OPEN(...)" form for the
+                            // language built-in -- so "SELF.Open(...)"/"PARENT.Ask(...)" unambiguously
+                            // means a class method call, even when the method's name collides with a
+                            // built-in keyword (Open/Close/Ask/Delete/Send/Get/... -- ABC itself defines
+                            // methods with these exact names on WindowManager/FileManager/etc.). The
+                            // symbolNameToId lookup below only ever succeeds against a real user-defined
+                            // procedure symbol, so this can't manufacture a false "calls" edge -- it only
+                            // stops erasing real ones.
 
                             // Try to resolve as ClassName.MethodName using the current procedure's class
                             string callerName = null;
@@ -1024,11 +1033,15 @@ namespace ClarionCodeGraph.Graph
                         {
                             string objName = dm.Groups[1].Value;
                             string methodName = dm.Groups[2].Value;
-                            // Skip SELF/PARENT (handled above) and built-ins
+                            // Skip SELF/PARENT (handled above -- see loop 1)
                             if (string.Equals(objName, "SELF", StringComparison.OrdinalIgnoreCase) ||
                                 string.Equals(objName, "PARENT", StringComparison.OrdinalIgnoreCase))
                                 continue;
-                            if (ClarionBuiltins.IsBuiltInOrKeyword(methodName)) continue;
+                            // Bug N: deliberately do NOT skip built-in/keyword method names here either,
+                            // for the same reason as loop 1 above -- "Object.Method(...)" dot notation is
+                            // never how a real Clarion built-in statement is invoked, so this can't be
+                            // confused with one; it only stops erasing real method calls whose name
+                            // happens to collide with a built-in keyword.
 
                             // Resolve the object name through its declared class type when it is a
                             // typed variable (e.g. "Worker.Sign" where Worker is a WorkerClass →

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -2,10 +2,15 @@
 
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
 the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92), the GROUP-typed CLASS-member fix
-(PR #93), and the inherited-CLASS-member dotted-call resolution fix (PR TBD) — a single
+(PR #93), and the inherited-CLASS-member dotted-call resolution fix (PR #112) — a single
 compiling Clarion solution whose procedures each exercise one historical parser/indexer bug.
 This is currently the only regression coverage the CodeGraph parser has; run it after ANY change
 to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
+
+Also documents one **known, not-yet-fixed** gap (Bug N, see below) as a deliberate negative
+control: `WorkerClass.Ask` is expected to have **zero** `calls` rows until Bug N is fixed. Don't
+"fix" the fixture by making it pass — re-run it after any attempt at Bug N and expect this count
+to change from 0, not stay at 0.
 
 ## Run
 
@@ -13,33 +18,61 @@ to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, and the
-inherited-CLASS-member dotted-call resolution fix)
+## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, and #112;
+line numbers below reflect the fixture AFTER Bug N's `Ask()` additions)
 
 ### Callers of `WorkerClass.Sign` — exactly 20 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
-| TestSignatureFlow | 18 | baseline (direct call) |
-| TestSignatureFlow | 19 | baseline (second call shape) |
-| ParameterTest | 31 | #87 (call through PROCEDURE parameter) |
-| ReturnTest | 40 | baseline (inline RETURN call shape) |
-| OwnerClass.CallViaMember | 51 | #84+#86 (.inc member, cross-file type) |
+| TestSignatureFlow | 25 | baseline (direct call) |
+| TestSignatureFlow | 31 | baseline (second call shape) |
+| ParameterTest | 43 | #87 (call through PROCEDURE parameter) |
+| ReturnTest | 52 | baseline (inline RETURN call shape) |
 | MainHelperProc | 62 | #81 (procedure in main PROGRAM file) |
-| OwnerClass.CallViaCommentedMember | 67 | #85+#86 (trailing-comment member) |
-| CommentedLocalTest | 83 | #85 (trailing-comment DATA local) |
-| GroupBugClass.CallViaAfterGroupMember | 101 | #88 (member after inline GROUP END) |
-| PeriodBugClass.CallViaAfterPeriodMember | 117 | #88 (member after inline GROUP period) |
-| OmitTest | 154 | #79 (call after OMIT block) |
-| AfterOmitProc | 163 | #79 (procedure after OMIT block) |
-| CommentEmbeddedTest | 180 | #80 (call with embedded comment) |
-| ConditionalOmitTest | 194 | #79 (conditional OMIT/COMPILE) |
-| GroupQueueLocalTest | 213 | #89 (local after GROUP(Type) two-line) |
-| InlineLocalGroupTest | 228 | #89 (local after GROUP(Type) END inline) |
-| LocalDerivedClassTest | 254 | #90 (attribution after local CLASS(Parent)) |
-| LikeMemberBugClass.CallViaPlainInstanceMember | 271 | #92 (call through a reference CLASS member, unaffected control) |
-| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 289 | #93 (member after multi-line GROUP with its own extra field) |
-| DerivedWorkerClass.CallViaInheritedMember | 300 | this PR (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
+| OwnerClass.CallViaMember | 63 | #84+#86 (.inc member, cross-file type) |
+| OwnerClass.CallViaCommentedMember | 85 | #85+#86 (trailing-comment member) |
+| CommentedLocalTest | 101 | #85 (trailing-comment DATA local) |
+| GroupBugClass.CallViaAfterGroupMember | 119 | #88 (member after inline GROUP END) |
+| PeriodBugClass.CallViaAfterPeriodMember | 135 | #88 (member after inline GROUP period) |
+| OmitTest | 172 | #79 (call after OMIT block) |
+| AfterOmitProc | 181 | #79 (procedure after OMIT block) |
+| CommentEmbeddedTest | 198 | #80 (call with embedded comment) |
+| ConditionalOmitTest | 212 | #79 (conditional OMIT/COMPILE) |
+| GroupQueueLocalTest | 231 | #89 (local after GROUP(Type) two-line) |
+| InlineLocalGroupTest | 246 | #89 (local after GROUP(Type) END inline) |
+| LocalDerivedClassTest | 272 | #90 (attribution after local CLASS(Parent)) |
+| LikeMemberBugClass.CallViaPlainInstanceMember | 289 | #92 (call through a reference CLASS member, unaffected control) |
+| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 307 | #93 (member after multi-line GROUP with its own extra field) |
+| DerivedWorkerClass.CallViaInheritedMember | 318 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
+
+### Callers of `WorkerClass.Ask` — exactly 0 `calls` rows (Bug N, **not yet fixed**)
+
+`Ask` is identical in shape to `Sign` (same class, same signature) — the only difference is its
+name, which happens to collide with the Clarion built-in `ASK()` window/UI statement. Both call
+sites below sit directly next to an equivalent, resolving `Sign` call on the SAME object, at the
+SAME call site, so the two can be compared line-for-line:
+
+| Caller | Line | Same-site `Sign` call (for comparison) | Path proven broken |
+|---|---|---|---|
+| TestSignatureFlow | 30 | line 25 (`worker.Sign( 1 )`) | DATA-section local variable (baseline path) |
+| OwnerClass.CallViaMember | 69 | line 63 (`SELF.MyWorker.Sign( 10 )`) | cross-file CLASS member (#84/#86, and #112's inheritance walk when applicable) |
+
+**Root cause**: `"ASK"` is in `ClarionBuiltins.cs`'s `_builtins` set (window/UI statement). Both
+the `SELF.Method` and the dotted `ObjectName.Method` call-detection loops in
+`CodeGraphIndexer.cs` unconditionally `continue` past any method name matched by
+`IsBuiltInOrKeyword(...)`, before any type resolution is attempted — with no way to tell a bare
+built-in statement (`ASK(...)`) apart from a class method call that merely shares its name
+(`worker.Ask(...)`). Confirmed independent of #112 (inheritance): the class-member call site
+above resolves the member's type correctly (`Sign` proves that at the very same call site) —
+`Ask` is skipped purely by name, before that type resolution is ever reached.
+
+Real-world confirmation (not reproduced in this fixture, referred to generically): the same
+built-in/keyword collision was confirmed against a production Clarion solution across at least
+19 distinct real class-method names beyond `Open`/`Close`/`Ask` (e.g. `Delete`, `Send`, `Post`,
+`Empty`, `Reset`, `Get`, `Put`, `Update`, `Destroy` — all real Clarion built-in keywords also used
+as ordinary ABC-style class method names), suggesting a substantial number of currently-invisible
+calls solution-wide, not a narrow edge case.
 
 ### Symbols
 
@@ -88,6 +121,10 @@ inherited-CLASS-member dotted-call resolution fix)
   calling method live on two different, both top-level, `.inc`-declared classes joined only by
   `CLASS(BaseClass)` inheritance. Proves the dotted-call resolver's class-member fallback walks
   the `inherits` chain instead of only ever checking the calling method's own class name.
+- `WorkerClass.Ask` (Bug N, **not yet fixed**): a `procedure` symbol, parsed and stored exactly
+  as correctly as `WorkerClass.Sign` right next to it (proving the symbol/parsing side is
+  unaffected) — the gap is entirely in call-site resolution, not symbol capture. Compare against
+  the "Callers of `WorkerClass.Ask`" table above.
 
 ### Program symbol (#81)
 
@@ -101,6 +138,12 @@ inherited-CLASS-member dotted-call resolution fix)
 SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
+
+-- Bug N, not yet fixed: expect 0 rows. Re-run after any attempt at Bug N and expect this
+-- to become 2 rows (TestSignatureFlow line 30, OwnerClass.CallViaMember line 69), not stay at 0.
+SELECT s2.name, r.line_number FROM relationships r
+JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
+WHERE s1.name='WorkerClass.Ask' AND r.type='calls' ORDER BY r.line_number;
 
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
 OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','GenCertData','SomeHandle','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember','AttrTermGroup','AttrTermGroupPeriod','BaseWorker');

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -2,15 +2,17 @@
 
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
 the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92), the GROUP-typed CLASS-member fix
-(PR #93), and the inherited-CLASS-member dotted-call resolution fix (PR #112) — a single
-compiling Clarion solution whose procedures each exercise one historical parser/indexer bug.
-This is currently the only regression coverage the CodeGraph parser has; run it after ANY change
-to `Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
+(PR #93), the inherited-CLASS-member dotted-call resolution fix (PR #112), and the
+built-in-name-collision fix (PR #118) — a single compiling Clarion solution whose procedures each
+exercise one historical parser/indexer bug. This is currently the only regression coverage the
+CodeGraph parser has; run it after ANY change to `Parsing/ClarionParser.cs` or
+`Graph/CodeGraphIndexer.cs` (either synced copy).
 
-Also documents one **known, not-yet-fixed** gap (Bug N, see below) as a deliberate negative
-control: `WorkerClass.Ask` is expected to have **zero** `calls` rows until Bug N is fixed. Don't
-"fix" the fixture by making it pass — re-run it after any attempt at Bug N and expect this count
-to change from 0, not stay at 0.
+Includes `WorkerClass.Ask` — a method whose name collides with the Clarion built-in `ASK()`
+statement — as coverage for Bug N (PR #118). Before that fix its two call sites resolved to
+**zero** `calls` rows (the dotted/`SELF.` call-detection loops skipped any built-in-named method);
+after it, they resolve to the expected **2**. If that count ever drops back to 0, Bug N has
+regressed.
 
 ## Run
 
@@ -18,8 +20,8 @@ to change from 0, not stay at 0.
 indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproSolution.sln --db %TEMP%\codegraph-repro.db
 ```
 
-## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, and #112;
-line numbers below reflect the fixture AFTER Bug N's `Ask()` additions)
+## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, #112, and
+#118; line numbers below reflect the fixture AFTER Bug N's `Ask()` additions)
 
 ### Callers of `WorkerClass.Sign` — exactly 20 `calls` rows
 
@@ -46,26 +48,27 @@ line numbers below reflect the fixture AFTER Bug N's `Ask()` additions)
 | MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 307 | #93 (member after multi-line GROUP with its own extra field) |
 | DerivedWorkerClass.CallViaInheritedMember | 318 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
 
-### Callers of `WorkerClass.Ask` — exactly 0 `calls` rows (Bug N, **not yet fixed**)
+### Callers of `WorkerClass.Ask` — exactly 2 `calls` rows (Bug N, **fixed in #118**)
 
 `Ask` is identical in shape to `Sign` (same class, same signature) — the only difference is its
 name, which happens to collide with the Clarion built-in `ASK()` window/UI statement. Both call
 sites below sit directly next to an equivalent, resolving `Sign` call on the SAME object, at the
 SAME call site, so the two can be compared line-for-line:
 
-| Caller | Line | Same-site `Sign` call (for comparison) | Path proven broken |
+| Caller | Line | Same-site `Sign` call (for comparison) | Path proven fixed |
 |---|---|---|---|
 | TestSignatureFlow | 30 | line 25 (`worker.Sign( 1 )`) | DATA-section local variable (baseline path) |
 | OwnerClass.CallViaMember | 69 | line 63 (`SELF.MyWorker.Sign( 10 )`) | cross-file CLASS member (#84/#86, and #112's inheritance walk when applicable) |
 
-**Root cause**: `"ASK"` is in `ClarionBuiltins.cs`'s `_builtins` set (window/UI statement). Both
-the `SELF.Method` and the dotted `ObjectName.Method` call-detection loops in
-`CodeGraphIndexer.cs` unconditionally `continue` past any method name matched by
-`IsBuiltInOrKeyword(...)`, before any type resolution is attempted — with no way to tell a bare
-built-in statement (`ASK(...)`) apart from a class method call that merely shares its name
-(`worker.Ask(...)`). Confirmed independent of #112 (inheritance): the class-member call site
-above resolves the member's type correctly (`Sign` proves that at the very same call site) —
-`Ask` is skipped purely by name, before that type resolution is ever reached.
+**Root cause (fixed by #118)**: `"ASK"` is in `ClarionBuiltins.cs`'s `_builtins` set (window/UI
+statement). Before #118 both the `SELF.Method` and the dotted `ObjectName.Method` call-detection
+loops in `CodeGraphIndexer.cs` unconditionally `continue`d past any method name matched by
+`IsBuiltInOrKeyword(...)`, before any type resolution was attempted — erasing the call. #118
+removed those two guards: a dotted call (`worker.Ask(...)` / `SELF.Ask(...)`) is syntactically
+never how a bare built-in statement (`ASK(...)`) is written, so the collision can't actually
+occur at these two sites. Independent of #112 (inheritance): the class-member call site above
+resolves the member's type correctly (`Sign` proves that at the very same call site) — `Ask` was
+skipped purely by name, before that type resolution was ever reached.
 
 Real-world confirmation (not reproduced in this fixture, referred to generically): the same
 built-in/keyword collision was confirmed against a production Clarion solution across at least
@@ -121,9 +124,9 @@ calls solution-wide, not a narrow edge case.
   calling method live on two different, both top-level, `.inc`-declared classes joined only by
   `CLASS(BaseClass)` inheritance. Proves the dotted-call resolver's class-member fallback walks
   the `inherits` chain instead of only ever checking the calling method's own class name.
-- `WorkerClass.Ask` (Bug N, **not yet fixed**): a `procedure` symbol, parsed and stored exactly
-  as correctly as `WorkerClass.Sign` right next to it (proving the symbol/parsing side is
-  unaffected) — the gap is entirely in call-site resolution, not symbol capture. Compare against
+- `WorkerClass.Ask` (Bug N, **fixed in #118**): a `procedure` symbol, parsed and stored exactly
+  as correctly as `WorkerClass.Sign` right next to it (proving the symbol/parsing side was always
+  unaffected) — the bug was entirely in call-site resolution, not symbol capture. Compare against
   the "Callers of `WorkerClass.Ask`" table above.
 
 ### Program symbol (#81)
@@ -139,8 +142,9 @@ SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
--- Bug N, not yet fixed: expect 0 rows. Re-run after any attempt at Bug N and expect this
--- to become 2 rows (TestSignatureFlow line 30, OwnerClass.CallViaMember line 69), not stay at 0.
+-- Bug N (fixed in #118): expect 2 rows (TestSignatureFlow line 30, OwnerClass.CallViaMember
+-- line 69). If this drops back to 0, Bug N has regressed — the built-in-named method is being
+-- erased at the dotted/SELF. call sites again.
 SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Ask' AND r.type='calls' ORDER BY r.line_number;

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -6,16 +6,28 @@ WorkerClass.Sign PROCEDURE( LONG pData )
   CODE
   RETURN 0
 
+! Bug N repro (NOT YET FIXED): see WorkerLib.inc for the full root-cause writeup. Ask is
+! identical in shape to Sign above -- only its name differs, and that name happens to collide
+! with the Clarion built-in ASK() keyword.
+WorkerClass.Ask PROCEDURE( LONG pData )
+  CODE
+  RETURN 0
+
 
 
 ! Bug C repro: worker is a local DATA-section variable, and Sign() is called on it
-! twice from this same procedure. Before the fix, only the line-9 call survived 
+! twice from this same procedure. Before the fix, only the line-9 call survived
 ! line 10 was silently dropped as a "duplicate" (same fromId/toId, no line in the key).
 TestSignatureFlow PROCEDURE()
 worker    WorkerClass
 result    LONG
   CODE
   result = worker.Sign( 1 )
+! Bug N repro (NOT YET FIXED, local-variable path): worker.Ask( 1 ), right next to
+! worker.Sign( 1 ) above -- same object, same file, same DATA-section-local resolution path.
+! Sign resolves; Ask does not, purely because of its name. Expected: zero calls rows to
+! WorkerClass.Ask from here until Bug N is fixed.
+  result = worker.Ask( 1 )
   result = worker.Sign( 2 )
   Result = ParameterTest( Worker )
   RETURN result
@@ -49,6 +61,12 @@ OwnerClass.CallViaMember PROCEDURE( )
 result   LONG
   CODE
   result = SELF.MyWorker.Sign( 10 )
+! Bug N repro (NOT YET FIXED, class-member path): SELF.MyWorker.Ask( 10 ), right next to
+! SELF.MyWorker.Sign( 10 ) above -- same member, same class, same cross-file class-member
+! resolution path (#84/#86, and Bug M's inheritance walk when applicable). Proves Bug N is
+! independent of Bug M/D/E: the member's type resolves correctly either way (Sign proves
+! that), Ask is skipped purely because of its name, before type resolution is even reached.
+  result = SELF.MyWorker.Ask( 10 )
   RETURN result
 
 ! Bug F repro: CommentedWorker is declared with a trailing inline comment in

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -6,9 +6,9 @@ WorkerClass.Sign PROCEDURE( LONG pData )
   CODE
   RETURN 0
 
-! Bug N repro (NOT YET FIXED): see WorkerLib.inc for the full root-cause writeup. Ask is
+! Bug N repro (FIXED in #118): see WorkerLib.inc for the full root-cause writeup. Ask is
 ! identical in shape to Sign above -- only its name differs, and that name happens to collide
-! with the Clarion built-in ASK() keyword.
+! with the Clarion built-in ASK() keyword, which used to erase its calls at dotted/SELF. sites.
 WorkerClass.Ask PROCEDURE( LONG pData )
   CODE
   RETURN 0
@@ -23,10 +23,10 @@ worker    WorkerClass
 result    LONG
   CODE
   result = worker.Sign( 1 )
-! Bug N repro (NOT YET FIXED, local-variable path): worker.Ask( 1 ), right next to
+! Bug N repro (FIXED in #118, local-variable path): worker.Ask( 1 ), right next to
 ! worker.Sign( 1 ) above -- same object, same file, same DATA-section-local resolution path.
-! Sign resolves; Ask does not, purely because of its name. Expected: zero calls rows to
-! WorkerClass.Ask from here until Bug N is fixed.
+! Both resolve now; before #118 Ask was erased purely because of its name. Expected: one
+! calls row to WorkerClass.Ask from here (this site) -- a drop to zero means Bug N regressed.
   result = worker.Ask( 1 )
   result = worker.Sign( 2 )
   Result = ParameterTest( Worker )
@@ -61,11 +61,11 @@ OwnerClass.CallViaMember PROCEDURE( )
 result   LONG
   CODE
   result = SELF.MyWorker.Sign( 10 )
-! Bug N repro (NOT YET FIXED, class-member path): SELF.MyWorker.Ask( 10 ), right next to
+! Bug N repro (FIXED in #118, class-member path): SELF.MyWorker.Ask( 10 ), right next to
 ! SELF.MyWorker.Sign( 10 ) above -- same member, same class, same cross-file class-member
-! resolution path (#84/#86, and Bug M's inheritance walk when applicable). Proves Bug N is
+! resolution path (#84/#86, and Bug M's inheritance walk when applicable). Proves Bug N was
 ! independent of Bug M/D/E: the member's type resolves correctly either way (Sign proves
-! that), Ask is skipped purely because of its name, before type resolution is even reached.
+! that), Ask was skipped purely because of its name, before type resolution was ever reached.
   result = SELF.MyWorker.Ask( 10 )
   RETURN result
 

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -1,16 +1,16 @@
 WorkerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
 
 Sign          PROCEDURE( LONG pData ), LONG
-! Bug N repro (NOT YET FIXED): Ask is an ordinary class method with the exact same shape as
+! Bug N repro (FIXED in #118): Ask is an ordinary class method with the exact same shape as
 ! Sign above -- the only difference is its name. "ASK" is also a hardcoded Clarion built-in
-! keyword (the window/UI ASK() statement) in ClarionBuiltins.cs's _builtins set. Both the
+! keyword (the window/UI ASK() statement) in ClarionBuiltins.cs's _builtins set. Before #118 the
 ! SELF.Method and the dotted ObjectName.Method call-detection loops in CodeGraphIndexer.cs
-! unconditionally skip any method name matched by IsBuiltInOrKeyword(...) before any type
-! resolution is attempted -- with no way to tell a bare built-in statement (ASK(...)) apart
-! from a class method call that merely shares its name (worker.Ask(...)). Placed directly next
-! to Sign in both this declaration and every call site in WorkerLib.clw, so the two can be
-! compared side by side: Sign resolves, Ask does not, at the exact same call sites. See
-! WorkerLib.clw for the call sites and README.md for the full writeup.
+! unconditionally skipped any method name matched by IsBuiltInOrKeyword(...) before any type
+! resolution -- erasing the call, since they couldn't tell a bare built-in statement (ASK(...))
+! from a class method call that merely shares its name (worker.Ask(...)). #118 removed those two
+! guards (a dotted call is never a bare built-in). Placed directly next to Sign in both this
+! declaration and every call site in WorkerLib.clw, so the two can be compared side by side: both
+! resolve now. See WorkerLib.clw for the call sites and README.md for the full writeup.
 Ask           PROCEDURE( LONG pData ), LONG
             END
 

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -1,6 +1,17 @@
 WorkerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
 
 Sign          PROCEDURE( LONG pData ), LONG
+! Bug N repro (NOT YET FIXED): Ask is an ordinary class method with the exact same shape as
+! Sign above -- the only difference is its name. "ASK" is also a hardcoded Clarion built-in
+! keyword (the window/UI ASK() statement) in ClarionBuiltins.cs's _builtins set. Both the
+! SELF.Method and the dotted ObjectName.Method call-detection loops in CodeGraphIndexer.cs
+! unconditionally skip any method name matched by IsBuiltInOrKeyword(...) before any type
+! resolution is attempted -- with no way to tell a bare built-in statement (ASK(...)) apart
+! from a class method call that merely shares its name (worker.Ask(...)). Placed directly next
+! to Sign in both this declaration and every call site in WorkerLib.clw, so the two can be
+! compared side by side: Sign resolves, Ask does not, at the exact same call sites. See
+! WorkerLib.clw for the call sites and README.md for the full writeup.
+Ask           PROCEDURE( LONG pData ), LONG
             END
 
 OwnerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )


### PR DESCRIPTION
## Summary

CodeGraph's "who calls X" resolution silently erases any `SELF.Method(...)` or
`ObjectName.Method(...)` call whose method name happens to be identical to a Clarion built-in
statement or keyword (e.g. `Open`, `Close`, `Ask`, `Delete`, `Send`, `Get`, `Update`, ...). This is
not a narrow edge case: ABC (Application Builder Classes) itself defines methods with these exact
names on `WindowManager`, `FileManager`, and similar base classes, invoked as `SELF.Open()`,
`SELF.Ask()`, `SELF.Close()` throughout ABC-derived application code — which is most Clarion
applications. Confirmed against a real production Clarion solution: at least 19
distinct real class-method names in active use collide with a built-in/keyword name (`Delete`,
`Close`, `Send`, `Open`, `Post`, `Empty`, `Reset`, `Get`, `Put`, `Update`, `Unlock`, `Sort`,
`SetPosition`, `GetPosition`, `Enable`, `Duplicate`, `Display`, `Destroy`, `Ask`), and reindexing
after this fix surfaced **325 previously-invisible `calls` relationships**.

## Root cause

`ResolveRelationships` in `CodeGraphIndexer.cs` has (at minimum) three separate call-detection
passes over each source line:

1. `SELF.Method(...)` / `PARENT.Method(...)` detection.
2. `ObjectName.Method(...)` detection (dotted calls, explicitly skipping when the object is
   literally `SELF`/`PARENT`, since loop 1 already owns that case).
3. Bare, unqualified procedure-name detection, matched against a `procNames` set that is already
   built to exclude anything `ClarionBuiltins.IsBuiltInOrKeyword(...)` matches — this loop can
   structurally never match a real built-in name, by construction, and needs no further guard.

Loops 1 and 2 ALSO each carried their own inline guard —
`if (ClarionBuiltins.IsBuiltInOrKeyword(methodName)) continue;` — that unconditionally skipped the
match whenever the METHOD NAME (not the object name) matched a builtin or keyword, before any type
resolution or symbol lookup was ever attempted.

This guard was based on a false premise for these two loops specifically: a genuine Clarion
built-in statement (`OPEN(SomeFile, mode)`, `ASK()`, `DELETE(SomeFile)`, ...) is always a plain,
unqualified call — Clarion has no `Object.OPEN(...)` dot-notation form for the *language*
built-in. So `SELF.Open(...)` / `Worker.Open(...)`, written with a dot, is syntactically
unambiguous: it can only ever mean a class method call, never the built-in statement, regardless
of whether the method's name happens to collide with a built-in keyword. The guard that was meant
to avoid confusing the two was solving a problem that can't actually occur at these two call
sites — it only occurs for loop 3's bare, unqualified token matching, where the guard correctly
remains.

## Fix

Removed the `if (ClarionBuiltins.IsBuiltInOrKeyword(methodName)) continue;` guard from both loop 1
and loop 2, in both synced copies of `CodeGraphIndexer.cs`, replacing each with an explanatory
comment. Left unchanged:

- The `procNames`-construction-time filter that keeps loop 3 safe — unrelated to this fix, still
  correctly needed there.
- Two other, unrelated uses of the same `IsBuiltInOrKeyword` check elsewhere in the same file (in
  the `uses_type`-relationship builder and in `TryResolveVariableClassType`) — those reject
  built-in/keyword **variable type names** (e.g. rejecting `LONG`/`GROUP`/`QUEUE` as not being a
  real user-defined class), a completely different, correctly-scoped concern with nothing to do
  with method-name collisions.

The final step in both loops is an exact dictionary lookup — `symbolNameToId.TryGetValue(fullName,
...)` — against real, user-defined `procedure`/`function`/`routine` symbols only. It is not a
fuzzy or heuristic match, so removing the guard cannot manufacture a new false-positive `calls`
edge; it can only stop erasing edges that were real all along. No duplicate-relationship risk
either: loop 2 already skips `SELF`/`PARENT` as the object name (loop 1 owns that case), and for an
indirect call like `SELF.SomeMember.Open(...)`, loop 1 only ever captures `methodName =
"SomeMember"` (a variable name, not `"Open"`), so the two loops' matches never target the same
relationship for the same line.

**Independent code-reviewer agent verification done before applying** (per this project's
now-standard practice): confirmed the fix is correct and safe as described above, confirmed the
two files were identical at both guard locations before the change, and — the one adjustment it
required — caught that the loop-2 comment ("Skip SELF/PARENT (handled above) and built-ins") had
to be rewritten, since it would otherwise keep advertising a builtin-skip that no longer exists.
The review also surfaced a completeness note worth recording here: a builtin-named method whose
*declaration* lives only in an `.inc` CLASS body is dropped by a separate, unrelated parser path
in non-library mode (an existing, pre-existing condition, not introduced or regressed by this
fix) — but the method's *implementation* in a `.clw` file is captured independently of that path
and always creates a usable symbol, which is what this fix's resolution actually depends on. In
other words: this fix fully resolves any builtin-named method that has a real implementation in
the indexed solution source (the common case), and does not regress or worsen the separate,
narrower gap around implementation-less methods.

## Minimal reproduction

Extended the shared `test-fixtures/codegraph-repro/` fixture: gave `WorkerClass` a second method,
`Ask`, identical in shape to the existing `Sign` method — chosen because `"ASK"` is a real,
hardcoded entry in `ClarionBuiltins.cs`'s built-in set (the window/UI `ASK()` statement). Two call
sites were added directly next to existing, already-resolving `Sign` calls on the exact same
objects, so the two can be compared line-for-line:

```clarion
WorkerClass.Ask PROCEDURE( LONG pData )
  CODE
  RETURN 0
```

```clarion
TestSignatureFlow PROCEDURE()
worker    WorkerClass
result    LONG
  CODE
  result = worker.Sign( 1 )
  result = worker.Ask( 1 )      ! <-- same object, same file, DATA-section-local path
  result = worker.Sign( 2 )
  ...

OwnerClass.CallViaMember PROCEDURE( )
result   LONG
  CODE
  result = SELF.MyWorker.Sign( 10 )
  result = SELF.MyWorker.Ask( 10 )   ! <-- same member, cross-file CLASS-member path
  RETURN result
```

**Before this fix**: `WorkerClass.Ask` exists as a correctly-parsed `procedure` symbol (proving
the symbol/parsing side is unaffected), yet `relationships` has zero `calls` rows targeting it
from either call site — while `WorkerClass.Sign`, right next to it at the same call sites, resolves
correctly.

**After this fix** (verified via the standalone `clarion-indexer.exe`): `WorkerClass.Ask` goes
from **0 to 2** `calls` rows (one via the DATA-section-local path, one via the cross-file
CLASS-member path). `WorkerClass.Sign` stays at **20/20**, matching every prior fixture case with
zero regressions.

**Also verified against the real production solution**: reindexing surfaced 325 previously
invisible `calls` relationships solution-wide, including every specific call site that had been
individually confirmed missing before the fix, across multiple unrelated classes and multiple
different built-in-colliding method names (not just `Open`/`Close`) — with no change to any
already-working call.

## Scope note

This PR is based on top of the still-unmerged `fix/codegraph-inherited-member-resolution`
(#112) — the shared repro fixture's `WorkerLib.inc`/`.clw`/`README.md` files were extended
incrementally on top of that PR's own fixture changes (both work sits in the same shared fixture
files), so this branch depends on #112's content, not on `master` directly. Once #112 merges,
this branch should be rebased onto `master` before finalizing.

Independent of, and unrelated to, #112's inheritance-chain fix — that PR changes how a class
member's *type* is resolved when the member is inherited; this PR changes whether a resolved
method name is skipped at all, regardless of inheritance. Confirmed during investigation that
they're genuinely separate bugs: the case that led to finding this one (`SELF.ParentMsg.Open()`)
uses a directly-declared, non-inherited member — the member's type resolves correctly either way,
and `Open` was still skipped purely by name, before type resolution was ever reached.
