### PR TITLE
fix(cafind): pad doesn't take keyboard focus on first Ctrl+F after IDE start

### DIFF
--- a/ClarionAssistant/CaFindPad.cs
+++ b/ClarionAssistant/CaFindPad.cs
@@ -109,6 +109,15 @@ namespace ClarionAssistant
                     // so they override the blob's legacy copies when present.
                     PushSharedHistory();
                     CaFindBroker.SetPadPoster(PostJson);
+                    // Same WebView2-in-WinForms focus race as #66 round-2 (see
+                    // MonacoEditorControl.FocusEditor/FocusAttempt, which this mirrors): on the VERY
+                    // FIRST Ctrl+F this pad didn't exist yet, so CaFindBroker.ShowPad's
+                    // BringPadToFront() ran before CoreWebView2/this page finished loading, and a
+                    // lone Focus() isn't enough to pull real Win32 keyboard focus into the browser
+                    // content afterward. See CaFindBroker.SuppressEditorFocusSteal for the other
+                    // half of this fix — MonacoClarionSourceEditor's WindowSelected hook was
+                    // actively fighting this same claim during first-time pad layout.
+                    FocusAttempt(0);
                 }
                 else if (action == "saveHistory")
                 {
@@ -194,6 +203,61 @@ namespace ClarionAssistant
             if (data != null && data.TryGetValue(key, out o) && o is object[])
                 foreach (var item in (object[])o) if (item != null) outp.Add(item.ToString());
             return outp;
+        }
+
+        // #66 round-2 (same bug as MonacoEditorControl.FocusAttempt): a single _webView.Focus() is
+        // not enough right after this page finishes loading. The WinForms WebView2 only forwards
+        // focus into Chromium from its GotFocus handler, so when the host HWND already holds Win32
+        // focus, the render widget never gets the keyboard. MoveFocus() is the authoritative
+        // hand-off. Root cause of the original flakiness was MonacoClarionSourceEditor's
+        // WindowSelected hook fighting this same claim during first-time pad layout (now dampened
+        // via CaFindBroker.SuppressEditorFocusSteal) — with that fixed, a normal stop-on-success
+        // retry (matching MonacoEditorControl's own cadence) is enough; no need to keep re-asserting
+        // after we've already won, which was only ever needed to survive that fight and produced a
+        // visible focus-flicker of its own once the fight was gone.
+        private void FocusAttempt(int attempt)
+        {
+            try
+            {
+                if (_webView == null || _webView.IsDisposed || !_webView.IsHandleCreated) return;
+                if (_webView.Visible)
+                {
+                    _webView.Focus();
+                    TryMoveFocusIntoChromium();
+                }
+                if (attempt < 3 && !_webView.ContainsFocus)
+                {
+                    var t = new Timer { Interval = 80 };
+                    t.Tick += (s, e) =>
+                    {
+                        try { t.Stop(); t.Dispose(); } catch { }
+                        FocusAttempt(attempt + 1);
+                    };
+                    t.Start();
+                }
+                else if (!_webView.ContainsFocus)
+                {
+                    MonacoSpikeLog.Write("[CaFindPad] FocusAttempt: focus never landed after retries (focused control elsewhere)");
+                }
+            }
+            catch { }
+        }
+
+        // The WinForms wrapper doesn't expose CoreWebView2Controller publicly; reflect it and call
+        // MoveFocus(Programmatic) — the only API that reliably puts the keyboard in the render widget.
+        private void TryMoveFocusIntoChromium()
+        {
+            try
+            {
+                object ctl =
+                    _webView.GetType().GetProperty("CoreWebView2Controller",
+                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.GetValue(_webView, null)
+                    ?? _webView.GetType().GetField("_coreWebView2Controller",
+                        BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(_webView);
+                var controller = ctl as CoreWebView2Controller;
+                if (controller != null) controller.MoveFocus(CoreWebView2MoveFocusReason.Programmatic);
+            }
+            catch { }
         }
 
         /// <summary>Post a JSON message into the pad page, marshalled to the UI thread. This is the

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -1455,8 +1455,19 @@ namespace ClarionAssistant
         {
             try
             {
-                MonacoSpikeLog.Write("select-hook fired: claim CA Find pad + focus (" + (_filePath ?? "?") + ")");
                 ClarionAssistant.Services.CaFindBroker.NotifyActivity(this);
+                // A just-opened CA Find pad is actively fighting for focus right now (its own
+                // FocusAttempt schedule, CaFindPad.cs) — this hook fires repeatedly while that
+                // pad's panel is being docked/laid out for the first time, and stealing focus back
+                // to the editor here is exactly what was losing that fight (see CaFindBroker.
+                // SuppressEditorFocusSteal for the full story). Stand down for this short window;
+                // NotifyActivity above still runs so find/replace routing stays correct either way.
+                if (ClarionAssistant.Services.CaFindBroker.SuppressEditorFocusSteal)
+                {
+                    MonacoSpikeLog.Write("select-hook fired: SUPPRESSED (CA Find pad claiming focus) (" + (_filePath ?? "?") + ")");
+                    return;
+                }
+                MonacoSpikeLog.Write("select-hook fired: claim CA Find pad + focus (" + (_filePath ?? "?") + ")");
                 if (_editor != null)
                 {
                     _editor.FocusEditor();

--- a/ClarionAssistant/Services/CaFindBroker.cs
+++ b/ClarionAssistant/Services/CaFindBroker.cs
@@ -242,6 +242,34 @@ namespace ClarionAssistant.Services
 
         // ── Pad activation (Ctrl+F in an editor) ──────────────────────────────────────────────
 
+        // First-open focus race: when the pad doesn't exist yet, ShowPad's BringPadToFront (below)
+        // runs BEFORE the pad's WebView2 finishes its async init, and CaFindPad's own "ready"-time
+        // focus claim (CaFindPad.FocusAttempt) then fights MonacoClarionSourceEditor's PRE-EXISTING
+        // WindowSelected hook (OnWorkbenchWindowSelected, "#66 follow-up: claim CA Find pad + focus
+        // Monaco") — that hook fires repeatedly while the new pad panel is being docked/laid out,
+        // each time re-stealing focus back to the editor with the identical Focus()+MoveFocus
+        // mechanism. Confirmed live via monaco-spike.log: both sides winning and losing focus in
+        // alternation until the editor's hook wins the last word. Since the two mechanisms want
+        // opposite outcomes for the same brief window, suppress the editor's side of the fight for
+        // long enough to cover CaFindPad's own focus-claim retries (3 attempts, 80ms apart — well
+        // under a second) plus margin. Only narrows the pre-existing hook's window — normal
+        // tab-switch behavior (its actual purpose) is unaffected once this window elapses.
+        private static long _suppressEditorFocusStealUntilTicks;
+
+        /// <summary>True while a just-opened CA Find pad should win any focus fight against
+        /// MonacoClarionSourceEditor's WindowSelected hook. Checked by that hook before it claims
+        /// focus back for the editor.</summary>
+        public static bool SuppressEditorFocusSteal
+        {
+            get { return DateTime.UtcNow.Ticks < System.Threading.Interlocked.Read(ref _suppressEditorFocusStealUntilTicks); }
+        }
+
+        private static void ArmEditorFocusStealSuppression(int ms)
+        {
+            long until = DateTime.UtcNow.AddMilliseconds(ms).Ticks;
+            System.Threading.Interlocked.Exchange(ref _suppressEditorFocusStealUntilTicks, until);
+        }
+
         /// <summary>Create/raise the CA Find pad — same reflection shape as ShowModernDataPadCommand.
         /// Marshalled to the UI thread by the workbench itself (BringPadToFront is UI-safe here since
         /// WebMessageReceived already runs on the UI thread).</summary>
@@ -249,6 +277,7 @@ namespace ClarionAssistant.Services
         {
             try
             {
+                ArmEditorFocusStealSuppression(1500);
                 var workbench = ICSharpCode.SharpDevelop.Gui.WorkbenchSingleton.Workbench;
                 if (workbench == null) return;
                 var getPad = workbench.GetType().GetMethod("GetPad", new Type[] { typeof(Type) });

--- a/ClarionAssistant/Terminal/ca-find.html
+++ b/ClarionAssistant/Terminal/ca-find.html
@@ -217,6 +217,13 @@
     var findHistory = [], replHistory = [];   // global (all editors), persisted
     var fzPx = 12, themeDark = true;
     var tabSeq = 0;
+    // The first onActiveEditor of a fresh page load carries over whatever tab/query was active in
+    // the PERSISTED state (from a previous session, possibly long ago) — pre-filling the box and
+    // silently re-running that stale search (passive re-run still populates matches/results) the
+    // instant the pad opens, before the developer's own Ctrl+F seed is even processed. Cleared after
+    // the first activation; later activations (switching between files WITHIN this same running pad
+    // session) restore their tab normally — that's the intended, wanted behavior.
+    var firstActivation = true;
 
     // Live working copy (active editor + active tab)
     var matches = [];              // [{line,startCol,endLine,endCol,text,editable,checked}]
@@ -695,7 +702,16 @@
         renderTarget();
         if (!activeKey) { renderTabs(); renderResults(); byId('findCount').textContent = ''; return; }
         var s = sessionFor(activeKey);
-        loadTab(s.activeTab);   // restores inputs/opts and re-runs the active tab's search on the new buffer
+        if (firstActivation) {
+            firstActivation = false;
+            // Don't carry over a possibly-stale saved query the first time this pad opens in a
+            // session — start the active tab blank instead of silently pre-filling + re-searching.
+            var t0 = s.tabs[s.activeTab];
+            if (t0) { t0.query = ''; t0.replaceText = ''; }
+            loadTab(s.activeTab, false);
+        } else {
+            loadTab(s.activeTab);   // restores inputs/opts and re-runs the active tab's search on the new buffer
+        }
     }
 
     function onEditorMsg(env) {


### PR DESCRIPTION
## Summary

The CA Find/Replace pad opened correctly on Ctrl+F, but the very first time it was created in an IDE session, keyboard focus stayed in the editor instead of moving into the find field — typing landed in the source buffer, not the search box. Every subsequent Ctrl+F in the same session worked as expected.

Two independent causes, both fixed:

1. **Async init race.** `CaFindPad`'s WebView2 (CoreWebView2 + page load) finishes initializing well after `CaFindBroker.ShowPad()`'s `BringPadToFront()` call returns, so on first creation the pad has no way to claim real Win32 keyboard focus until its page reports itself ready. Fixed by re-asserting focus at that point — `Focus()` plus `MoveFocus(Programmatic)` (reflected off `CoreWebView2Controller`, since a bare `Focus()` doesn't reliably forward into the Chromium render widget), with a short stop-on-success retry. This mirrors the existing `MonacoEditorControl.FocusEditor` fix for the analogous editor-side focus race.

2. **A second, unrelated mechanism was fighting the first fix.** `MonacoClarionSourceEditor` has its own `WindowSelected` hook that actively reclaims focus for the editor whenever the workbench window is selected. That hook fires repeatedly while the pad's panel is being docked for the first time, contending for focus with the exact same mechanism as fix #1 and consistently winning. Fixed with a short, time-boxed suppression flag (`CaFindBroker.SuppressEditorFocusSteal`) that the hook checks and stands down for while a freshly-opened pad is claiming focus. Normal tab-switch behavior — the hook's actual purpose — is unaffected once that window elapses.

**Also fixed, found during verification:** the pad's persisted state was silently pre-filling and re-running whatever search had last been active in a *previous* session the instant the pad first opened, regardless of what the developer actually wanted to search for — including auto-navigating the caret to the first match, unrelated to the current Ctrl+F. The first `onActiveEditor` of a fresh page load now starts the active tab blank instead of restoring it, so a session always begins from a clean slate. Switching between files within an already-running pad session still restores each file's own tab/query normally.

## Test plan
- [x] Clean build
- [x] Live-verified in the running IDE across multiple fresh-IDE-restart Ctrl+F tests: focus lands in the find field immediately, no flicker, find/replace fields start blank on first open
- [x] Confirmed normal tab-switch focus behavior (the pre-existing `WindowSelected` hook's actual purpose) is unaffected outside the suppression window
- [x] Confirmed switching between already-open files within a single pad session still restores each file's own search tab as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
