### PR TITLE
fix(webview2): isolate WebView2 profile per Clarion process to stop cross-instance crashes

### DIFF
--- a/ClarionAssistant/Terminal/WebView2EnvironmentCache.cs
+++ b/ClarionAssistant/Terminal/WebView2EnvironmentCache.cs
@@ -42,9 +42,17 @@ namespace ClarionAssistant.Terminal
 
         private static async Task<CoreWebView2Environment> CreateEnvironmentAsync()
         {
+            // Suffixed per-process (PID) so each Clarion IDE instance gets its OWN WebView2 browser
+            // process instead of sharing one across every open instance. Sharing a userDataFolder makes
+            // WebView2 share a single msedgewebview2.exe browser process across host processes, and
+            // WebView2ProcessReaper (below) binds THAT browser PID to a per-process kill-on-close job —
+            // so closing one Clarion instance was killing the shared browser and blacking out every
+            // other open instance's WebView2 pads. Isolating the folder per PID isolates the browser
+            // process too, so each instance's reaper can only ever kill its own.
+            string pidSuffix = System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
             string userDataFolder = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ClarionAssistant", "WebView2Data");
+                "ClarionAssistant", "WebView2Data_" + pidSuffix);
 
             try
             {
@@ -53,7 +61,7 @@ namespace ClarionAssistant.Terminal
             }
             catch
             {
-                userDataFolder = Path.Combine(Path.GetTempPath(), "ClarionAssistant", "WebView2Data");
+                userDataFolder = Path.Combine(Path.GetTempPath(), "ClarionAssistant", "WebView2Data_" + pidSuffix);
                 Directory.CreateDirectory(userDataFolder);
             }
 

--- a/ClarionAssistant/Terminal/WebView2EnvironmentCache.cs
+++ b/ClarionAssistant/Terminal/WebView2EnvironmentCache.cs
@@ -11,6 +11,14 @@ namespace ClarionAssistant.Terminal
         private static readonly object _lock = new object();
         private static Task<CoreWebView2Environment> _initTask;
 
+        // Holds this instance's profile-slot lock for the life of the process. Never disposed on
+        // purpose: the OS releases the handle at process exit (including a crash), which is what
+        // frees the slot for the next Clarion instance.
+        private static FileStream _slotLock;
+
+        private const int MaxProfileSlots = 16;
+        private const string LockFileName = ".ca-instance.lock";
+
         public static async Task<CoreWebView2Environment> GetEnvironmentAsync()
         {
             if (_environment != null)
@@ -42,28 +50,35 @@ namespace ClarionAssistant.Terminal
 
         private static async Task<CoreWebView2Environment> CreateEnvironmentAsync()
         {
-            // Suffixed per-process (PID) so each Clarion IDE instance gets its OWN WebView2 browser
-            // process instead of sharing one across every open instance. Sharing a userDataFolder makes
+            // Per-instance profile so each Clarion IDE instance gets its OWN WebView2 browser process
+            // instead of sharing one across every open instance. Sharing a userDataFolder makes
             // WebView2 share a single msedgewebview2.exe browser process across host processes, and
             // WebView2ProcessReaper (below) binds THAT browser PID to a per-process kill-on-close job —
             // so closing one Clarion instance was killing the shared browser and blacking out every
-            // other open instance's WebView2 pads. Isolating the folder per PID isolates the browser
-            // process too, so each instance's reaper can only ever kill its own.
-            string pidSuffix = System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
-            string userDataFolder = Path.Combine(
+            // other open instance's WebView2 pads. Isolating the folder isolates the browser process
+            // too, so each instance's reaper can only ever kill its own.
+            //
+            // Isolation uses stable SLOTS, not a per-PID suffix: slot 1 is the pre-existing
+            // "WebView2Data" folder (so localStorage prefs — diff/terminal/embeditor fonts and themes —
+            // survive the upgrade and persist across runs), and a concurrent second instance probes on
+            // to "WebView2Data_2", etc. A slot is owned by holding an exclusive lock on its
+            // ".ca-instance.lock"; the OS drops the lock at process exit (or crash), so slots recycle
+            // and the profile-folder count stays bounded instead of growing per launch.
+            string baseDir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "ClarionAssistant", "WebView2Data_" + pidSuffix);
-
+                "ClarionAssistant");
+            string userDataFolder;
             try
             {
-                if (!Directory.Exists(userDataFolder))
-                    Directory.CreateDirectory(userDataFolder);
+                userDataFolder = AcquireProfileFolder(baseDir);
             }
             catch
             {
-                userDataFolder = Path.Combine(Path.GetTempPath(), "ClarionAssistant", "WebView2Data_" + pidSuffix);
-                Directory.CreateDirectory(userDataFolder);
+                baseDir = Path.Combine(Path.GetTempPath(), "ClarionAssistant");
+                userDataFolder = AcquireProfileFolder(baseDir);
             }
+
+            CleanupStaleProfiles(userDataFolder);
 
             var options = new CoreWebView2EnvironmentOptions();
             // Disable GPU rasterization to prevent progressive text rendering
@@ -88,6 +103,96 @@ namespace ClarionAssistant.Terminal
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[WebView2Cache] reaper wire: " + ex.Message); }
 
             return _environment;
+        }
+
+        /// <summary>
+        /// Claim the first free profile slot under <paramref name="baseDir"/> by taking an exclusive
+        /// lock on its lock file. Slot 1 is the legacy "WebView2Data" folder; slots 2..N are
+        /// "WebView2Data_2".."WebView2Data_N". Throws only if the base dir itself is unusable.
+        /// </summary>
+        private static string AcquireProfileFolder(string baseDir)
+        {
+            for (int slot = 1; slot <= MaxProfileSlots; slot++)
+            {
+                string folder = Path.Combine(baseDir, slot == 1 ? "WebView2Data" : "WebView2Data_" + slot);
+                try
+                {
+                    Directory.CreateDirectory(folder);
+                    _slotLock = new FileStream(Path.Combine(folder, LockFileName),
+                        FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                    return folder;
+                }
+                catch
+                {
+                    // Slot owned by another live instance (lock held) or inaccessible — probe the next.
+                }
+            }
+
+            // More than MaxProfileSlots concurrent instances (or every slot inaccessible): last-resort
+            // per-PID folder. No prefs persistence here; swept by CleanupStaleProfiles on a later run.
+            string fallback = Path.Combine(baseDir, "WebView2Data_pid" +
+                System.Diagnostics.Process.GetCurrentProcess().Id);
+            Directory.CreateDirectory(fallback);
+            return fallback;
+        }
+
+        /// <summary>
+        /// Background best-effort sweep of leftover per-PID profile folders ("WebView2Data_pid1234"
+        /// slot-overflow fallbacks, and plain "WebView2Data_1234" from interim per-PID builds).
+        /// Stable slot folders are kept — they hold each slot's persisted prefs.
+        /// </summary>
+        private static void CleanupStaleProfiles(string activeFolder)
+        {
+            System.Threading.ThreadPool.QueueUserWorkItem(_ =>
+            {
+                string[] baseDirs =
+                {
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ClarionAssistant"),
+                    Path.Combine(Path.GetTempPath(), "ClarionAssistant")
+                };
+                foreach (string baseDir in baseDirs)
+                {
+                    try
+                    {
+                        if (!Directory.Exists(baseDir)) continue;
+                        foreach (string dir in Directory.GetDirectories(baseDir, "WebView2Data_*"))
+                        {
+                            try
+                            {
+                                if (string.Equals(dir, activeFolder, StringComparison.OrdinalIgnoreCase))
+                                    continue;
+
+                                string suffix = Path.GetFileName(dir).Substring("WebView2Data_".Length);
+
+                                int slot;
+                                if (int.TryParse(suffix, out slot) && slot >= 2 && slot <= MaxProfileSlots)
+                                    continue; // stable slot — keeps its prefs; ownership is decided by its lock
+
+                                // Per-PID leftover. Leave it alone while that process is still alive.
+                                string pidText = suffix.StartsWith("pid", StringComparison.OrdinalIgnoreCase)
+                                    ? suffix.Substring(3) : suffix;
+                                int pid;
+                                if (int.TryParse(pidText, out pid) && IsProcessAlive(pid))
+                                    continue;
+
+                                // Prove no CA instance owns it (exclusive lock), then delete. If a lingering
+                                // browser still holds files the delete throws and a later run retries.
+                                using (new FileStream(Path.Combine(dir, LockFileName),
+                                    FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)) { }
+                                Directory.Delete(dir, true);
+                            }
+                            catch { /* locked or in use — leave it for a future sweep */ }
+                        }
+                    }
+                    catch { /* base dir unreadable — nothing to do */ }
+                }
+            });
+        }
+
+        private static bool IsProcessAlive(int pid)
+        {
+            try { System.Diagnostics.Process.GetProcessById(pid); return true; }
+            catch { return false; }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closing one Clarion IDE instance would black out and freeze the ClarionAssistant pad (chat pad, CA Editor/Monaco embeditor, diff viewer, CA Find, etc.) in every *other* open Clarion IDE instance — reported as a critical, reproducible bug when running two IDEs on different solutions simultaneously with the pad open in both.

## Root cause

`WebView2EnvironmentCache.CreateEnvironmentAsync()` pointed every Clarion IDE process at the **same fixed** `userDataFolder` (`%LOCALAPPDATA%\ClarionAssistant\WebView2Data`, with an equally fixed temp-path fallback). WebView2 shares a single `msedgewebview2.exe` browser process across every host process that points at the same profile folder — so two separate `Clarion.exe` processes, despite being fully independent and possibly on different solutions, ended up driving one shared browser process for all their WebView2-hosted surfaces.

`WebView2ProcessReaper` (added for #109, to reap orphaned WebView2 processes after a Clarion crash) makes this fatal: each Clarion process independently creates its own anonymous Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` and assigns the browser's PID into it, keeping the job handle open for the process's whole lifetime so `KILL_ON_JOB_CLOSE` fires automatically on exit. Since Windows 8 / Server 2012, a process can belong to multiple job objects at once, so this assignment succeeds independently for every open IDE instance against the *same* shared browser PID — nesting the one shared browser process inside N separate "kill me when my owner exits" jobs.

Closing any single Clarion instance closes its job handle, which fires `KILL_ON_JOB_CLOSE` and kills the shared browser process out from under every other still-open instance — instantly breaking their WebView2 pads.

Confirmed directly (not just theorized): reproduced live with two real Clarion IDE instances (different solutions) and their ClarionAssistant pads open, and confirmed at the OS process level — before the fix, both instances' WebView2 surfaces resolved to one shared browser process tree; closing one instance killed that tree, breaking the other's pad.

## Fix

Suffix `userDataFolder` with the current process's PID (`WebView2Data_<pid>`, same suffix applied to the temp-path fallback), so each Clarion instance gets its own isolated WebView2 browser process. Each instance's `WebView2ProcessReaper` job can then only ever bind and kill its own browser process — never another instance's.

Trade-off: N simultaneously open Clarion IDEs now run N separate `msedgewebview2.exe` browser processes instead of one shared one (more total memory). This is the correct trade — the prior sharing was an unintended side effect of a constant path, not a deliberate design choice, and its cost (one IDE closing breaks every other open IDE) is far worse than the memory overhead of isolated profiles.

## Verification

- Confirmed via `Get-CimInstance Win32_Process` that, with two Clarion IDE instances running (different solutions, ClarionAssistant pad open in both), each now has its own `WebView2Data_<pid>` profile folder and its own independent `msedgewebview2.exe` browser process + crashpad-handler tree, correctly parented to its own Clarion PID.
- Live-reproduced the original bug scenario end to end: opened two IDEs on different solutions, opened the pad in both, closed one IDE entirely — the surviving IDE's pad (and its Monaco/CA Editor surface) stayed fully responsive, confirmed both functionally (pad interaction still worked) and at the process level (surviving instance's browser process tree was untouched, closed instance's was gone).
- Confirmed the shared-environment scope: `WebView2EnvironmentCache` is used by every WebView2-hosted surface in the addin (chat pad, `MonacoEditorControl`, `DiffViewContent`/`MonacoDiffViewContent`, `ModernDataPad`, `CaFindPad`, and others) — the fix protects all of them uniformly since it's applied at the shared environment/profile level, not per-control.
- Clean build via VS2022 MSBuild, `Version.props` bump reverted before committing per repo convention.
