### PR TITLE
chore(lsp): keep lsp-snapshot.json targetPin/currentPin honest on every sync (#77 housekeeping)

### DIFF
--- a/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
+++ b/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
@@ -79,6 +79,25 @@ function Info($m) { Line 'INFO' $m 'Cyan' }
 function Warn($m) { Line 'WARN' $m 'Yellow' }
 function Fail($m) { Line 'FAIL' $m 'Red' }
 
+# Keep ALL pin fields honest on a successful sync (#77 housekeeping): the sync used to update only
+# resolvedTag/resolvedCommit/lastSync, leaving targetPin/currentPin frozen at whatever hand-written
+# audit they last held -- after the v1.0.0 re-pin the manifest still reported targetPin v0.9.8 and a
+# June currentPin, so a first read said "behind" when the bundle was current. One writer, all fields.
+function Update-PinFields($manifest, $Tag, $repoRoot) {
+    $commit     = (git -C $repoRoot rev-parse --short HEAD)
+    $commitDate = (git -C $repoRoot show -s --format=%cs HEAD)
+    $manifest | Add-Member -NotePropertyName 'targetPin' -NotePropertyValue ([pscustomobject]@{
+        note = "Tag to sync toward; -Tag overrides. AUTO-UPDATED to the last successfully synced tag by Sync-LspServer.ps1 -- edit by hand only to stage a pin to a NEWER release before running the sync."
+        tag  = $Tag
+    }) -Force
+    $manifest | Add-Member -NotePropertyName 'currentPin' -NotePropertyValue ([pscustomobject]@{
+        note       = "AUTO-UPDATED by Sync-LspServer.ps1 on each successful sync -- the observed state of the just-synced checkout. Historical hand-audit notes live in git history (pre-#77 revisions of this file)."
+        tag        = $Tag
+        commit     = $commit
+        commitDate = $commitDate
+    }) -Force
+}
+
 # --- Resolve inputs -------------------------------------------------------------------
 if (-not (Test-Path $ManifestPath)) { throw "Manifest not found: $ManifestPath" }
 $manifest = Get-Content $ManifestPath -Raw | ConvertFrom-Json
@@ -177,8 +196,9 @@ try {
             Fail "Expected build output not found: $builtServer"; exit 6
         }
 
-        # Record the pure pin
+        # Record the pure pin (targetPin/currentPin included -- see Update-PinFields)
         $resolved = (git -C $PureRoot rev-parse --short HEAD 2>$null)
+        Update-PinFields $manifest $Tag $PureRoot
         $manifest | Add-Member -NotePropertyName 'pure'           -NotePropertyValue $true   -Force
         $manifest | Add-Member -NotePropertyName 'resolvedCommit' -NotePropertyValue $resolved -Force
         $manifest | Add-Member -NotePropertyName 'resolvedTag'    -NotePropertyValue $Tag      -Force
@@ -279,9 +299,11 @@ try {
         Fail "Expected build output not found: $builtServer"; exit 5
     }
 
-    # 5. Record the resolved pin back into the manifest
+    # 5. Record the resolved pin back into the manifest (targetPin/currentPin included)
     $resolved = (git rev-parse --short HEAD)
+    Update-PinFields $manifest $Tag '.'
     $manifest.resolvedCommit = $resolved
+    $manifest | Add-Member -NotePropertyName 'resolvedTag' -NotePropertyValue $Tag -Force
     $manifest.lastSync = (Get-Date -Format 'yyyy-MM-dd')
     ($manifest | ConvertTo-Json -Depth 12) | Set-Content -Path $ManifestPath -Encoding UTF8
     OK "manifest updated: resolvedCommit=$resolved lastSync=$($manifest.lastSync)"

--- a/ClarionAssistant/lsp-server-sync/lsp-snapshot.json
+++ b/ClarionAssistant/lsp-server-sync/lsp-snapshot.json
@@ -27,16 +27,14 @@
     ]
   },
   "currentPin": {
-    "note": "STATE AS OBSERVED 2026-07-03 in $CLARIONLSP_ROOT. The deployed snapshot is built from an UNTAGGED dev branch that forked near the 0.8.7 line — it is 318 commits BEHIND the v0.9.6 tag with only 2 experimental commits on top. This is the exact drift #40 tracks: the bundle is ~0.8.7-era code, well behind upstream v0.9.6 and the shared clarion-lsp addin v1.4.0.",
-    "branch": "feat/lsp-member-completion",
-    "commit": "383ef95",
-    "commitDate": "2026-06-13",
-    "behindLatestTagBy": 318,
-    "aheadOfLatestTagBy": 2
+    "note": "AUTO-UPDATED by Sync-LspServer.ps1 on each successful sync -- the observed state of the just-synced checkout. Historical hand-audit notes live in git history (pre-#77 revisions of this file).",
+    "tag": "v1.0.0",
+    "commit": "571ffcee",
+    "commitDate": "2026-07-11"
   },
   "targetPin": {
-    "note": "Recommended anchor to sync toward. As of the 2026-07-03 fetch the available tags are v0.9.6 (2026-04-23), v0.9.7 and v0.9.8 — v0.9.8 is the newest. Sync-LspServer.ps1 reports exact drift against whatever tag is chosen (-Tag), so confirm the cadence with @msarson and pick the newest STABLE tag. Pinning to any of these DROPS the 2 experimental member-completion commits (383ef95, 643b269) that are not on a tag — per issue #51 the equivalent capability ships in the public extension, so this is expected and desirable (it also pulls the bundle forward off the ~0.8.7-era branch). If the member-completion prototype must be retained, ask @msarson to cut a tag at/after 383ef95 and set that tag here instead.",
-    "tag": "v0.9.8"
+    "note": "Tag to sync toward; -Tag overrides. AUTO-UPDATED to the last successfully synced tag by Sync-LspServer.ps1 -- edit by hand only to stage a pin to a NEWER release before running the sync.",
+    "tag": "v1.0.0"
   },
   "pure": true,
   "resolvedCommit": "571ffcee",


### PR DESCRIPTION
## Summary

Housekeeping fallout from #77 (now closed): after the v1.0.0 re-pin in ed8bde5, `lsp-snapshot.json` still reported `targetPin: v0.9.8` and a June-era `currentPin` with a 318-commits-behind audit note — because the sync script only ever updated `resolvedTag`/`resolvedCommit`/`lastSync`. A first read of the manifest claimed the bundle was behind when it was fully current.

## Changes

- New `Update-PinFields` helper in `Sync-LspServer.ps1`, called from **both** sync paths (`-Pure` and legacy `-Apply`): sets `targetPin.tag` to the just-synced tag and replaces `currentPin` with the observed checkout state (tag, commit, commit date), each with an AUTO-UPDATED note pointing historians at git history.
- Fixes a latent gap: the legacy `-Apply` path never wrote `resolvedTag` at all.
- One-time correction of the snapshot to current reality: v1.0.0 / `571ffcee` / 2026-07-11 (verified against upstream — latest release is still v1.0.0, upstream master is 0/0 vs the tag).

## Verification

- PowerShell parser: zero errors.
- Snapshot JSON parses; helper dry-run against a live repo writes the expected fields and survives a `ConvertTo-Json` round-trip.
- `deploy.ps1` unaffected (it prefers `resolvedTag`, falling back to `targetPin.tag` — both now agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)