### PR TITLE
feat(source-editor): save dirty CA Editor tabs before a build starts

### DIFF
--- a/ClarionAssistant/ClarionAssistant.addin.template
+++ b/ClarionAssistant/ClarionAssistant.addin.template
@@ -27,6 +27,9 @@
     <Class id="ClarionAssistantStartEmbedMonitor" class="ClarionAssistant.EmbedEditorMonitorAutostartCommand"/>
     <!-- Arm the ApplicationExit shutdown backstop unconditionally (not gated on the chat MCP server). -->
     <Class id="ClarionAssistantArmShutdown" class="ClarionAssistant.ShutdownAutostartCommand"/>
+    <!-- Save every dirty CA Editor (Monaco) tab right before a build starts — the native IDE's own
+         save-before-build has no visibility into this WebView2-hosted editor (see SaveSourceEditorsBeforeBuildCommand). -->
+    <Class id="ClarionAssistantSaveSourceEditorsBeforeBuild" class="ClarionAssistant.SaveSourceEditorsBeforeBuildCommand"/>
   </Path>
 
   <!-- Ordered addin teardown at shutdown. Our heavy teardown (stop MCP, kill ConPty child trees, dispose

--- a/ClarionAssistant/ClarionAssistant.csproj
+++ b/ClarionAssistant/ClarionAssistant.csproj
@@ -148,6 +148,7 @@
     <Compile Include="ShowModernEmbeditorCommand.cs" />
     <Compile Include="ClarionBindingAssemblyResolver.cs" />
     <Compile Include="LspAutostartCommand.cs" />
+    <Compile Include="SaveSourceEditorsBeforeBuildCommand.cs" />
     <Compile Include="EmbedEditorMonitorAutostartCommand.cs" />
     <Compile Include="ShutdownTerminateCommand.cs" />
     <Compile Include="OpenModernEmbeditorPickerCommand.cs" />

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -86,8 +86,15 @@ namespace ClarionAssistant
         // keeps the native ClaTextAreaControl from peeking through underneath.)
         private static readonly Color CoverColor = Color.FromArgb(0xEF, 0xF1, 0xF5);
 
+        // Every live tab, so a build-triggered save (SaveAllDirtyBeforeBuild) can reach all of them. This
+        // class has no other central registry — unlike ModernEmbeditorViewContent's own _instances — because
+        // until now nothing outside a single instance's own close/dispose path ever needed to reach it.
+        private static readonly List<MonacoClarionEditor> _instances = new List<MonacoClarionEditor>();
+
         public MonacoClarionEditor()
         {
+            lock (_instances) { _instances.Add(this); }
+
             // The text area isn't necessarily realized at ctor time (the wrapper builds it as the
             // view loads). Poll on the UI thread until Control exists + has a handle, then capture.
             try
@@ -97,6 +104,43 @@ namespace ClarionAssistant
                 _captureTimer.Start();
             }
             catch (Exception ex) { MonacoSpikeLog.Write("MonacoClarionEditor ctor timer error: " + ex.Message); }
+        }
+
+        /// <summary>Called from SaveSourceEditorsBeforeBuildCommand just before a build starts. The Monaco
+        /// overlay saves straight to disk itself and deliberately never touches the native ClarionEditor's
+        /// own buffer/IsDirty (see AttachOverlay/OnSave's doc comments) — so it stays invisible to the native
+        /// IDE's own save-before-build (SaveAllFiles.SaveAll, which only reaches AbstractViewContent.IsDirty).
+        /// Without this, "Build Solution" can silently compile a stale on-disk version of a file being
+        /// edited in the CA Editor. Best-effort per tab; one tab's failure must not stop the others.</summary>
+        internal static void SaveAllDirtyBeforeBuild()
+        {
+            List<MonacoClarionEditor> snapshot;
+            lock (_instances) { snapshot = new List<MonacoClarionEditor>(_instances); }
+            foreach (var inst in snapshot)
+            {
+                try { inst.SaveDirtyBeforeBuild(); }
+                catch (Exception ex) { MonacoSpikeLog.Write("SaveAllDirtyBeforeBuild per-instance error: " + ex.Message); }
+            }
+        }
+
+        /// <summary>Same write path + dirty guard as OnWorkbenchClosing/Dispose's save-on-close, minus the
+        /// close: writes the overlay's live buffer to disk if there are unsaved edits, then clears the dirty
+        /// flag so a subsequent close doesn't prompt again for something already safely on disk. Does NOT
+        /// touch the page's own ● dirty indicator — same accepted cosmetic gap as the embeditor's equivalent
+        /// (the host doesn't track Monaco's edit-sequence counter, so it can't safely clear it). Silently
+        /// skips a read-only file rather than throwing (matches OnSave's own guard) — the build will simply
+        /// compile the file as it already is on disk.</summary>
+        private void SaveDirtyBeforeBuild()
+        {
+            try
+            {
+                if (!(_overlayDirty && _overlayLiveText != null && !string.IsNullOrEmpty(_filePath))) return;
+                if (IsFileReadOnly()) return;
+                int n = WriteToDisk(_overlayLiveText);
+                _overlayDirty = false;
+                MonacoSpikeLog.Write("overlay build-triggered save wrote: " + _filePath + " (" + n + " chars)");
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("overlay build-triggered save error: " + ex.Message); }
         }
 
         private void CaptureTick(object sender, EventArgs e)
@@ -1492,6 +1536,7 @@ namespace ClarionAssistant
 
         public override void Dispose()
         {
+            lock (_instances) { _instances.Remove(this); }
             StopCaptureTimer();
             try { if (_hookRetry != null) { _hookRetry.Stop(); _hookRetry.Dispose(); _hookRetry = null; } } catch { }
             UnwireBreakpoints();

--- a/ClarionAssistant/SaveSourceEditorsBeforeBuildCommand.cs
+++ b/ClarionAssistant/SaveSourceEditorsBeforeBuildCommand.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Reflection;
+using ICSharpCode.Core;
+
+namespace ClarionAssistant
+{
+    /// <summary>
+    /// /Workspace/Autostart command — saves every open CA Editor tab (MonacoClarionEditor, the Monaco/
+    /// WebView2 overlay over the native source-file editor) that has unsaved edits, just before a build
+    /// starts.
+    ///
+    /// The Monaco overlay saves straight to disk itself and deliberately never touches the native
+    /// ClarionEditor's own buffer/IsDirty underneath it (see MonacoClarionEditor's AttachOverlay/OnSave
+    /// doc comments — "the native editor underneath stays a clean, untouched shell"). The native IDE's
+    /// own save-before-build (AbstractBuildMenuCommand.BeforeBuild -> SaveAllFiles.SaveAll) only reaches
+    /// AbstractViewContent.IsDirty, so it never sees an unsaved Monaco edit. Without this hook, "Build
+    /// Solution" could silently compile a STALE on-disk version of a file still being edited in the CA
+    /// Editor — confirmed directly: an edit left unsaved in Monaco compiled clean until this hook was
+    /// added, and correctly surfaced a compiler error afterwards.
+    ///
+    /// Subscribes to ProjectService.StartBuild (a static, non-cancelable EventHandler) via reflection —
+    /// same technique LspAutostartCommand uses for SolutionLoaded/SolutionClosed. Guarded throughout:
+    /// this MUST NOT throw at workbench load, and MUST NOT block/slow down a build when nothing is dirty.
+    /// </summary>
+    public class SaveSourceEditorsBeforeBuildCommand : ICommand
+    {
+        private object _owner;
+        public object Owner
+        {
+            get { return _owner; }
+            set
+            {
+                _owner = value;
+                var h = OwnerChanged;
+                if (h != null) h(this, EventArgs.Empty);
+            }
+        }
+
+        public event EventHandler OwnerChanged;
+
+        // Rooted so the StartBuild delegate is never GC'd.
+        private static Delegate _startBuildHandler;
+
+        public void Run()
+        {
+            try
+            {
+                SubscribeStartBuild();
+            }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SaveSourceEditorsBeforeBuild] subscribe failed: " + ex.Message); }
+        }
+
+        /// <summary>
+        /// Subscribes to ICSharpCode.SharpDevelop.Project.ProjectService.StartBuild via reflection
+        /// (same assembly/type EditorService/LspAutostartCommand use).
+        /// </summary>
+        private void SubscribeStartBuild()
+        {
+            var sharpDevelopAsm = Assembly.Load("ICSharpCode.SharpDevelop");
+            if (sharpDevelopAsm == null) return;
+
+            var projectServiceType = sharpDevelopAsm.GetType("ICSharpCode.SharpDevelop.Project.ProjectService");
+            if (projectServiceType == null) return;
+
+            var evt = projectServiceType.GetEvent("StartBuild", BindingFlags.Public | BindingFlags.Static);
+            if (evt == null) return;
+
+            MethodInfo handlerMethod = typeof(SaveSourceEditorsBeforeBuildCommand).GetMethod(
+                "OnStartBuild", BindingFlags.NonPublic | BindingFlags.Static);
+            if (handlerMethod == null) return;
+
+            _startBuildHandler = Delegate.CreateDelegate(evt.EventHandlerType, handlerMethod);
+            evt.AddEventHandler(null, _startBuildHandler);
+        }
+
+        private static void OnStartBuild(object sender, EventArgs e)
+        {
+            try { MonacoClarionEditor.SaveAllDirtyBeforeBuild(); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[SaveSourceEditorsBeforeBuild] OnStartBuild failed: " + ex.Message); }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Editing a source file in the CA Editor and then pressing the IDE's own Build Solution button — without first pressing Ctrl+S — silently compiled the STALE on-disk version of the file. The edit was never lost (Monaco still had it, and a later save wrote it correctly), but the build ran against whatever was already on disk, with no warning that anything was skipped.

## Root cause

The native IDE's own "save dirty files before build" behavior is `AbstractBuildMenuCommand.BeforeBuild()` calling `ICSharpCode.SharpDevelop.Commands.SaveAllFiles.SaveAll()`, which iterates every open `AbstractViewContent` and saves it if `IsDirty` is true (confirmed directly by disassembling the bundled SharpDevelop 2.1.0.2447 assembly).

`MonacoClarionEditor` (the class behind the CA Editor) is invisible to this. Its Monaco overlay owns the buffer end-to-end and saves straight to disk itself (`OnSave`/`WriteToDisk`); the native `ClarionEditor` instance it's docked over is deliberately left untouched — by design, so there's no dueling-save conflict between the overlay and the native editor's own machinery. That means the native editor's `IsDirty` never becomes true while editing through the overlay, so `SaveAllFiles.SaveAll()`'s dirty check always reads false for these tabs and skips them entirely. No other build-time hook existed either — the only place unsaved overlay edits got flushed to disk was on tab close (a per-instance `ClosingEvent` handler + a `Dispose` fallback), never on build.

## Fix

Added a static `_instances` list to `MonacoClarionEditor` (it had no central registry before this — nothing previously needed to reach every open instance at once) and `SaveAllDirtyBeforeBuild()`, which saves any tab with unsaved edits using the exact same write path and dirty guard already used by the existing close-time save (`WriteToDisk`, gated on `_overlayDirty && _overlayLiveText != null && !string.IsNullOrEmpty(_filePath)`, skipped for a read-only file) — just without closing the tab afterward.

Wired it up via a new `/Workspace/Autostart` command, `SaveSourceEditorsBeforeBuildCommand`, which subscribes to `ProjectService.StartBuild` (a static, non-cancelable `EventHandler`) by reflection — the same technique `LspAutostartCommand` already uses for `SolutionLoaded`/`SolutionClosed`.

One accepted, deliberate gap: this does not clear the CA Editor page's own "unsaved changes" (●) indicator. The page tracks its own edit-sequence counter to decide when it's safe to clear that indicator (`saveResult` echoes back the sequence number it saved), and the host doesn't currently track that counter for a non-interactive save. The file on disk is correct either way, which is the only thing the compiler reads — the indicator staying lit after an autosave is cosmetic, not a correctness issue.

## Verification

Live-tested against the running Clarion 11.1 IDE (redeployed before testing):

- Opened a real production `.clw` file in the CA Editor, changed a token to an illegal one, and built **without saving** — the compiler correctly reported the resulting error, proving the edit reached disk before the build ran.
- Reverted the edit (again without saving) and built again — clean, zero errors.
- **Interaction with the Application Generator (App-based projects):** edited a `.clw` file in the CA Editor that AppGen also regenerates from a `.app` + embeds, then ran "Generate and make". AppGen's regeneration overwrote the raw edit with its own generated content, as it always does for a generated file regardless of this change — confirms this fix introduces no new risk of clobbering generated/embed content, and no risk of generated content losing out to a stray hand-edit either.
- **Unrelated open tabs:** with an unrelated file open and edited (not part of the current build target) in a CA Editor tab, triggering a build saved it too, silently. This is intentional, not a scope leak: confirmed side-by-side against the plain native Clarion editor (no CA Editor involved at all) — pressing F8 with an unrelated, unsaved native tab open saves that file as well. `SaveAllFiles.SaveAll()` already saves every open document regardless of project membership; this fix's Monaco tabs now just get the same treatment.
