### PR TITLE
feat(editor): dark pre-cover — no white flash opening the CA Embeditor in dark mode

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -189,10 +189,11 @@ namespace ClarionAssistant
                 if (_editor != null) return;
                 // Reuse the rich embeditor Monaco surface (colorize/minimap/find/keymap come free) instead of
                 // the bespoke monaco-source.html page. We are its host; it renders a read-only fileMode mirror.
-                // isDark:false → the control backdrop + the WebView2 DefaultBackgroundColor are LIGHT, matching
-                // the page's default light theme (the page itself owns the actual light/dark choice via its
-                // persisted pref; this only sets the pre-paint backdrop so there's no dark flash on a light load).
-                _editor = new MonacoEditorControl(this, false, "monaco-embeditor.html", "clarion-embeditor-data");
+                // The control backdrop + WebView2 DefaultBackgroundColor follow the MIRRORED Monaco theme pref
+                // (CaEditorSettings.MonacoThemeDark — the page still owns the actual light/dark choice via its
+                // persisted localStorage pref; this only sets the pre-paint backdrop so there's no flash of the
+                // WRONG color on load, in either theme).
+                _editor = new MonacoEditorControl(this, Services.CaEditorSettings.MonacoThemeDark, "monaco-embeditor.html", "clarion-embeditor-data");
                 host.Controls.Add(_editor);
                 _editor.BringToFront();
                 HideNativeNavBar(host);   // hide the native class/members drop-down bar so it doesn't peek through the overlay top

--- a/ClarionAssistant/Services/CaEditorSettings.cs
+++ b/ClarionAssistant/Services/CaEditorSettings.cs
@@ -23,6 +23,7 @@ namespace ClarionAssistant.Services
         private const string KeySourceEnabled       = "ClarionAssistant.MonacoSourceEnabled";
         private const string KeyEmbeditorEnabled    = "ClarionAssistant.MonacoEmbeditorEnabled";
         private const string KeySourceFileTypes     = "ClarionAssistant.MonacoSourceFileTypes";
+        private const string KeyThemeDark           = "ClarionAssistant.MonacoThemeDark";
 
         /// <summary>Default extensions the Monaco SOURCE overlay applies to (when enabled).</summary>
         public const string DefaultSourceFileTypes = ".clw;.inc;.equ;.txa";
@@ -82,6 +83,32 @@ namespace ClarionAssistant.Services
                 catch { return true; }
             }
             set { TrySet(KeyEmbeditorEnabled, value ? "true" : "false"); }
+        }
+
+        /// <summary>
+        /// Host-side MIRROR of the Monaco page's persisted light/dark preference. The page owns the
+        /// authoritative value (localStorage "modernEmbeditor.themeDark", default LIGHT per John
+        /// 2026-06-02) and pushes a "themeChanged" bridge message on boot and on every toolbar theme
+        /// toggle; MonacoEditorControl persists it here. This exists so the pre-paint surfaces created
+        /// BEFORE any WebView2 is alive — the instant cover dropped over the native embeditor, the
+        /// control backdrop, WebView2.DefaultBackgroundColor — can match the theme the page will paint,
+        /// instead of hardcoding light and flashing WHITE for a dark-mode user on every embeditor open.
+        /// May lag the page by one toggle on a machine whose localStorage was cleared externally — the
+        /// boot push re-converges it on the next open, and the cost of a mismatch is one soft flash.
+        /// </summary>
+        public static bool MonacoThemeDark
+        {
+            get
+            {
+                try
+                {
+                    string raw = new SettingsService().Get(KeyThemeDark);
+                    if (raw == null) return false;   // default LIGHT — matches the page's default pref
+                    return ParseBool(raw, false);
+                }
+                catch { return false; }
+            }
+            set { TrySet(KeyThemeDark, value ? "true" : "false"); }
         }
 
         /// <summary>

--- a/ClarionAssistant/Services/EmbedEditorMonitorService.cs
+++ b/ClarionAssistant/Services/EmbedEditorMonitorService.cs
@@ -175,7 +175,9 @@ namespace ClarionAssistant.Services
                 // New embed / proc-change → (re)attach. Record BEFORE attaching so a re-entrant call can't double-fire.
                 _lastEditor = editor; _lastPwee = pwee;
 
-                string err = ModernEmbeditorLauncher.AttachOverlayToOpenEmbed(isDark: false);
+                // Theme the pre-cover (and the control backdrop behind it) from the mirrored Monaco pref —
+                // hardcoding light here flashed a WHITE cover on every embeditor open for dark-mode users.
+                string err = ModernEmbeditorLauncher.AttachOverlayToOpenEmbed(isDark: CaEditorSettings.MonacoThemeDark);
                 Log(err != null ? ("attach skipped (" + source + "): " + err) : ("attached via " + source));
                 FileLog(err != null ? ("attach skipped (" + source + "): " + err) : ("attached via " + source));
             }

--- a/ClarionAssistant/ShowModernEmbeditorCommand.cs
+++ b/ClarionAssistant/ShowModernEmbeditorCommand.cs
@@ -45,8 +45,10 @@ namespace ClarionAssistant
                     return;
                 }
 
-                // Light by default to match the Clarion IDE; auto-following the IDE theme is M3 polish.
-                var view = new ModernEmbeditorViewContent(title ?? "Embeditor", source, editableRanges, "clarion", isDark: false);
+                // Pre-paint backdrop follows the mirrored Monaco theme pref (the page owns the real
+                // choice and repaints itself) — hardcoded light flashed white for dark-mode users.
+                var view = new ModernEmbeditorViewContent(title ?? "Embeditor", source, editableRanges, "clarion",
+                    isDark: Services.CaEditorSettings.MonacoThemeDark);
                 WorkbenchSingleton.Workbench.ShowView(view);
             }
             catch (Exception ex)

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -256,6 +256,14 @@ namespace ClarionAssistant.Terminal
 
                 switch (action)
                 {
+                    case "themeChanged":
+                        // Page → host mirror of the persisted light/dark pref (localStorage is authoritative;
+                        // see CaEditorSettings.MonacoThemeDark). Handled here — not on IMonacoEditorHost — so
+                        // every Monaco surface mirrors it without each host implementing anything. Payload is
+                        // our own tiny fixed message, so a literal match beats a JSON round-trip.
+                        try { Services.CaEditorSettings.MonacoThemeDark = json.IndexOf("\"dark\":true", StringComparison.Ordinal) >= 0; }
+                        catch { }
+                        break;
                     case "ready":             h.OnReady(this); break;
                     case "save":              h.OnSave(this, json); break;
                     case "cancel":            h.OnCancel(this); break;

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -894,6 +894,11 @@
         try { document.documentElement.style.background = themePrefDark ? '#1e1e2e' : '#eff1f5'; } catch (e) { }
         function applyEarlyTheme() { try { document.body.classList.toggle('light', !themePrefDark); } catch (e) { } }
         if (document.body) applyEarlyTheme(); else document.addEventListener('DOMContentLoaded', applyEarlyTheme);
+        // Mirror the effective pref to the host (settings.txt) so the NEXT open's pre-paint surfaces —
+        // the C# instant cover over the native embeditor, the control backdrop, the WebView2 default
+        // background — match this theme instead of hardcoding light. localStorage stays authoritative;
+        // pushing on every boot re-converges the mirror if the two ever diverge (e.g. cleared profile).
+        try { postToHost({ action: 'themeChanged', dark: themePrefDark }); } catch (e) { }
     })();
 
     function updateThemeBtn() {
@@ -909,6 +914,8 @@
         try { localStorage.setItem('modernEmbeditor.themeDark', themePrefDark ? '1' : '0'); } catch (e) { }
         setTheme(themePrefDark);
         updateThemeBtn();
+        // Keep the host-side mirror current (see the boot push above) so the next open's pre-cover matches.
+        try { postToHost({ action: 'themeChanged', dark: themePrefDark }); } catch (e) { }
     }
 
     // Grey out Undo/Redo when the focused editor's model has nothing to undo/redo. Best-effort: if the Monaco


### PR DESCRIPTION
## Problem

A dev running dark mode gets a **flash of white** every time the CA Embeditor opens. The instant cover we drop over the native embeditor (to smooth the transition) — plus the control backdrop and WebView2 `DefaultBackgroundColor` behind it — hardcode light, because the real theme choice lives only in the *page's* `localStorage` (`modernEmbeditor.themeDark`, default light, wins over everything), which C# can't read before any WebView2 exists.

## Fix — mirror the pref host-side (John's design)

- **Page** posts `{action:'themeChanged', dark}` at boot and on every toolbar theme toggle. Boot-push means the mirror re-converges on every open, so it can lag localStorage by at most one toggle (cost: one soft flash) even if the WebView2 profile is cleared externally.
- **`MonacoEditorControl`** handles the new `themeChanged` case in its bridge dispatch and persists it via a new `CaEditorSettings.MonacoThemeDark` (settings.txt). Handled in the control rather than `IMonacoEditorHost`, so every Monaco surface mirrors it with zero per-host code.
- **Consumers** read the mirror instead of hardcoding light:
  - the embed monitor's `AttachOverlayToOpenEmbed` pre-cover (the reported flash),
  - `ShowModernEmbeditorCommand`'s view,
  - `MonacoClarionSourceEditor`'s control backdrop (CA Editor tabs get the same treatment).

localStorage remains authoritative — this only themes the pre-paint surfaces; the page still repaints itself from its own pref.

## Verification

- NUL-byte scan clean; all inline script blocks pass `node --check`; Debug build clean.
- In-IDE pass next deploy: on a machine with the dark pref, open the CA Embeditor → the cover comes up dark with no white flash (first open after this deploy may still flash once — the mirror seeds on that first page boot); light-pref machines unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)