### PR TITLE
Fix/ca editor reload button

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -885,13 +885,17 @@ namespace ClarionAssistant
         // Was a no-op since the very first Monaco-converge commit (748c150) that stubbed the whole
         // IMonacoEditorHost interface — confirmed via `git log -S"OnReload"`, never implemented since.
         //
-        // Deliberately sends cursorLine/cursorColumn=1/1 and an empty bookmarks array, not a persisted
-        // position: the page's restoreEmbedState is one-shot (monaco-embeditor.html) — once a tab has
-        // restored its cursor/bookmarks on first open, a LATER setSource (this one) is ignored for
-        // cursor/scroll/bookmark purposes and the page reveals line 1 regardless of what's sent here.
-        // Computing/sending a persisted value would be dead code pretending to do something it can't;
-        // fixing that for real is a page-side (JS) change, out of scope for this fix (whose bug was that
-        // this C# method never ran at all).
+        // Sends the LIVE cursor position (_lastCursorLine/_lastCursorCol, kept current by
+        // OnSelectionChanged) plus a "reload":true flag, which monaco-embeditor.html's
+        // restoreEmbedState() checks FIRST — bypassing its one-shot "already restored" guard that would
+        // otherwise ignore cursorLine/cursorColumn on any setSource after the tab's first open (landing
+        // on line 1 regardless). That flag is CA-Editor-only by construction: nothing in
+        // ModernEmbeditorViewContent's own save/reload path ever sets it, so the CA Embeditor's reload
+        // behavior is completely unchanged by this. Scope note: the embeditor's reload has the exact
+        // same "lands on line 1" limitation today — deliberately NOT touched here; extending this to
+        // embed mode would need its own look first (a saved/live line can drift outside an editable
+        // embed slot after a regenerate, which lineInEditable's fileMode-always-true fast path never
+        // has to consider for a plain source file).
         //
         // KEEP IN SYNC: this setSource JSON is an independent copy of OnReady's, not shared code (see
         // above) — if a field is added/removed/renamed in OnReady's setSource, mirror it here too.
@@ -935,7 +939,10 @@ namespace ClarionAssistant
                 CaptureIdeChromeColors();
                 bool fileReadOnly = IsFileReadOnly();
                 string pageTitle = fileReadOnly ? (_overlayTitle + " (read-only)") : _overlayTitle;
+                int curLine = _lastCursorLine >= 1 ? _lastCursorLine : 1;
+                int curCol = _lastCursorCol >= 1 ? _lastCursorCol : 1;
                 string json = "{\"type\":\"setSource\","
+                    + "\"reload\":true,"
                     + "\"title\":" + MonacoEditorControl.JsonString(pageTitle) + ","
                     + "\"language\":\"clarion\","
                     + "\"isDark\":false,"
@@ -951,7 +958,7 @@ namespace ClarionAssistant
                     + "\"editableRanges\":[],"
                     + "\"settings\":" + settingsJson + ","
                     + "\"findHistory\":" + findHistJson + ",\"replaceHistory\":" + replHistJson + ",\"procHistory\":" + procHistJson + ","
-                    + "\"cursorLine\":1,\"cursorColumn\":1,"
+                    + "\"cursorLine\":" + curLine + ",\"cursorColumn\":" + curCol + ","
                     + "\"bookmarks\":[],"
                     + "\"snippets\":" + Services.SnippetStore.ToJson(Services.SnippetStore.Load()) + ","
                     + "\"breakpoints\":[" + bpCsv + "],"

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -344,6 +344,8 @@ namespace ClarionAssistant
                 CaptureIdeChromeColors();   // active Clarion IDE theme colors → our toolbar chrome (task c8e669d3)
                 // Honor the file's Windows read-only attribute: open the buffer read-only + flag the title,
                 // instead of letting the user edit freely only to fail at save time (issue #50).
+                // KEEP IN SYNC: OnReload below sends an independent copy of this setSource JSON (not shared
+                // code) — mirror any field added/removed/renamed here over there too.
                 bool fileReadOnly = IsFileReadOnly();
                 string pageTitle = fileReadOnly ? (_overlayTitle + " (read-only)") : _overlayTitle;
                 string json = "{\"type\":\"setSource\","
@@ -873,7 +875,96 @@ namespace ClarionAssistant
             catch { }
         }
         void IMonacoEditorHost.OnFocusEditor(MonacoEditorControl editor) { }
-        void IMonacoEditorHost.OnReload(MonacoEditorControl editor) { }
+
+        // Reload button (fileMode page, two-click confirm): discards the overlay's in-buffer edits and
+        // re-reads the file fresh from disk, then resends it as a new setSource — same message shape
+        // OnReady sends on first open, built independently HERE rather than by refactoring OnReady itself,
+        // so this new, less-tested path can never regress the tab-open path every CA Editor tab depends on.
+        // Unlike OnReady, does NOT re-run CaFindBroker registration, the close-hook attach, or debugger-nav
+        // consumption — the tab isn't being reopened, only its content is refreshed to match disk.
+        // Was a no-op since the very first Monaco-converge commit (748c150) that stubbed the whole
+        // IMonacoEditorHost interface — confirmed via `git log -S"OnReload"`, never implemented since.
+        //
+        // Deliberately sends cursorLine/cursorColumn=1/1 and an empty bookmarks array, not a persisted
+        // position: the page's restoreEmbedState is one-shot (monaco-embeditor.html) — once a tab has
+        // restored its cursor/bookmarks on first open, a LATER setSource (this one) is ignored for
+        // cursor/scroll/bookmark purposes and the page reveals line 1 regardless of what's sent here.
+        // Computing/sending a persisted value would be dead code pretending to do something it can't;
+        // fixing that for real is a page-side (JS) change, out of scope for this fix (whose bug was that
+        // this C# method never ran at all).
+        //
+        // KEEP IN SYNC: this setSource JSON is an independent copy of OnReady's, not shared code (see
+        // above) — if a field is added/removed/renamed in OnReady's setSource, mirror it here too.
+        void IMonacoEditorHost.OnReload(MonacoEditorControl editor)
+        {
+            try
+            {
+                if (_editor == null || _editor.TempDir == null || string.IsNullOrEmpty(_filePath)) return;
+                if (!File.Exists(_filePath))
+                {
+                    MonacoSpikeLog.Write("overlay reload: file no longer exists (" + _filePath + ")");
+                    try { editor.PostSaveResult(false, "Reload failed: file no longer exists."); } catch { }
+                    return;
+                }
+
+                Encoding enc = EncodingHelper.DetectFileEncoding(_filePath);
+                string text = File.ReadAllText(_filePath, enc);
+                _overlayLiveText = text;
+                _overlayDirty = false;
+
+                File.WriteAllText(Path.Combine(_editor.TempDir, "source.txt"), text, Encoding.UTF8);
+
+                string settingsJson;
+                try { settingsJson = new JavaScriptSerializer().Serialize(ModernEmbeditorSettings.Load().ToDict()); }
+                catch { settingsJson = "null"; }
+
+                string bpCsv = BreakpointLinesCsv();
+
+                string findHistJson = "[]", replHistJson = "[]", procHistJson = "[]";
+                try
+                {
+                    string sol, key; ResolveHistoryScope(out sol, out key);
+                    List<string> hf, hr, hp;
+                    ModernEmbeditorHistory.Load(sol, key, out hf, out hr, out hp);
+                    findHistJson = ModernEmbeditorHistory.ToJson(hf);
+                    replHistJson = ModernEmbeditorHistory.ToJson(hr);
+                    procHistJson = ModernEmbeditorHistory.ToJson(hp);
+                }
+                catch { }
+
+                CaptureIdeChromeColors();
+                bool fileReadOnly = IsFileReadOnly();
+                string pageTitle = fileReadOnly ? (_overlayTitle + " (read-only)") : _overlayTitle;
+                string json = "{\"type\":\"setSource\","
+                    + "\"title\":" + MonacoEditorControl.JsonString(pageTitle) + ","
+                    + "\"language\":\"clarion\","
+                    + "\"isDark\":false,"
+                    + "\"chromeBg1\":" + MonacoEditorControl.JsonString(_chromeBg1 ?? "") + ","
+                    + "\"chromeBg2\":" + MonacoEditorControl.JsonString(_chromeBg2 ?? "") + ","
+                    + "\"fileMode\":true,"
+                    + "\"readOnly\":" + (fileReadOnly ? "true" : "false") + ","
+                    + "\"breakpointsEnabled\":true,"
+                    + "\"designerEnabled\":true,"
+                    + "\"filePath\":" + MonacoEditorControl.JsonString(_filePath ?? "") + ","
+                    + "\"saveEnabled\":" + (fileReadOnly ? "false" : "true") + ","
+                    + "\"findUiMode\":\"" + Services.CaFindSettings.FindUiModeForPage + "\","
+                    + "\"editableRanges\":[],"
+                    + "\"settings\":" + settingsJson + ","
+                    + "\"findHistory\":" + findHistJson + ",\"replaceHistory\":" + replHistJson + ",\"procHistory\":" + procHistJson + ","
+                    + "\"cursorLine\":1,\"cursorColumn\":1,"
+                    + "\"bookmarks\":[],"
+                    + "\"snippets\":" + Services.SnippetStore.ToJson(Services.SnippetStore.Load()) + ","
+                    + "\"breakpoints\":[" + bpCsv + "],"
+                    + "\"sourceUrl\":\"https://clarion-embeditor-data/source.txt\"}";
+                _editor.PostJson(json);
+                MonacoSpikeLog.Write("overlay reload: re-read from disk and resent (" + _filePath + ", " + text.Length + " chars)");
+            }
+            catch (Exception ex)
+            {
+                MonacoSpikeLog.Write("overlay reload error: " + ex.Message);
+                try { editor.PostSaveResult(false, "Reload failed: " + ex.Message); } catch { }
+            }
+        }
         // The source-editor overlay has no Cancel affordance (the native file editor owns its own close); no-op.
         void IMonacoEditorHost.OnCancel(MonacoEditorControl editor) { }
         // No clickable header in the source-editor overlay (that's the embeditor overlay's feature); no-op.

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -1123,6 +1123,12 @@
                         return;
                     }
                     reloadArmed = false;
+                    // The "click again to confirm" toast (shown on the first click, 8s auto-dismiss since
+                    // it's an err-styled toast) is now stale the instant the confirm click lands — clear it
+                    // immediately instead of leaving it on screen for the rest of its timeout.
+                    var toastEl = document.getElementById('toast');
+                    if (toastEl) toastEl.className = '';
+                    if (toastTimer) { clearTimeout(toastTimer); toastTimer = null; }
                     postToHost({ action: 'reload' });
                 });
                 var splitBtn = document.getElementById('splitBtn');
@@ -2299,6 +2305,24 @@
     // numbers are valid. Subsequent setSource calls (if any) just reveal line 1 without re-restoring.
     var stateRestored = false;
     function restoreEmbedState(msg) {
+        // CA Editor Reload only (msg.reload, opt-in): re-apply the position the C# host tells us to,
+        // bypassing the one-shot guard below entirely — a reload is not a fresh tab open, so it must
+        // NOT flip `stateRestored` or re-run the bookmark restore. The CA Embeditor never sends this
+        // flag (its own reload path is untouched by this branch, still lands on line 1 as before), so
+        // this is strictly additive for the plain source-file editor. Deliberately skips recordNavAt —
+        // a reload isn't a new navigation, so it shouldn't push a Navigate-Back entry.
+        if (msg && msg.reload) {
+            var rModel = editor.getModel(), rLc = rModel.getLineCount();
+            var rl = msg.cursorLine, rc = msg.cursorColumn || 1;
+            if (rl && rl >= 1 && rl <= rLc && lineInEditable(rl)) {
+                editor.setPosition({ lineNumber: rl, column: Math.max(1, rc) });
+                editor.revealLineInCenter(rl);
+                setTimeout(function () { try { editor.focus(); } catch (e) { } }, 0);
+            } else {
+                editor.revealLine(1);
+            }
+            return;
+        }
         if (stateRestored) { editor.revealLine(1); return; }
         stateRestored = true;
         var model = editor.getModel(), lc = model.getLineCount();


### PR DESCRIPTION
## Summary

The CA Editor's Reload button (fileMode, two-click confirm, tooltip "Reload from disk — discards your edits") did nothing. The frontend was fully wired the whole time — clicking it correctly armed the two-click confirm, showed the warning toast, and posted `{action:"reload"}` to the host on the second click — but the C# side of `IMonacoEditorHost.OnReload` was an empty `{ }` stub, so nothing ever happened.

## Root cause

`git log -S"OnReload"` on `MonacoClarionSourceEditor.cs` returns exactly one commit: `748c150`, "Monaco-converge Step 4 — overlay hosts MonacoEditorControl in fileMode". That commit stubbed out a whole batch of `IMonacoEditorHost` interface methods at once (`OnSelectionChanged`, `OnFocusEditor`, `OnReload`, `OnFileState`, `OnOpenDesigner`, `OnOpenDesignerCreate`) so the class would compile while the overlay was still an early, partially-inert milestone. In the convergence steps that followed, every sibling stub from that same batch eventually got a real implementation — except `OnReload`, which was simply never picked back up.

## Fix

Implemented `OnReload` as an independent method — deliberately not refactored to share code with `OnReady` (the tab-open handler), so this new, less-tested path can never regress the tab-open path every CA Editor tab depends on:

- Re-reads the file fresh from disk with re-detected encoding (`EncodingHelper.DetectFileEncoding`, matching `ModernEmbeditorViewContent.HandleReload`'s own approach), resets the overlay's dirty state, and resends the same `{"type":"setSource",...}` shape `OnReady` sends on first open.
- On a missing file or any exception, reports it back to the page via `PostSaveResult(false, ...)` instead of failing silently (matching the embeditor's own `HandleReload` error-reporting convention) — previously any failure would leave the developer unaware the file wasn't picked up.

**Caret/scroll position on reload.** The page's `restoreEmbedState()` (`monaco-embeditor.html`) is a one-shot guard: it only honors a `setSource` message's `cursorLine`/`cursorColumn` on a tab's very first open — any *later* `setSource` (including a reload) is short-circuited straight to `editor.revealLine(1)`, regardless of what's sent. Fixed with a `"reload":true` flag on the `setSource` payload that `restoreEmbedState` checks *first*, before its one-shot guard — when set, it applies the position directly (same `setPosition`/`revealLineInCenter` calls the normal restore path uses) without touching `stateRestored` or re-running the bookmark restore. The flag is CA-Editor-only by construction: nothing in `ModernEmbeditorViewContent` (the CA Embeditor) ever sets it — and the CA Embeditor has no Reload button at all — so this is strictly additive for the plain source-file editor. The position sent is the *live* cursor (`_lastCursorLine`/`_lastCursorCol`, kept current by `OnSelectionChanged`), not a persisted/saved one, so a reload lands you back where you were reading/editing rather than wherever the file was last known to be from a previous session.

**Toast cleanup.** The "click Reload again to confirm" toast (shown on the first click) is styled as an error toast, which gives it an 8s auto-dismiss timer. The confirming second click never cleared it, so it sat on screen for whatever was left of that 8s regardless of the reload having already happened. Now cleared immediately when the second click confirms.

## Scope note

Extending position-restore to embed mode was not considered beyond confirming the CA Embeditor has no Reload button to begin with (so there is currently nothing to extend). If one is ever added: a saved/live line could have drifted outside an editable embed slot after a regenerate — a case the CA Editor's `lineInEditable`'s always-true fast path (whole file is editable) never has to handle, so the embed case would need its own safety check, not a copy-paste of this fix.

## Verification

Live-tested against the running Clarion 11.1 IDE (redeployed before testing):

- Cursor on line 398 of a real, long production `.clw` file (near the bottom of the file), edited a token without saving, pressed Reload (two clicks) — file re-read from disk, the edit was gone, and the caret/scroll landed back on line 398, centered.
- Compared directly against closing and reopening the same file via the Solution list at the same line: identical landing line and centering, caret position on the line also correct — reload now matches a manual close+reopen exactly instead of jumping to the top.
- Confirmed the "click again to confirm" toast now disappears the instant the second click lands, instead of lingering for the rest of its 8s timeout.
