### PR TITLE
fix(codegraph): don't leak dataGroupDepth on attrs+same-line-terminator GROUP/QUEUE locals (#97)

### DIFF
--- a/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/CodeGraph/Parsing/ClarionParser.cs
@@ -707,9 +707,14 @@ namespace ClarionCodeGraph.Parsing
                         // dataGroupDepth here would leak it permanently, silently swallowing every
                         // subsequent local variable in this DATA section (the same class of bug fixed
                         // for ParseIncFile's classEndDepth -- see the inline-group-depth-leak fix).
-                        // GroupQueueDeclRegex's own "term" group already recognized the same-line
-                        // terminator (if any), so no separate re-check of the line text is needed here.
-                        if (!gqMatch.Groups["term"].Success)
+                        // GroupQueueDeclRegex's "term" group only sees a terminator that DIRECTLY
+                        // follows the name/type -- when an attribute list is present ("...,DIM(2) END" /
+                        // "...,DIM(2)."), the ",.*" attrs alternative swallows the terminator into itself
+                        // and "term" never matches -- so ALSO re-check the end of the line to cover the
+                        // attrs+same-line-terminator form (GitHub #97, mirroring ae9805b's CLASS-body fix).
+                        bool gqSelfClosing = gqMatch.Groups["term"].Success ||
+                            Regex.IsMatch(gqMatch.Value.TrimEnd(), @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
+                        if (!gqSelfClosing)
                         {
                             dataGroupDepth++;
                         }

--- a/ClarionAssistant/indexer/Parsing/ClarionParser.cs
+++ b/ClarionAssistant/indexer/Parsing/ClarionParser.cs
@@ -689,9 +689,14 @@ namespace ClarionCodeGraph.Parsing
                         // dataGroupDepth here would leak it permanently, silently swallowing every
                         // subsequent local variable in this DATA section (the same class of bug fixed
                         // for ParseIncFile's classEndDepth -- see the inline-group-depth-leak fix).
-                        // GroupQueueDeclRegex's own "term" group already recognized the same-line
-                        // terminator (if any), so no separate re-check of the line text is needed here.
-                        if (!gqMatch.Groups["term"].Success)
+                        // GroupQueueDeclRegex's "term" group only sees a terminator that DIRECTLY
+                        // follows the name/type -- when an attribute list is present ("...,DIM(2) END" /
+                        // "...,DIM(2)."), the ",.*" attrs alternative swallows the terminator into itself
+                        // and "term" never matches -- so ALSO re-check the end of the line to cover the
+                        // attrs+same-line-terminator form (GitHub #97, mirroring ae9805b's CLASS-body fix).
+                        bool gqSelfClosing = gqMatch.Groups["term"].Success ||
+                            Regex.IsMatch(gqMatch.Value.TrimEnd(), @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
+                        if (!gqSelfClosing)
                         {
                             dataGroupDepth++;
                         }

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -21,9 +21,10 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 ```
 
 ## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, #112, and
-#118; line numbers below reflect the fixture AFTER Bug N's `Ask()` additions)
+#118, then re-verified with #97; line numbers below reflect the fixture AFTER #97's
+`AttrTermLocalGroupTest` addition)
 
-### Callers of `WorkerClass.Sign` — exactly 20 `calls` rows
+### Callers of `WorkerClass.Sign` — exactly 21 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
@@ -31,7 +32,7 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | TestSignatureFlow | 31 | baseline (second call shape) |
 | ParameterTest | 43 | #87 (call through PROCEDURE parameter) |
 | ReturnTest | 52 | baseline (inline RETURN call shape) |
-| MainHelperProc | 62 | #81 (procedure in main PROGRAM file) |
+| MainHelperProc | 64 | #81 (procedure in main PROGRAM file) |
 | OwnerClass.CallViaMember | 63 | #84+#86 (.inc member, cross-file type) |
 | OwnerClass.CallViaCommentedMember | 85 | #85+#86 (trailing-comment member) |
 | CommentedLocalTest | 101 | #85 (trailing-comment DATA local) |
@@ -43,10 +44,11 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | ConditionalOmitTest | 212 | #79 (conditional OMIT/COMPILE) |
 | GroupQueueLocalTest | 231 | #89 (local after GROUP(Type) two-line) |
 | InlineLocalGroupTest | 246 | #89 (local after GROUP(Type) END inline) |
-| LocalDerivedClassTest | 272 | #90 (attribution after local CLASS(Parent)) |
-| LikeMemberBugClass.CallViaPlainInstanceMember | 289 | #92 (call through a reference CLASS member, unaffected control) |
-| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 307 | #93 (member after multi-line GROUP with its own extra field) |
-| DerivedWorkerClass.CallViaInheritedMember | 318 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
+| AttrTermLocalGroupTest | 266 | #97 (local after GROUP(Type),attrs + same-line terminator) |
+| LocalDerivedClassTest | 292 | #90 (attribution after local CLASS(Parent)) |
+| LikeMemberBugClass.CallViaPlainInstanceMember | 309 | #92 (call through a reference CLASS member, unaffected control) |
+| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 327 | #93 (member after multi-line GROUP with its own extra field) |
+| DerivedWorkerClass.CallViaInheritedMember | 338 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
 
 ### Callers of `WorkerClass.Ask` — exactly 2 `calls` rows (Bug N, **fixed in #118**)
 

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
@@ -12,6 +12,7 @@ ConditionalOmitTest PROCEDURE, LONG
 CommentedLocalTest PROCEDURE, LONG
 GroupQueueLocalTest PROCEDURE, LONG
 InlineLocalGroupTest PROCEDURE, LONG
+AttrTermLocalGroupTest PROCEDURE, LONG
 LocalDerivedClassTest PROCEDURE, LONG
     END
 MainHelperProc     PROCEDURE, LONG
@@ -43,6 +44,7 @@ derivedWorker DerivedWorkerClass
     r# = afterBug.CallSomethingElse()
     r# = GroupQueueLocalTest()
     r# = InlineLocalGroupTest()
+    r# = AttrTermLocalGroupTest()
     r# = LocalDerivedClassTest()
     r# = likeMemberBug.CallViaPlainInstanceMember()
     r# = multiLineGroupBug.CallViaAfterMultiLineGroupMember()

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -246,6 +246,26 @@ AfterInlineLocalGroup &WorkerClass
   result = AfterInlineLocalGroup.Sign( 31 )
   RETURN result
 
+! Bug O repro (#97): attrs + same-line terminator on a DATA-section GROUP local. A legal
+! single-line declaration like "LocalAttrGroup GROUP(SmallGroupType),DIM(2) END" (or the
+! period form ",DIM(2).") is self-closing, but GroupQueueDeclRegex's "term" group only
+! recognizes a terminator that DIRECTLY follows the name/type -- the ",.*" attrs alternative
+! swallows the terminator, "term" never matches, and the line was treated as opening a
+! multi-line body: dataGroupDepth leaked (contained to this DATA section -- CODE resets it),
+! silently skipping every subsequent local. AfterAttrLocalGroup below must still be captured
+! and its Sign call must resolve, proving no leak. Identical mechanism to the CLASS-body
+! variant fixed in ae9805b for #93 (MultiLineGroupBugClass.AttrTermGroup in WorkerLib.inc).
+! NOTE (#97 discussion): the ",attrs END" spelling is undocumented-but-working; if the Clarion
+! compiler rejects it, fall back to the doc-blessed period form for BOTH lines.
+AttrTermLocalGroupTest PROCEDURE( )
+result                 LONG
+LocalAttrGroup         GROUP(SmallGroupType),DIM(2) END
+LocalAttrGroupPeriod   GROUP(SmallGroupType),DIM(2).
+AfterAttrLocalGroup    &WorkerClass
+  CODE
+  result = AfterAttrLocalGroup.Sign( 32 )
+  RETURN result
+
 DerivableClass.Compute PROCEDURE( LONG pValue )
   CODE
   RETURN pValue


### PR DESCRIPTION
## Summary

Fixes the DATA-section variant of the `term`-group flaw (#97) — the same mechanism ae9805b fixed for CLASS members in #93. `GroupQueueDeclRegex`'s named `term` group only recognizes a terminator that DIRECTLY follows the name/type; with an attribute list present, the `,.*` attrs alternative swallows the terminator, so a legal single-line local like

```clarion
LocalAttrGroup   GROUP(SmallGroupType),DIM(2) END
LocalAttrGroup   GROUP(SmallGroupType),DIM(2).
```

was treated as opening a multi-line body. `dataGroupDepth` incremented with no closing line ever coming, and every subsequent local in that procedure's DATA section was silently skipped — so calls made through them couldn't resolve. (Contained to the one DATA section, since `CODE` resets the depth.)

## Fix

The ae9805b one-liner, applied to the `dataGroupDepth` check in **both synced parser copies** (`indexer/Parsing/ClarionParser.cs`, `CodeGraph/Parsing/ClarionParser.cs`): keep the regex for capture, but let the self-closing decision also re-check the end of the comment-stripped line:

```csharp
bool gqSelfClosing = gqMatch.Groups["term"].Success ||
    Regex.IsMatch(gqMatch.Value.TrimEnd(), @"(\bEND|\.)\s*$", RegexOptions.IgnoreCase);
```

(`gqMatch.Value` is the whole comment-stripped line — the regex is `^...$`-anchored.)

## Fixture

`AttrTermLocalGroupTest` added to `codegraph-repro` with **both** terminator spellings plus `AfterAttrLocalGroup &WorkerClass` whose `.Sign` call proves the section didn't leak. README expectations updated (20 → 21 `Sign` callers; shifted line numbers).

## Verification (ran the indexer against the fixture both ways)

| Parser | Sign callers | AttrTermLocalGroupTest | Symbols |
|---|---|---|---|
| master (pre-fix) | 20 | **missing** | 93 |
| this branch | **21** | present, call at line 266 | 95 |

No other caller rows changed. Main addin builds clean too (the CodeGraph copy compiles into it).

## Caveat from the issue discussion

The `,attrs END` spelling is undocumented-but-working per the #97 DocGraph/LR check; the fixture has not been re-compiled in Clarion with the new lines. If a compile of `ReproSolution` rejects the `,DIM(2) END` line, swap it to the doc-blessed period form (the fixture comment says so inline).

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
