### PR TITLE
fix(editor): a structure keyword used as a plain variable name breaks the per-slot balance heuristic

### DIFF
--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -57,6 +57,25 @@ namespace ClarionAssistant.Services
         private static readonly Regex BandOpen = new Regex(
             @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(HEADER|FOOTER|FORM|DETAIL)\s*(?:[,(]|$)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // Declaration structures that declare a NAMED INSTANCE always require a preceding label
+        // ("Label STRUCTURETYPE,attrs") — these keywords are NOT reserved words in Clarion, so a
+        // variable/label legally named e.g. "Report" or "Window" (declared as "Report &STRING") must
+        // not be mistaken for the keyword itself. Deliberately narrow: only keywords confirmed to
+        // ALWAYS take a label are gated here. Excluded on purpose — these are legitimately written
+        // BARE, with no preceding label, and gating them caused a real regression (confirmed live:
+        // "MAP" / "MODULE('')" in a plain MAP...END prototype block):
+        //   MAP, MODULE       — namespace-like scoping constructs, never labeled.
+        //   ITEMIZE, JOIN     — nested inside LIST/VIEW bodies, never labeled.
+        //   HEADER, FOOTER, FORM, DETAIL, MENUBAR, MENU, TOOLBAR, SHEET, TAB, OPTION
+        //                     — nested inside WINDOW/REPORT bodies; identified by an optional
+        //                       ?field-equate via USE(), not a plain leading label.
+        // Execution structures (LOOP/CASE/BEGIN/EXECUTE/ACCEPT) legitimately have no preceding label
+        // either and were never in this set.
+        private static readonly HashSet<string> DeclarationStructKeywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "GROUP", "QUEUE", "RECORD", "FILE", "VIEW", "REPORT", "WINDOW", "APPLICATION",
+            "CLASS", "INTERFACE"
+        };
         private static readonly Regex EndRx = new Regex(@"^END\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex IfRx = new Regex(@"^IF\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         // 'DO RoutineName' — DO must start the statement (line start, whitespace, or after ';').
@@ -170,12 +189,33 @@ namespace ClarionAssistant.Services
                         if (!oneLiner) open.Push(new[] { ln, FirstNonWs(code) + 1 });
                         // fall through so a 'DO' on the same line is still checked
                     }
-                    else if (StructOpen.IsMatch(u) || BandOpen.IsMatch(u))
+                    else
                     {
-                        // Skip a self-terminated inline structure (trailing '.' or an END later on the
-                        // same line, e.g. "EXECUTE n; a; b END") — only multi-line openers are tracked.
-                        bool selfTerminated = TrailingDot.IsMatch(trimmed) || InlineEnd.IsMatch(u);
-                        if (!selfTerminated) open.Push(new[] { ln, FirstNonWs(code) + 1 });
+                        Match structMatch = StructOpen.Match(u);
+                        Match bandMatch = structMatch.Success ? null : BandOpen.Match(u);
+                        Match openMatch = structMatch.Success ? structMatch : bandMatch;
+
+                        if (openMatch != null && openMatch.Success)
+                        {
+                            // ✅ FIX: if the matched keyword is a declaration-structure keyword AND
+                            // nothing but whitespace precedes it on the line, the optional label group
+                            // backtracked to empty — meaning this word IS the label itself (e.g. "Report"
+                            // in "Report          &STRING"), not a structure type in second position.
+                            // Skip it so it falls through as a plain statement instead of pushing a
+                            // bogus, never-closed opener that would swallow a later real END and make an
+                            // unrelated, genuinely-terminated structure misreport as unterminated.
+                            string keyword = openMatch.Groups[1].Value;
+                            bool keywordIsFirstWord = u.Substring(0, openMatch.Groups[1].Index).Trim().Length == 0;
+                            bool usedAsLabel = keywordIsFirstWord && DeclarationStructKeywords.Contains(keyword);
+
+                            if (!usedAsLabel)
+                            {
+                                // Skip a self-terminated inline structure (trailing '.' or an END later on the
+                                // same line, e.g. "EXECUTE n; a; b END") — only multi-line openers are tracked.
+                                bool selfTerminated = TrailingDot.IsMatch(trimmed) || InlineEnd.IsMatch(u);
+                                if (!selfTerminated) open.Push(new[] { ln, FirstNonWs(code) + 1 });
+                            }
+                        }
                     }
 
                     // Undefined routine: DO <name>

--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -197,15 +197,19 @@ namespace ClarionAssistant.Services
 
                         if (openMatch != null && openMatch.Success)
                         {
-                            // ✅ FIX: if the matched keyword is a declaration-structure keyword AND
-                            // nothing but whitespace precedes it on the line, the optional label group
-                            // backtracked to empty — meaning this word IS the label itself (e.g. "Report"
-                            // in "Report          &STRING"), not a structure type in second position.
-                            // Skip it so it falls through as a plain statement instead of pushing a
-                            // bogus, never-closed opener that would swallow a later real END and make an
-                            // unrelated, genuinely-terminated structure misreport as unterminated.
+                            // ✅ FIX: if the matched keyword is a declaration-structure keyword AND it's at
+                            // column 0 of this (already-trimmed) line, the optional label group backtracked
+                            // to empty — meaning this word IS the label itself (e.g. "Report" in
+                            // "Report          &STRING"), not a structure type in second position. A Clarion
+                            // label always starts at column 0 (confirmed directly against the compiler:
+                            // indenting a label desyncs the parser and produces unrelated errors on the
+                            // following tokens), so a match at column 0 can only be the label — a real
+                            // structure type always has a label before it. Skip it so it falls through as a
+                            // plain statement instead of pushing a bogus, never-closed opener that would
+                            // swallow a later real END and make an unrelated, genuinely-terminated structure
+                            // misreport as unterminated.
                             string keyword = openMatch.Groups[1].Value;
-                            bool keywordIsFirstWord = u.Substring(0, openMatch.Groups[1].Index).Trim().Length == 0;
+                            bool keywordIsFirstWord = openMatch.Groups[1].Index == 0;
                             bool usedAsLabel = keywordIsFirstWord && DeclarationStructKeywords.Contains(keyword);
 
                             if (!usedAsLabel)


### PR DESCRIPTION
## Summary

Fixes a false "structure not terminated" warning (and a cascading false positive on an unrelated, genuinely-terminated structure) when a Clarion structure keyword is used as a plain variable/label name.

## Root cause

`ModernEmbeditorDiagnostics.Compute(...)`'s per-slot structure-balance heuristic (Passes 2/3 of the hybrid diagnostics pipeline — used both by the dedicated Modern Embeditor and, deliberately, by the regular Monaco source editor for plain `.clw`/`.inc` files, per that method's own doc comments) matches Clarion structure keywords (`GROUP`, `QUEUE`, `RECORD`, `FILE`, `VIEW`, `REPORT`, `WINDOW`, `APPLICATION`, `CLASS`, `INTERFACE`, plus namespace/nested constructs like `MAP`, `MODULE`, band structures, etc.) via a regex (`StructOpen`) with an optional leading-label group.

These keywords are **not reserved words** in Clarion — they're fully legal identifiers. A DATA-section declaration like:

```
Report          &STRING
```

declares a reference-to-STRING variable literally named `Report`. When the regex's optional label group backtracks to empty and the keyword sits at the very start of the trimmed line, that's structurally ambiguous — it's the correct shape for execution structures with no label, but here it means `Report` was matched *as if it opened a REPORT structure*, pushing a bogus, never-closed "opener" onto the per-slot balance stack.

This is not just a cosmetic issue — it cascades: a second bare usage of the same identifier later in the same procedure body (e.g. `Report &= SomeObject.SomeMethod()`, also at the start of its line) matched too, pushing a *second* bogus opener. Two extra, permanently un-popped stack entries meant two later, real `END`s got mis-attributed when the stack drained — making a genuinely-terminated, unrelated `IF`/`END` pair elsewhere in the same procedure also misreport as "not terminated."

## Fix

Changed the match check from a boolean `IsMatch` to capturing the actual `Match`, then: if the matched keyword is in a narrow `DeclarationStructKeywords` set (`GROUP`, `QUEUE`, `RECORD`, `FILE`, `VIEW`, `REPORT`, `WINDOW`, `APPLICATION`, `CLASS`, `INTERFACE`) **and** nothing but whitespace precedes the match on the line, skip pushing an opener — the word is in the label position, not the structure-type position.

## Deliberately narrow keyword set

The gated set was chosen because these keywords always declare a **named instance**, and Clarion syntax always requires `Label KEYWORD,attrs` for them. Excluded, because they're legitimately written bare with no preceding label:

- `MAP`, `MODULE` — namespace/scoping constructs (e.g. `MAP ... MODULE('') ... END ... END` prototype blocks)
- `ITEMIZE`, `JOIN` — nested inside LIST/VIEW bodies
- `HEADER`, `FOOTER`, `FORM`, `DETAIL`, `MENUBAR`, `MENU`, `TOOLBAR`, `SHEET`, `TAB`, `OPTION` — nested inside WINDOW/REPORT bodies, identified by an optional `?field` via `USE()`, not a plain leading label

**This exclusion is not theoretical.** An earlier draft of this fix gated on the full declaration-structure list (including `MAP`/`MODULE`), and caused a real, confirmed regression: a genuine, bare `MAP ... MODULE('') ... END ... END` prototype block started misreporting both `END`s as unmatched. Narrowed to the current set to fix the original bug without reintroducing this class of false positive.

## Repro

Paste this into a plain `.clw` source file (or an embed slot) — before this fix, `Report`, `Window`, `Group`, and `Queue` (all just plain variable declarations/usages) each trigger a bogus "not terminated" squiggle, and the false positives can cascade to make correctly-terminated structures misreport too:

```clarion
TestProc PROCEDURE()
Report          &STRING     ! bug: keyword used as a plain label — must NOT be treated as an opener
Window          &STRING     ! same bug, different keyword
Group           &STRING     ! same bug, different keyword
Queue           LONG        ! same bug, different keyword
MyWinReal       WINDOW('Test'),AT(0,0,100,100)   ! a REAL, correctly-terminated WINDOW — must still work
                END
MyMap           MAP                                ! regression check: MAP/MODULE are legitimately BARE —
                  MODULE('')                        ! must NOT be treated as label usage either
                END
                END
 CODE
    Report = ''
    Window = ''
```

Expected after this fix: zero diagnostics on the whole snippet. Before this fix: `Report`, `Window`, `Group`, `Queue` all flagged as "not terminated" (and, depending on ordering, can knock `MyWinReal`'s own `END` out of alignment too).

To confirm the fix hasn't gone too far the other way, deliberately break `MyWinReal` (delete its `END`) — it should still correctly report "WINDOW statement is not terminated with END or '.'".

## Follow-up commit: tightened to strict column 0

The initial version of this fix checked "nothing but whitespace precedes the match" (`u.Substring(0, index).Trim().Length == 0`), reasoning defensively that a label might in principle be indented. Directly confirmed against the real Clarion compiler that this can't happen: indenting a DATA-section label by even one space desyncs the parser and produces unrelated errors on the following tokens — a label **must** start at column 0, full stop.

Given that, and given `u` is already `.Trim()`'d before this check runs (so it can never have leading whitespace to begin with), the check was simplified to a strict `index == 0` — provably identical outcome for every input this code ever sees, just without indirecting through a `Substring`+`Trim` to express it. Re-verified via the same 28-case harness plus the full-stack repro above (identical results) and re-confirmed independently by a fresh reviewer pass focused specifically on this simplification.

## Verification

- Reproduced against real production Clarion source: `Report &STRING` and its second bare-usage no longer push bogus openers; the previously-misreported, unrelated `IF`/`END` pair in the same procedure now correctly reports no error; a real, indented `MAP ... MODULE('') ... END ... END` block is unaffected (both ENDs correctly matched); a deliberately-broken real `WINDOW` structure (no matching `END`) is still correctly flagged.
- A standalone 28-case .NET console test harness (isolated regex + gating logic) covered: the 4 original false-positive bugs, the `MAP`/`MODULE` regression plus 9 other legitimately-bare keywords, 9 real-labeled-declaration positive cases, and 4 execution-structure cases — all 28 passed with the current keyword set.
- Independent code-reviewer pass (with a clean `dotnet build`) confirmed: the `IF` branch is completely unaffected, the `StructOpen`/`BandOpen` short-circuit is correct (their keyword sets are disjoint, so no case where `BandOpen` should win but doesn't get the chance), both regexes capture the keyword consistently as group 1, the substring-index alignment against `u` is correct, real labeled declarations (e.g. `MyWin WINDOW('Test'),AT(...)`) are unaffected, the `selfTerminated` inline-END/trailing-dot check is unchanged for all non-label cases, and the `DeclarationStructKeywords` set correctly excludes the ten regression-causing keywords.

## Testing gotcha worth noting for reviewers

This code path (Passes 2/3 of `Compute`) is invisible to the LSP's own `textDocument/publishDiagnostics` — its markers are computed client-side and pushed directly to Monaco via `IMonacoEditorHost.OnDiagnostics`/`PostResponse`. Verifying this fix requires either the live IDE's actual hover/squiggles, or a standalone harness that exercises the regex/gating logic directly (as done here) — `lsp_diagnostics`-style tooling that only queries the LSP won't see it.

## Related

A companion fix for the analogous ambiguity in the real Clarion LSP's own tokenizer (`msarson/Clarion-Extension`'s `ClarionTokenizer.ts`, which drives hover/go-to-definition/semantic-token classification, a separate code path from this per-slot heuristic) is filed as its own PR against that repo.
