### PR TITLE
fix(webview2): reap the browser process tree on crash via a kill-on-close job (#109)

### DIFF
--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Services\EmbedEditorMonitorService.cs" />
     <Compile Include="Services\ShutdownLog.cs" />
     <Compile Include="Services\ShutdownService.cs" />
+    <Compile Include="Services\WebView2ProcessReaper.cs" />
     <Compile Include="Services\KnowledgeService.cs" />
     <Compile Include="Services\ClarionVersionService.cs" />
     <Compile Include="Services\RedFileService.cs" />

--- a/ClarionAssistant/Services/WebView2ProcessReaper.cs
+++ b/ClarionAssistant/Services/WebView2ProcessReaper.cs
@@ -49,12 +49,23 @@ namespace ClarionAssistant.Services
                     if (!EnsureJobLocked()) return;               // job unavailable — graceful path still applies
 
                     IntPtr h = NativeMethods.OpenProcess(
-                        NativeMethods.PROCESS_SET_QUOTA | NativeMethods.PROCESS_TERMINATE, false, pid);
+                        NativeMethods.PROCESS_SET_QUOTA | NativeMethods.PROCESS_TERMINATE
+                            | NativeMethods.PROCESS_QUERY_LIMITED_INFORMATION,
+                        false, pid);
                     if (h == IntPtr.Zero) return;
                     try
                     {
+                        // Between GetProcessInfos and OpenProcess the browser could die and Windows could
+                        // recycle the PID onto an unrelated process — which we'd then kill at Clarion exit.
+                        // Tiny window, but the failure mode is severe, so confirm the image name first.
+                        // Fail-closed: a later ProcessInfosChanged retries with a fresh PID.
+                        if (!IsWebView2Image(h)) return;
+
                         if (NativeMethods.AssignProcessToJobObject(_job, h))
+                        {
                             _boundPid = pid;
+                            ShutdownLog.Log("[reaper] WebView2 browser pid=" + pid + " bound to kill-on-close job");
+                        }
                         // else: leave _boundPid so a later fire retries; assign can fail transiently.
                     }
                     finally
@@ -70,6 +81,11 @@ namespace ClarionAssistant.Services
             }
         }
 
+        // Only the BROWSER process is ever assigned to the job — deliberately. Children spawned after the
+        // assignment (renderers/gpu/utility) inherit job membership automatically, and any spawned before it
+        // self-exit when their browser dies (Chromium children hold a channel to the browser and terminate
+        // when it drops). Do NOT "fix" this by assigning every PID in GetProcessInfos — that just adds
+        // OpenProcess/assign churn on every process churn event for no coverage gain.
         private static uint FindBrowserPid(CoreWebView2Environment env)
         {
             try
@@ -87,6 +103,26 @@ namespace ClarionAssistant.Services
                 System.Diagnostics.Debug.WriteLine("[WebView2Reaper] FindBrowserPid: " + ex.Message);
             }
             return 0;
+        }
+
+        /// <summary>True if the opened process's image is msedgewebview2.exe. Guards the PID-reuse window
+        /// between GetProcessInfos and OpenProcess (see call site). Handle needs PROCESS_QUERY_LIMITED_INFORMATION.</summary>
+        private static bool IsWebView2Image(IntPtr h)
+        {
+            try
+            {
+                var sb = new System.Text.StringBuilder(1024);
+                uint size = (uint)sb.Capacity;
+                if (!NativeMethods.QueryFullProcessImageName(h, 0, sb, ref size))
+                    return false;
+                string name = System.IO.Path.GetFileName(sb.ToString(0, (int)size));
+                return string.Equals(name, "msedgewebview2.exe", StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[WebView2Reaper] IsWebView2Image: " + ex.Message);
+                return false;
+            }
         }
 
         /// <summary>Create the kill-on-close job once. Mirrors ConPtyTerminal.CreateJobAndAssignProcess. Caller

--- a/ClarionAssistant/Services/WebView2ProcessReaper.cs
+++ b/ClarionAssistant/Services/WebView2ProcessReaper.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Runtime.InteropServices;
+using ClarionAssistant.Terminal;
+using Microsoft.Web.WebView2.Core;
+
+namespace ClarionAssistant.Services
+{
+    /// <summary>
+    /// Binds the shared WebView2 browser process to a Windows Job Object with KILL_ON_JOB_CLOSE, so the OS
+    /// tears the whole WebView2 process tree down when Clarion dies — including a CRASH, which the graceful
+    /// ShutdownService path can't cover (ApplicationExit never fires, so nothing disposes the WebViews and the
+    /// browser + every renderer are orphaned; GitHub #109).
+    ///
+    /// Same mechanism ConPtyTerminal already uses for the terminal's child processes
+    /// (ConPtyTerminal.CreateJobAndAssignProcess) — the only difference is WebView2 shares ONE browser process
+    /// across every surface, and we only have its PID (from the environment's process list), so we OpenProcess
+    /// it rather than owning a handle from CreateProcess.
+    ///
+    /// The job handle is created once and DELIBERATELY never closed: KILL_ON_JOB_CLOSE fires when the last
+    /// handle to the job closes, and the only thing holding it is our process. So it fires exactly at Clarion
+    /// exit — clean or crash — reaping any WebView2 process still in the job. On a clean exit the graceful path
+    /// has already disposed the WebViews (the browser exits normally); this is purely the crash backstop.
+    ///
+    /// Everything is best-effort: any native failure (down-level OS, a nested-job refusal) is swallowed and we
+    /// fall back to the graceful path. It must never throw into WebView2's ProcessInfosChanged event.
+    /// </summary>
+    internal static class WebView2ProcessReaper
+    {
+        private static readonly object _gate = new object();
+        private static IntPtr _job = IntPtr.Zero;   // held for the process lifetime; never closed (see class remarks)
+        private static uint _boundPid;              // the browser PID currently assigned to the job (0 = none)
+
+        /// <summary>
+        /// Ensure the CURRENT WebView2 browser process is inside our kill-on-close job. Idempotent and cheap:
+        /// re-binds only when the browser PID has changed (WebView2 re-launches the browser after a browser
+        /// crash), so it's safe to call on every ProcessInfosChanged fire.
+        /// </summary>
+        public static void BindBrowser(CoreWebView2Environment env)
+        {
+            if (env == null) return;
+            try
+            {
+                uint pid = FindBrowserPid(env);
+                if (pid == 0) return;   // browser process not spawned yet — a later ProcessInfosChanged will carry it
+
+                lock (_gate)
+                {
+                    if (pid == _boundPid) return;                 // already in the job
+                    if (!EnsureJobLocked()) return;               // job unavailable — graceful path still applies
+
+                    IntPtr h = NativeMethods.OpenProcess(
+                        NativeMethods.PROCESS_SET_QUOTA | NativeMethods.PROCESS_TERMINATE, false, pid);
+                    if (h == IntPtr.Zero) return;
+                    try
+                    {
+                        if (NativeMethods.AssignProcessToJobObject(_job, h))
+                            _boundPid = pid;
+                        // else: leave _boundPid so a later fire retries; assign can fail transiently.
+                    }
+                    finally
+                    {
+                        // The job keeps its own association with the process; we don't need this handle.
+                        NativeMethods.CloseHandle(h);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[WebView2Reaper] BindBrowser: " + ex.Message);
+            }
+        }
+
+        private static uint FindBrowserPid(CoreWebView2Environment env)
+        {
+            try
+            {
+                var infos = env.GetProcessInfos();
+                if (infos == null) return 0;
+                foreach (var pi in infos)
+                {
+                    if (pi.Kind == CoreWebView2ProcessKind.Browser)
+                        return (uint)pi.ProcessId;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[WebView2Reaper] FindBrowserPid: " + ex.Message);
+            }
+            return 0;
+        }
+
+        /// <summary>Create the kill-on-close job once. Mirrors ConPtyTerminal.CreateJobAndAssignProcess. Caller
+        /// holds _gate.</summary>
+        private static bool EnsureJobLocked()
+        {
+            if (_job != IntPtr.Zero) return true;
+            try
+            {
+                IntPtr job = NativeMethods.CreateJobObject(IntPtr.Zero, null);
+                if (job == IntPtr.Zero) return false;
+
+                var info = new NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+                {
+                    BasicLimitInformation = new NativeMethods.JOBOBJECT_BASIC_LIMIT_INFORMATION
+                    {
+                        LimitFlags = NativeMethods.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+                    }
+                };
+
+                int infoSize = Marshal.SizeOf(typeof(NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+                IntPtr infoPtr = Marshal.AllocHGlobal(infoSize);
+                try
+                {
+                    Marshal.StructureToPtr(info, infoPtr, false);
+                    if (!NativeMethods.SetInformationJobObject(
+                            job, NativeMethods.JobObjectExtendedLimitInformation, infoPtr, (uint)infoSize))
+                    {
+                        // Without KILL_ON_JOB_CLOSE the job is pointless (it wouldn't reap on our death) — drop it.
+                        NativeMethods.CloseHandle(job);
+                        return false;
+                    }
+                }
+                finally { Marshal.FreeHGlobal(infoPtr); }
+
+                _job = job;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[WebView2Reaper] EnsureJob: " + ex.Message);
+                return false;
+            }
+        }
+    }
+}

--- a/ClarionAssistant/Terminal/NativeMethods.cs
+++ b/ClarionAssistant/Terminal/NativeMethods.cs
@@ -107,6 +107,15 @@ namespace ClarionAssistant.Terminal
 
         #region Job Object API
 
+        // Open an existing process by PID to get a handle we can assign to a job. WebView2's browser process
+        // is shared and spawned by WebView2 (not us), so unlike ConPty we don't own a CreateProcess handle —
+        // we open one by BrowserProcessId. PROCESS_SET_QUOTA is required for AssignProcessToJobObject.
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
+
+        internal const uint PROCESS_TERMINATE = 0x0001;
+        internal const uint PROCESS_SET_QUOTA = 0x0100;
+
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string lpName);
 

--- a/ClarionAssistant/Terminal/NativeMethods.cs
+++ b/ClarionAssistant/Terminal/NativeMethods.cs
@@ -115,6 +115,13 @@ namespace ClarionAssistant.Terminal
 
         internal const uint PROCESS_TERMINATE = 0x0001;
         internal const uint PROCESS_SET_QUOTA = 0x0100;
+        internal const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+
+        // Used to confirm a PID we opened is still the WebView2 browser before assigning it to the
+        // kill-on-close job (guards the GetProcessInfos → OpenProcess PID-reuse window).
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool QueryFullProcessImageName(
+            IntPtr hProcess, uint dwFlags, System.Text.StringBuilder lpExeName, ref uint lpdwSize);
 
         [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string lpName);

--- a/ClarionAssistant/Terminal/WebView2EnvironmentCache.cs
+++ b/ClarionAssistant/Terminal/WebView2EnvironmentCache.cs
@@ -67,6 +67,18 @@ namespace ClarionAssistant.Terminal
                 userDataFolder: userDataFolder,
                 options: options);
 
+            // #109: bind the shared browser process to a kill-on-close job so the OS reaps the whole WebView2
+            // tree if Clarion crashes (the graceful ShutdownService path can't cover a crash). The browser
+            // process spawns lazily with the first CoreWebView2, so it usually isn't up yet here — the live
+            // subscription binds it when ProcessInfosChanged fires, and re-binds if WebView2 relaunches it after
+            // a browser crash. The immediate call covers the case where a browser is already present. Best-effort.
+            try
+            {
+                _environment.ProcessInfosChanged += (s, e) => Services.WebView2ProcessReaper.BindBrowser(_environment);
+                Services.WebView2ProcessReaper.BindBrowser(_environment);
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[WebView2Cache] reaper wire: " + ex.Message); }
+
             return _environment;
         }
     }


### PR DESCRIPTION
Closes #109. New branch off master, four files.

## The bug (BoxSoft's diagnosis, confirmed)

The addin reaps WebView2 only through the **graceful** path — `ShutdownService.Terminate`, from `/Workspace/Terminate` + an `ApplicationExit` backstop — which disposes every live WebView2 before native teardown. Clean close: fine. **Crash:** `ApplicationExit` never fires, `Terminate` never runs, and the shared browser process plus every renderer/gpu/utility are orphaned. Each crash strands another batch — the 3+ dozen while running, ~2 dozen surviving a later close.

## The fix

Bind the shared WebView2 **browser process** to a Windows **Job Object** with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, held for the addin's process lifetime. The job handle is **deliberately never closed**, so the flag fires exactly when the Clarion process dies — clean *or* crash — and the OS tears down whatever WebView2 processes remain in the job. It's an OS-level backstop *under* the existing graceful path (which stays, and still does the work on a clean exit).

This is the same mechanism **`ConPtyTerminal.CreateJobAndAssignProcess`** already uses for the terminal's child processes. The only difference: WebView2 shares one browser process across every surface and spawns it itself, so we `OpenProcess(BrowserProcessId)` rather than owning a `CreateProcess` handle. Every native primitive already lived in `NativeMethods.cs` except `OpenProcess`, added here.

## Shape

- **`NativeMethods.cs`** — add `OpenProcess` + `PROCESS_SET_QUOTA | PROCESS_TERMINATE`. (Job API was already present.)
- **`Services/WebView2ProcessReaper.cs`** (new) — create the kill-on-close job once (mirrors ConPty), bind the current browser PID, re-bind on PID change. Best-effort throughout.
- **`WebView2EnvironmentCache.cs`** — one hook: the single shared-environment chokepoint subscribes to `CoreWebView2Environment.ProcessInfosChanged` and binds. **No consumer sites touched.** Live subscription, so a browser process WebView2 relaunches after a browser crash is re-bound.
- **`.csproj`** — the new `Compile` item.

## Scope: binding only, no orphan-sweep (deliberate)

Binding makes new orphans impossible. A startup sweep of *historical* debris was deferred because CA's user-data-dir is **shared across Clarion instances** — a naive sweep in a second IDE would kill the first IDE's live browser. This isn't hypothetical: on my machine **25 of the running `msedgewebview2.exe` belong to WhatsApp / Outlook / Citrix / Windows Search** (~1 GB). A blind name-match sweep would nuke all of them. A guarded sweep (kill only orphans whose parent Clarion PID is dead, or per-session data dirs) can be a follow-up if the historical debris is worth automating away; a reboot clears it in the meantime.

## Verified end-to-end (not just compiled)

This is an OS-level behaviour, so I ran the crash test rather than trusting the build:

- Launched Clarion, opened several WebView2 surfaces → **8 CA-owned WebView2 processes, 694 MB** (1 browser root + gpu + 3 renderers + 2 utility + crashpad).
- **Hard-killed Clarion via End Task** (not File→Exit — a graceful close uses the path that already works and would prove nothing).
- Result: **all 8 reaped within ~1s**; the 25 non-CA WebView2 processes untouched.

The nested-job concern (WebView2 may already place its processes in a job on some Windows builds) did not bite on Win11 — the browser process was accepted into our job and reaped cleanly. If it ever does on another OS, the code fails soft to the graceful path.

Built + deployed against Clarion 11.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)