### PR TITLE
fix(lsp): Don't jump to self on go-to-definition fallback

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -347,7 +347,26 @@ namespace ClarionAssistant.Services
                 ? (LspClient.Active != null ? LspClient.Active.GetDefinition(filePath, line, character) : null)
                 : SharedGetDefinition(c, filePath, line, character);
             if (!IsEmptyResult(primary)) return primary;
-            return CodeGraphDefinition(filePath, line, character, bufferText) ?? primary;
+
+            var cgResult = CodeGraphDefinition(filePath, line, character, bufferText);
+            if (IsSelfReferential(cgResult, filePath, line)) return primary;
+            return cgResult ?? primary;
+        }
+
+        /// <summary>True when a CodeGraph-fallback definition result resolves back to the EXACT same
+        /// file+line the query started from — e.g. F12 on a method's own PROCEDURE implementation
+        /// header, where the LSP deliberately returns empty ("already at the definition, nothing to
+        /// navigate to") but CodeGraph's flat symbol table has only the implementation row (no
+        /// separate .inc prototype symbol) and so "resolves" the bare name back to itself. Such a
+        /// result is never useful — return null instead of a bogus self-referential jump.</summary>
+        private static bool IsSelfReferential(Dictionary<string, object> result, string queryFilePath, int queryLine)
+        {
+            if (result == null) return false;
+            string foundFile; int foundLine, foundChar;
+            if (!TryGetFirstLocation(result, out foundFile, out foundLine, out foundChar)) return false;
+            if (foundLine != queryLine || string.IsNullOrEmpty(foundFile)) return false;
+            try { return string.Equals(Path.GetFullPath(foundFile), Path.GetFullPath(queryFilePath), StringComparison.OrdinalIgnoreCase); }
+            catch { return false; }
         }
 
         /// <summary>textDocument/implementation → raw LSP-response-shaped dict (locations), or null.


### PR DESCRIPTION
## Summary

Fixes a bogus "jump to self" result from `go to definition` (F12) when invoked on a method's own `PROCEDURE` implementation header line.

## Root cause

`SharedLspBridge.cs`'s `GetDefinition` calls the LSP first; if the LSP returns an empty result, it falls back to `CodeGraphDefinition(...)` (this addin's own indexed-symbol-table lookup, separate from the LSP).

F12 on a method's own implementation header is exactly the case where the LSP correctly returns empty — you're already at the definition, there's nothing to navigate to. But CodeGraph's flat symbol table only has the *implementation* row for such a method (no separate `.inc` prototype-declaration symbol), so the bare-name fallback lookup "resolves" the method name right back to the exact file+line the query started from. The result: F12 reports a "definition found" at the cursor's own position instead of doing nothing.

## Fix

Adds `IsSelfReferential(result, queryFilePath, queryLine)`, reusing the existing `TryGetFirstLocation` helper: returns true only when the CodeGraph fallback's first location resolves to the exact same file (full-path, case-insensitive) and line as the query. `GetDefinition` now checks this before returning the CodeGraph result — if self-referential, it falls through to the original (empty) LSP result instead of the bogus self-jump.

The non-self-referential path is unchanged: `CodeGraphDefinition(...) ?? primary`, same as before.

## Verification

- Clean build (`ClarionAssistant.csproj`, VS2022 MSBuild, Debug config).
- Independent code-reviewer pass confirmed: correct types/signatures matching `TryGetFirstLocation`, no null-ref surface, 0-based line numbering consistent on both sides of the comparison (verified against `CgLocation`'s DB-to-LSP conversion and the LSP's own `range.start.line`), `Path.GetFullPath` safe for the absolute paths used here (worst case on a mismatch is a silent no-op, not a crash), and the guard's only comparison dimension (file+line, not column) is a non-issue for Clarion source — the bare-name fallback resolves by symbol identity, so a same-line match can only mean the cursor is genuinely on that symbol's own declaration; Clarion's one-declaration-per-line convention makes a false-positive collision impractical.

## Related

Originally drafted as a general defense-in-depth guard while investigating a specific symptom (F12 on an implementation header not reaching its `.inc` prototype). That specific symptom's true root cause was fixed upstream in the Clarion-Extension VS Code extension (nesting-depth leak across GROUP/QUEUE/RECORD scanners) — this guard remains useful as a smaller, independent safety net for the general self-referential-fallback case regardless of that fix.
