### PR TITLE
docs: v5.4 release notes, README, and user-guide updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ClarionLive/ClarionAssistant/releases/tag/v5.3.0"><img src="https://img.shields.io/github/v/release/ClarionLive/ClarionAssistant?include_prereleases&label=download&style=for-the-badge" alt="Download"></a>
-  <img src="https://img.shields.io/badge/Clarion-10%20%7C%2011%20%7C%2012-blue?style=for-the-badge" alt="Clarion 10 | 11 | 12">
-  <img src="https://img.shields.io/badge/version-5.3-blue?style=for-the-badge" alt="v5.3">
+  <a href="https://github.com/ClarionLive/ClarionAssistant/releases/tag/v5.4.0"><img src="https://img.shields.io/github/v/release/ClarionLive/ClarionAssistant?include_prereleases&label=download&style=for-the-badge" alt="Download"></a>
+  <img src="https://img.shields.io/badge/Clarion-10%20%7C%2011%20%7C%2011.1%20%7C%2012-blue?style=for-the-badge" alt="Clarion 10 | 11 | 11.1 | 12">
+  <img src="https://img.shields.io/badge/version-5.4-blue?style=for-the-badge" alt="v5.4">
 </p>
 
 ---
@@ -41,23 +41,47 @@ Ask it to write Clarion code, explain procedures, refactor classes, build COM co
 - **Code Snippets (Ctrl+J)** &mdash; classic Clarion template-picker parity: insert reusable code with tab-stops and a `${SELECTED}` placeholder, managed from Settings &rarr; Snippets
 - **CA Explorer** &mdash; docked pad showing the active CA Embeditor tab's Local, Module &amp; Global Data, Declared Tables, Other Files, and their Keys, Columns, and Relations; drag a field to the editor or Window designer, copy/paste variables native-style, and a Cheat Sheet tab of editor shortcuts
 - **Evaluate Code** &mdash; interactive code review for entire apps, procedures, open files, or selected code
-- **Diff viewer** &mdash; Monaco-based side-by-side diffs with syntax highlighting
+- **CA Find & Replace** &mdash; dockable Find pad or classic in-editor overlay (your pick), Find-All with results in their own editor tab, and one shared history across every CA surface
+- **Document Structure** &mdash; fly-out outline of the current buffer with symbol icons, Class &#9656; Methods regrouping, and filtering; click to navigate
+- **Diff viewer** &mdash; Monaco-based side-by-side diffs with syntax highlighting, live-buffer diffing, and a current-line comparison panel
 - **Knowledge system** &mdash; persistent cross-session memory for decisions, patterns, and gotchas
 - **Zoom persistence** &mdash; Ctrl+mousewheel zoom is saved and restored across sessions
 
 ---
 
-## What's New (Unreleased)
+## What's New in v5.4
+
+v5.4 is the biggest community cycle yet. Full notes: [docs/releases/v5.4.0.md](docs/releases/v5.4.0.md).
+
+### CA Find & Replace suite (#66)
+Find & Replace becomes a first-class subsystem: a dockable **CA Find pad** (the default for Ctrl+F/Ctrl+H), an optional classic **in-editor overlay** (Options &rarr; Clarion Assistant &rarr; Find / Replace), a **Find-All** column whose results can open in their own editor tab with context, click-through, and filtering (#113/#114), and **one shared find/replace history** across every CA surface with a per-procedure recent group.
+
+### Document Structure outline
+A fly-out outline of the current buffer &mdash; procedures, routines, classes and data with VS Code's symbol icons, Class &#9656; Methods regrouping, filtering, and expand/collapse-all. Click to jump; Navigate Back returns you.
+
+### Parameter hints, Ctrl+F12, real-scope embeds
+Signature help while typing a call (#75) and go-to-implementation (#78) in both Monaco surfaces. The embed buffer is now presented to the language server as a real MEMBER module of your PROGRAM, so completion/hover/F12 inside embeds see your global data (#74). `:` triggers completion like `.` (#52).
 
 ### Dictionary- and CodeGraph-aware completion in the CA Embeditor
+Completion reaches into your ingested **SchemaGraph** (dictionary tables/fields/keys) and **CodeGraph** (solution-wide symbols) databases (#99): `PRE:` prefixes suggest that table's columns and keys with declared types and descriptions; bare prefixes suggest dictionary table names; variable completions show real declared types and scope. Requires a SchemaGraph source indexed once via Solution Settings &rarr; Schema Sources.
 
-The CA Embeditor's completion now reaches into your ingested **SchemaGraph** (dictionary tables/fields/keys) and **CodeGraph** (solution-wide symbols) databases, not just the LSP and the current buffer:
+### Navigation history that keeps its promises
+Back/Forward reliably return to the position the editor opened at, outline jump targets, go-to-definition origins, and host-driven jumps &mdash; explicit targets are pinned so a follow-up click can't erase them.
 
-- **Dictionary fields and keys** &mdash; typing a table's `PRE:` prefix (e.g. `Cus:`) now also suggests that table's columns and keys straight from the ingested `.dctx`, with declared type, description, and (for keys) full field composition shown in the completion detail/documentation panel. Shown alongside any same-named in-buffer `GROUP`/`QUEUE` fields, not instead of them.
-- **Dictionary table names** &mdash; bare-prefix completion now also suggests table names from the dictionary (e.g. `Cus` &rarr; `Customers`).
-- **Richer variable detail** &mdash; completion for locals, module-scope variables, and cross-file CodeGraph globals now shows the actual declared type (`STRING(30)`, `DECIMAL(13,2)`, ...), a `!`-comment description when present, and local/global scope &mdash; instead of a generic "variable" label.
+### Dark mode & accessibility
+No white flash opening the embeditor in dark mode; contrast-guarded toolbar text on dark IDE chrome; Monaco's High Contrast toggle persists across sessions with visibly shaded read-only sections; CA Explorer tooltips drawn in-page (fixes a stuck-tooltip bug, #108).
 
-Requires a SchemaGraph source to be added and indexed once via the **Schema Sources** panel (Solution Settings &rarr; Schema Sources &rarr; Add Source).
+### CodeGraph accuracy campaign
+~20 indexer fixes driven by real production code (#79&ndash;#93, #97, #112, #118): INCLUDE discovery, typed PROCEDURE parameters, cross-file and inherited member call resolution, every GROUP/QUEUE/CLASS declaration spelling, built-in name collisions &mdash; with the repro solution vendored as a regression fixture.
+
+### Clarion 11.1, VS2026, portable installs (#91)
+Clarion **11.1** is a distinct build/deploy/install target; the build supports VS2026 Build Tools; installer paths are portable.
+
+### Diff, terminal & reliability
+Live-buffer diffs with encoding detection (#94), a current-line comparison panel (#96), clipboard-image paste as @-reference (#95); embeditor tab-switch no longer reloads/loses edits (#76), WebView2 crash process reaping (#109/#120), bundled LSP re-pinned to Clarion-Extension v1.0.0 (#77 &mdash; the per-configuration redirection fix), server re-root on solution switch (#106).
+
+### Thanks
+Community contributions from **Mark Sarson**, **geircodes**, **Andrew Santarelli**, **OkayPlunk**, plus reports from **BoxSoft** and **Bill Atchison**.
 
 ---
 

--- a/docs/ClarionAssistant-Guide.html
+++ b/docs/ClarionAssistant-Guide.html
@@ -439,6 +439,7 @@
   <nav class="sidebar">
     <h3>What's New</h3>
     <a href="#whats-new">Release Notes</a>
+    <a href="#whats-new-54" class="sub">v5.4</a>
     <a href="#whats-new-50" class="sub">v5.1</a>
     <a href="#whats-new-snippets" class="sub">Code Snippets (Ctrl+J)</a>
     <a href="#whats-new-sidecar" class="sub">Custom MCP Servers</a>
@@ -470,6 +471,8 @@
     <a href="#ca-monaco-editor" class="sub">Monaco Source Editor</a>
     <a href="#ca-snippets" class="sub">Code Snippets (Ctrl+J)</a>
     <a href="#ca-data-pad" class="sub">CA Explorer</a>
+    <a href="#ca-find" class="sub">Find &amp; Replace</a>
+    <a href="#ca-outline" class="sub">Document Structure</a>
 
     <h3>Class Helper</h3>
     <a href="#class-helper">Overview</a>
@@ -523,6 +526,26 @@
 <!-- ════════════════════════════════════════════════════ -->
 <section id="whats-new" class="doc-section">
   <h2>What's New</h2>
+
+  <h3 id="whats-new-54">v5.4 &mdash; Find &amp; Replace Suite, Document Structure, Dark Mode Polish</h3>
+
+  <p>
+    v5.4 is the biggest community release cycle yet. <a href="#ca-find"><strong>Find &amp; Replace</strong></a>
+    becomes a full subsystem &mdash; a dockable CA Find pad (the default for <kbd>Ctrl</kbd>+<kbd>F</kbd> /
+    <kbd>Ctrl</kbd>+<kbd>H</kbd>), an optional classic in-editor overlay, Find-All results in their own
+    editor tab, and one shared history across every CA surface. The new
+    <a href="#ca-outline"><strong>Document Structure</strong></a> fly-out shows an outline of the current
+    buffer with click-to-navigate. The editor gains <strong>signature help</strong> (parameter hints),
+    <strong>Ctrl+F12 go-to-implementation</strong>, and dictionary/CodeGraph-aware completion; embeds are
+    presented to the language server in your app's <em>real</em> scope, so completion and F12 inside an
+    embed see your global data. Navigation history now reliably returns to where the editor opened and to
+    outline jump targets. Dark-mode users get flash-free embeditor opens, readable toolbar chrome, and a
+    persisted High Contrast toggle with visible read-only shading. CodeGraph accuracy improves with ~20
+    parser fixes driven by real production code, and <strong>Clarion 11.1</strong> joins 10/11/12 as a
+    distinct install target. Full notes:
+    <a href="https://github.com/ClarionLive/ClarionAssistant/blob/master/docs/releases/v5.4.0.md">v5.4.0 release notes</a>
+    (v5.2 and v5.3 notes are on GitHub as well).
+  </p>
 
   <h3 id="whats-new-50">v5.1 &mdash; CA Embeditor, CA Explorer &amp; Monaco Editor</h3>
 
@@ -1582,6 +1605,46 @@
       shortcuts.
     </li>
   </ul>
+
+  <h3 id="ca-find">Find &amp; Replace</h3>
+  <p>
+    <kbd>Ctrl</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>H</kbd> in a CA editor open the
+    <strong>CA Find pad</strong> &mdash; a dockable IDE pad that follows whichever CA Editor or
+    CA Embeditor tab is active. Prefer the classic in-editor find box? Switch to the
+    <strong>Overlay</strong> style under <strong>Options &rarr; Clarion Assistant &rarr;
+    Find / Replace</strong>.
+  </p>
+  <ul>
+    <li>
+      <strong>Find-All</strong> &mdash; list every match in a results column, or open the results in
+      their <em>own editor tab</em> with surrounding context lines, click-through navigation to each
+      match, and filtering.
+    </li>
+    <li>
+      <strong>Shared history</strong> &mdash; find and replace terms are shared across the pad, the
+      overlay, and every CA editor tab, with this procedure's recent terms grouped on top.
+    </li>
+    <li>
+      <strong>Embeditor-aware replace</strong> &mdash; in the CA Embeditor, replace respects
+      read-only generated code; an "include read-only blocks" toggle controls whether generated
+      lines appear in the results at all.
+    </li>
+    <li>
+      <strong>Live positions</strong> &mdash; matches track your edits, so <kbd>F3</kbd> and
+      Replace land where the match is <em>now</em>, not where it was when you searched.
+    </li>
+  </ul>
+
+  <h3 id="ca-outline">Document Structure</h3>
+  <p>
+    The <strong>Document Structure</strong> fly-out (toolbar button in the CA Editor and
+    CA Embeditor) shows an outline of the current buffer &mdash; procedures, routines, classes,
+    and data &mdash; using the same symbol icons VS Code uses, with classes regrouped as
+    <strong>Class &#9656; Methods</strong>. Type in the filter box to narrow the tree; matches
+    stay expanded. Click any symbol to jump to it &mdash; and <strong>Navigate Back</strong>
+    (<kbd>Alt</kbd>+<kbd>Left</kbd>) returns you to where you were, with the jump target kept
+    in the navigation history dropdown.
+  </p>
 </section>
 
 <!-- ════════════════════════════════════════════════════ -->

--- a/docs/releases/v5.4.0.md
+++ b/docs/releases/v5.4.0.md
@@ -1,0 +1,94 @@
+# Clarion Assistant 5.4
+
+5.4 is the biggest community cycle yet — find & replace grows into a full suite, the editor gains a Document Structure outline, signature help, and go-to-implementation, the CodeGraph parser gets a ~20-fix accuracy campaign driven by real production code, and dark-mode users get a long list of polish. **Clarion 11.1 joins the supported lineup as a distinct install target.**
+
+**Supported:** Clarion 10, 11, 11.1, and 12 (32‑bit IDE). The installer lets you pick which version(s) to install.
+
+---
+
+## Highlights
+
+### 🔍 CA Find & Replace suite ([#66](https://github.com/ClarionLive/ClarionAssistant/issues/66))
+Find & Replace grows from an editor widget into a first-class subsystem:
+- **CA Find pad** — a dockable IDE pad (the default UI for Ctrl+F / Ctrl+H) that follows whichever CA editor tab is active.
+- **In-editor overlay** — prefer the classic top-right find box? Pick it under **Options → Clarion Assistant → Find / Replace**.
+- **Find-All** — a results column in the editor, and results can open in their **own editor tab** with surrounding context, click-through navigation, and filtering ([#113](https://github.com/ClarionLive/ClarionAssistant/issues/113), [#114](https://github.com/ClarionLive/ClarionAssistant/pull/114)).
+- **One shared history** — find/replace terms are shared across the pad, the overlay, the CA Editor, and the CA Embeditor, with a per-procedure recent group on top.
+
+### 🧭 Document Structure outline
+A fly-out outline for the current buffer: procedures, routines, classes and data in a tree with VS Code's own symbol icons, a **Class ▸ Methods** regrouping, filtering, and expand/collapse-all. Click a symbol to jump there — and Navigate Back returns you to where you were ([#110](https://github.com/ClarionLive/ClarionAssistant/pull/110)).
+
+### ✍️ Parameter hints, go-to-implementation, and real-scope embeds
+- **Signature help** — parameter hints as you type a call, in both the CA Editor and CA Embeditor ([#75](https://github.com/ClarionLive/ClarionAssistant/pull/75)).
+- **Ctrl+F12 go-to-implementation** in both Monaco surfaces ([#78](https://github.com/ClarionLive/ClarionAssistant/pull/78)).
+- **Embeds live in your app's real scope** — the embed buffer is presented to the language server as a real MEMBER module of your PROGRAM, so completion, hover, and F12 inside an embed see your global data and prefixed structures ([#74](https://github.com/ClarionLive/ClarionAssistant/pull/74), [#56](https://github.com/ClarionLive/ClarionAssistant/issues/56)).
+- **`:` triggers completion** like `.` does ([#52](https://github.com/ClarionLive/ClarionAssistant/pull/52)).
+- **Dictionary- and CodeGraph-aware completion** in the CA Embeditor — file columns and solution symbols in the suggestion list ([#99](https://github.com/ClarionLive/ClarionAssistant/pull/99)).
+- **No completion popups inside string literals or comments.**
+
+### 🧭 Navigation history that keeps its promises
+Back/Forward (Alt+Left / Alt+Right) now reliably return you to:
+- the position the editor **opened** at (the restored cursor),
+- any symbol you jumped to from the **Document Structure** outline,
+- go-to-definition origins and targets, host-driven jumps (debugger, breakpoint list, search results), and Data-pad routine go-tos.
+Explicit jump targets are pinned — a small follow-up click no longer silently erases them from the history.
+
+### 🌒 Dark mode & accessibility
+- **No more white flash** opening the CA Embeditor in dark mode — the transition cover now matches your editor theme.
+- **Readable toolbar text on dark IDE chrome** — Reload/Save and the title get a contrast-guarded color whatever theme combination you run.
+- **High Contrast sticks** — Monaco's right-click "Toggle High Contrast Theme" is now persisted and restored across sessions, and read-only (generated) sections stay visibly shaded under both Monaco HC themes and Windows High Contrast ([#129](https://github.com/ClarionLive/ClarionAssistant/pull/129)).
+- **CA Explorer tooltips are drawn in-page** — fixes a stuck native tooltip that could linger on screen until the IDE closed ([#108](https://github.com/ClarionLive/ClarionAssistant/issues/108)).
+
+### 🗺️ CodeGraph accuracy campaign
+A sustained, production-code-driven fix series for the solution indexer — INCLUDE discovery, PROCEDURE parameters as typed symbols, cross-file class-member call resolution, trailing-comment declarations, GROUP/QUEUE/CLASS capture in all their single-line/attribute/named-type spellings, calls through inherited members, method names that collide with Clarion built-ins, and more ([#79](https://github.com/ClarionLive/ClarionAssistant/issues/79)–[#93](https://github.com/ClarionLive/ClarionAssistant/issues/93), [#97](https://github.com/ClarionLive/ClarionAssistant/issues/97), [#112](https://github.com/ClarionLive/ClarionAssistant/pull/112), [#118](https://github.com/ClarionLive/ClarionAssistant/pull/118)). The repro solution behind many of these is now a vendored regression fixture, so the fixes stay fixed.
+
+### 🏗️ Clarion 11.1, VS2026, portable installs ([#91](https://github.com/ClarionLive/ClarionAssistant/pull/91))
+Clarion **11.1** is now a distinct build/deploy/install target (its binding DLLs are version-specific — it never shares 11's), the build supports **VS2026 Build Tools**, and installer paths are portable.
+
+### 🩻 Diff & terminal
+- `show_diff` can diff the **live editor buffer** directly, in-process — and detects file encoding instead of assuming UTF-8 ([#94](https://github.com/ClarionLive/ClarionAssistant/issues/94)).
+- Optional **current-line comparison panel** in the Monaco diff viewer ([#96](https://github.com/ClarionLive/ClarionAssistant/pull/96)).
+- **Paste a clipboard image** into the terminal as an @-reference file ([#95](https://github.com/ClarionLive/ClarionAssistant/pull/95)).
+
+---
+
+## 🐞 Fixed
+
+### Editor & Embeditor
+- **Tab-away/tab-back no longer reloads the overlay** — unsaved embed edits survive switching tabs, and closing a file opened via F12 returns you to the embed exactly where you were ([#76](https://github.com/ClarionLive/ClarionAssistant/issues/76)).
+- Overlay-mode embed close now consistently releases the find broker and the LSP module shadow — stale hover/definition answers and dead search-results clicks after closing an embed are gone ([#113](https://github.com/ClarionLive/ClarionAssistant/issues/113), [#115](https://github.com/ClarionLive/ClarionAssistant/issues/115), [#119](https://github.com/ClarionLive/ClarionAssistant/issues/119)).
+- `open_file` line navigation lands on the right line, centered ([#111](https://github.com/ClarionLive/ClarionAssistant/pull/111)).
+- Find accelerators no longer leak to the hidden native editor; initial-open focus lands in the editor.
+
+### Reliability
+- **WebView2 crash cleanup** — a crashed browser process tree is reaped via a kill-on-close job ([#109](https://github.com/ClarionLive/ClarionAssistant/issues/109), [#120](https://github.com/ClarionLive/ClarionAssistant/pull/120)).
+- **Bundled language server re-pinned to Clarion-Extension v1.0.0** ([#77](https://github.com/ClarionLive/ClarionAssistant/issues/77)) — headline: per-configuration redirection sections are no longer dropped (previously ~99% of a redirection-heavy solution's files could fail to resolve), plus a major startup/responsiveness overhaul and persisted indexes.
+- The bundled server **re-roots when you switch solutions** ([#106](https://github.com/ClarionLive/ClarionAssistant/issues/106)).
+- Diff viewer tabs are view-only — Save can't crash them ([#103](https://github.com/ClarionLive/ClarionAssistant/issues/103)).
+- MCP tools: `select_range` no longer throws on ambiguous matches ([#83](https://github.com/ClarionLive/ClarionAssistant/issues/83)); `get_open_files`/`is_modified` work against non-public editor members ([#82](https://github.com/ClarionLive/ClarionAssistant/issues/82)).
+
+---
+
+## 🙏 Thanks
+
+This cycle's community contributions:
+- **Mark Sarson** — signature help ([#75](https://github.com/ClarionLive/ClarionAssistant/pull/75)), go-to-implementation ([#78](https://github.com/ClarionLive/ClarionAssistant/pull/78)), real-scope embeds ([#74](https://github.com/ClarionLive/ClarionAssistant/pull/74)), Find-All results tab ([#114](https://github.com/ClarionLive/ClarionAssistant/pull/114)), LSP re-root ([#107](https://github.com/ClarionLive/ClarionAssistant/pull/107)), overlay shadow revert ([#117](https://github.com/ClarionLive/ClarionAssistant/pull/117)), WebView2 crash reaping ([#120](https://github.com/ClarionLive/ClarionAssistant/pull/120)) — plus the Clarion-Extension v1.0.0 release the bundled server now rides on.
+- **geircodes** — much of the CodeGraph accuracy campaign (fixes [#92](https://github.com/ClarionLive/ClarionAssistant/pull/92), [#93](https://github.com/ClarionLive/ClarionAssistant/pull/93), [#112](https://github.com/ClarionLive/ClarionAssistant/pull/112), [#118](https://github.com/ClarionLive/ClarionAssistant/pull/118) and the repro reports behind [#79](https://github.com/ClarionLive/ClarionAssistant/issues/79)–[#90](https://github.com/ClarionLive/ClarionAssistant/issues/90)), the vendored regression fixture, diff/terminal features ([#94](https://github.com/ClarionLive/ClarionAssistant/pull/94), [#95](https://github.com/ClarionLive/ClarionAssistant/pull/95), [#96](https://github.com/ClarionLive/ClarionAssistant/pull/96), [#100](https://github.com/ClarionLive/ClarionAssistant/pull/100), [#101](https://github.com/ClarionLive/ClarionAssistant/pull/101), [#103](https://github.com/ClarionLive/ClarionAssistant/pull/103), [#111](https://github.com/ClarionLive/ClarionAssistant/pull/111)).
+- **Andrew Santarelli** — dictionary/CodeGraph-aware completion ([#99](https://github.com/ClarionLive/ClarionAssistant/pull/99)).
+- **OkayPlunk** — Clarion 11.1 target, VS2026 Build Tools, portable installer paths ([#91](https://github.com/ClarionLive/ClarionAssistant/pull/91)).
+- **BoxSoft** and **Bill Atchison** — sharp bug reports and feature discussion ([#70](https://github.com/ClarionLive/ClarionAssistant/issues/70), [#72](https://github.com/ClarionLive/ClarionAssistant/issues/72), [#108](https://github.com/ClarionLive/ClarionAssistant/issues/108)).
+
+---
+
+## 📦 Install
+
+1. Download **`ClarionAssistant-5.4-Setup.exe`** below (code‑signed).
+2. Close the Clarion IDE.
+3. Run the installer and pick your Clarion version(s) (10 / 11 / 11.1 / 12).
+4. Start Clarion — the **Clarion Assistant** pane docks automatically (Tools → Clarion Assistant, or Ctrl+Alt+C).
+
+Upgrading from 5.1/5.2/5.3 installs cleanly over the top.
+
+---
+
+_Clarion Assistant is an AI‑powered coding assistant embedded in the Clarion IDE. See the bundled User Guide (Help) for the full walkthrough._


### PR DESCRIPTION
Documentation for the upcoming 5.4 release, written while John validates the deploy.

- **`docs/releases/v5.4.0.md`** — full themed release notes for everything since 5.3.0, with contributor credits (msarson, geircodes, asantarelli, OkayPlunk, BoxSoft, Bill Atchison). Named v5.4.0 per the `-Minor` release recipe — trivial rename if the release ends up a different number.
- **README** — `What's New (Unreleased)` → `What's New in v5.4` (the #99 completion notes folded in), badges bumped (5.4, Clarion 10|11|11.1|12), Key Capabilities gains **CA Find & Replace** and **Document Structure** bullets.
- **User guide** — v5.4 What's New entry, plus new **Find & Replace** and **Document Structure** sections in the CA Embeditor chapter with sidebar links. The guide's What's New had stopped at v5.1; the new entry links the GitHub notes for 5.2/5.3 rather than backfilling — a fuller guide refresh can ride a future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)