### PR TITLE
feat(source-editor): watch for external readonly/content changes on disk

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -57,6 +57,19 @@ namespace ClarionAssistant
         private string _overlayLiveText; // last live buffer the page mirrored, for the close-save write
         private IDisposable _settingsReg; // registration in MonacoSettingsBroadcaster (cross-surface gear-settings sync, deac3d16)
 
+        // External disk watch: SourceSafe checkout/checkin flips the Windows read-only attribute, and any
+        // outside editor (Notepad++, another IDE) can change the content — neither is visible to us without
+        // this. See WireDiskWatch/CheckDiskState below for the full mechanism.
+        // _diskWatchDisposed guards a real race: a watcher/Error event can already be queued via BeginInvoke
+        // onto the (long-lived) workbench form BEFORE Dispose runs, and execute AFTER it — without this flag,
+        // that queued callback would recreate a live FileSystemWatcher/Timer that nothing will ever tear down.
+        private FileSystemWatcher _diskWatcher;
+        private Timer _diskWatchDebounce;
+        private volatile bool _diskWatchDisposed;
+        private bool _lastKnownReadOnly;
+        private DateTime _lastKnownWriteUtc;
+        private long _lastKnownLength = -1;
+
         // Host-driven navigation (debugger / breakpoint-list click via MonacoSourceNavigator). The page can't
         // be positioned until it signals ready, so a nav that arrives earlier is parked here and flushed in
         // OnReady. 1-based; _navPendingLine == 0 means "nothing queued".
@@ -428,6 +441,7 @@ namespace ClarionAssistant
                 if (_navPendingLine >= 1) { _editor.RevealLine(_navPendingLine, _navPendingCol); _navPendingLine = 0; }
                 if (navLine >= 1) _editor.RevealLine(navLine, navCol);
                 else ApplyPendingNavigation();   // nothing seeded → drain any nav that arrived between capture and ready
+                WireDiskWatch();   // start watching for external readonly/readwrite + content changes
             }
             catch (Exception ex) { MonacoSpikeLog.Write("overlay OnReady error: " + ex.Message); }
         }
@@ -959,6 +973,7 @@ namespace ClarionAssistant
                 string text = File.ReadAllText(_filePath, enc);
                 _overlayLiveText = text;
                 _overlayDirty = false;
+                RefreshDiskWatchBaseline();   // we just resynced with disk — any pending watcher event is now stale
 
                 File.WriteAllText(Path.Combine(_editor.TempDir, "source.txt"), text, Encoding.UTF8);
 
@@ -1236,6 +1251,8 @@ namespace ClarionAssistant
         }
         void IMonacoEditorHost.OnUnknownAction(MonacoEditorControl editor, string action, string rawJson)
         {
+            if (action == "diffWithDisk") { ShowDiskDiff(rawJson); return; }
+            if (action == "closeTab") { CloseWorkbenchTab(); return; }
             if (action != "toggleBreakpoint") return;
             // Gutter click in Monaco → toggle the IDE breakpoint on the native document. The native + CA
             // debuggers both listen to DebuggerService; the BreakPointAdded/Removed event re-pushes the set.
@@ -1349,7 +1366,224 @@ namespace ClarionAssistant
             // for UTF-8 or an unknown/missing encoding, write BOM-free UTF-8.
             if (enc == null || enc is UTF8Encoding) enc = NoBomUtf8;
             File.WriteAllText(_filePath, normalized, enc);
+            RefreshDiskWatchBaseline();   // this write is OURS — bring the baseline current so the watcher doesn't mistake it for an external change
             return normalized.Length;
+        }
+
+        // ── External disk watch (readonly/readwrite + content changes from outside the IDE) ────────
+        // FileSystemWatcher fires on a ThreadPool thread and often fires more than once for one logical
+        // change (SourceSafe touching attributes, an editor's atomic replace-save, antivirus scanning);
+        // a short UI-thread-owned debounce timer coalesces a burst into a single re-stat + notify pass.
+        // Our own writes (WriteToDisk) refresh the baseline immediately after writing, and OnReload
+        // refreshes it after re-syncing, so neither is ever mistaken for an "external" change even if a
+        // watcher event for it arrives late.
+
+        /// <summary>(Re)point the watcher at the current _filePath and capture a fresh baseline. Safe to
+        /// call more than once (idempotent) — OnReady is the only caller today, but a stray double-fire
+        /// must not leak a second watcher.</summary>
+        private void WireDiskWatch()
+        {
+            try
+            {
+                if (_diskWatchDisposed) return;   // instance is torn down — a queued Error-rewire must not resurrect a live watcher
+                UnwireDiskWatch();
+                if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath)) return;
+                RefreshDiskWatchBaseline();
+                _diskWatcher = new FileSystemWatcher(Path.GetDirectoryName(_filePath), Path.GetFileName(_filePath));
+                _diskWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Attributes | NotifyFilters.Size | NotifyFilters.FileName;
+                _diskWatcher.Changed += OnDiskWatcherEvent;
+                _diskWatcher.Created += OnDiskWatcherEvent;
+                _diskWatcher.Renamed += OnDiskWatcherEvent;
+                _diskWatcher.Deleted += OnDiskWatcherEvent;
+                // The watcher observes the whole directory (Filter is applied client-side, not by the OS),
+                // so heavy unrelated churn there (build output, logs, another tool) can overflow its internal
+                // buffer. On that error the watcher silently goes dark forever unless recreated — rewire
+                // instead of just logging, so watching self-heals rather than quietly stopping.
+                _diskWatcher.Error += OnDiskWatcherError;
+                _diskWatcher.EnableRaisingEvents = true;
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("WireDiskWatch error: " + ex.Message); }
+        }
+
+        /// <summary>Stop watching and drop the debounce timer. Called from Dispose so a torn-down
+        /// editor's watcher/timer never fires against a disposed instance.</summary>
+        private void UnwireDiskWatch()
+        {
+            try
+            {
+                if (_diskWatcher != null)
+                {
+                    _diskWatcher.EnableRaisingEvents = false;
+                    _diskWatcher.Changed -= OnDiskWatcherEvent;
+                    _diskWatcher.Created -= OnDiskWatcherEvent;
+                    _diskWatcher.Renamed -= OnDiskWatcherEvent;
+                    _diskWatcher.Deleted -= OnDiskWatcherEvent;
+                    _diskWatcher.Error -= OnDiskWatcherError;
+                    _diskWatcher.Dispose();
+                }
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("UnwireDiskWatch error: " + ex.Message); }
+            finally { _diskWatcher = null; }
+            try { if (_diskWatchDebounce != null) { _diskWatchDebounce.Stop(); _diskWatchDebounce.Dispose(); } } catch { }
+            _diskWatchDebounce = null;
+        }
+
+        /// <summary>Record the current on-disk attribute/size/timestamp as "known" — called once when the
+        /// watcher attaches, after OnReload resyncs, and after every self-write (WriteToDisk), so only a
+        /// genuinely external change ever looks different from this baseline.</summary>
+        private void RefreshDiskWatchBaseline()
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath)) return;
+                var fi = new FileInfo(_filePath);
+                _lastKnownReadOnly = fi.IsReadOnly;
+                _lastKnownWriteUtc = fi.LastWriteTimeUtc;
+                _lastKnownLength = fi.Length;
+            }
+            catch { }
+        }
+
+        // FileSystemWatcher callbacks land on a ThreadPool thread — hop to the UI thread before touching
+        // the Timer or any Monaco/WinForms state.
+        private void OnDiskWatcherEvent(object sender, FileSystemEventArgs e)
+        {
+            try
+            {
+                if (_diskWatchDisposed) return;
+                var form = ICSharpCode.SharpDevelop.Gui.WorkbenchSingleton.Workbench as Form;
+                // No workbench form (shutdown/teardown) → a notification doesn't matter anymore. Do NOT run
+                // ArmDiskWatchDebounce inline here: it constructs a System.Windows.Forms.Timer, which needs
+                // the creating thread's message pump to ever fire — this callback runs on a ThreadPool
+                // thread, which has none, so an inline call would silently create a Timer that never ticks.
+                if (form != null) form.BeginInvoke((Action)ArmDiskWatchDebounce);
+                else MonacoSpikeLog.Write("OnDiskWatcherEvent: no workbench form, dropping (shutdown)");
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("OnDiskWatcherEvent error: " + ex.Message); }
+        }
+
+        // The watcher raises Error (instead of throwing) on e.g. an internal buffer overflow — from then on
+        // it is permanently dead unless recreated. WireDiskWatch disposes any existing watcher first, so
+        // calling it again here is a clean rewire, not a leak.
+        private void OnDiskWatcherError(object sender, ErrorEventArgs e)
+        {
+            try
+            {
+                if (_diskWatchDisposed) return;
+                Exception inner = e.GetException();
+                MonacoSpikeLog.Write("DiskWatcher error, rewiring: " + (inner != null ? inner.Message : "(no exception)"));
+                var form = ICSharpCode.SharpDevelop.Gui.WorkbenchSingleton.Workbench as Form;
+                // Same reasoning as OnDiskWatcherEvent above: WireDiskWatch touches WinForms/FileSystemWatcher
+                // state that must be UI-thread-owned — never run it inline off the ThreadPool.
+                if (form != null) form.BeginInvoke((Action)WireDiskWatch);
+                else MonacoSpikeLog.Write("OnDiskWatcherError: no workbench form, dropping rewire (shutdown)");
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("OnDiskWatcherError handler error: " + ex.Message); }
+        }
+
+        private void ArmDiskWatchDebounce()
+        {
+            try
+            {
+                if (_diskWatchDisposed) return;   // BeginInvoke can deliver this after Dispose already tore the timer down
+                if (_diskWatchDebounce == null)
+                {
+                    _diskWatchDebounce = new Timer { Interval = 350 };
+                    _diskWatchDebounce.Tick += (s, e) => { _diskWatchDebounce.Stop(); CheckDiskState(); };
+                }
+                _diskWatchDebounce.Stop();
+                _diskWatchDebounce.Start();
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("ArmDiskWatchDebounce error: " + ex.Message); }
+        }
+
+        /// <summary>Re-stat the file against the last known baseline and tell the page what actually
+        /// changed. A readonly-only flip is applied silently (no user interaction, per the request that
+        /// started this); a content change always surfaces a toast (Reload / Show diff) — never a silent
+        /// auto-reload, so an open tab's content/scroll never shifts out from under the developer.</summary>
+        private void CheckDiskState()
+        {
+            try
+            {
+                if (_editor == null || string.IsNullOrEmpty(_filePath)) return;
+                if (!File.Exists(_filePath))
+                {
+                    _editor.PostJson("{\"type\":\"externalFileState\",\"deleted\":true,\"contentChanged\":false,\"readOnly\":false}");
+                    MonacoSpikeLog.Write("overlay external watch: file deleted/moved (" + _filePath + ")");
+                    return;
+                }
+                var fi = new FileInfo(_filePath);
+                bool nowReadOnly = fi.IsReadOnly;
+                bool contentChanged = fi.LastWriteTimeUtc != _lastKnownWriteUtc || fi.Length != _lastKnownLength;
+                bool readOnlyChanged = nowReadOnly != _lastKnownReadOnly;
+                if (!contentChanged && !readOnlyChanged) return;   // e.g. an AV scan touched mtime without a real change
+
+                _lastKnownReadOnly = nowReadOnly;
+                _lastKnownWriteUtc = fi.LastWriteTimeUtc;
+                _lastKnownLength = fi.Length;
+
+                string json = "{\"type\":\"externalFileState\",\"deleted\":false,"
+                    + "\"contentChanged\":" + (contentChanged ? "true" : "false") + ","
+                    + "\"readOnly\":" + (nowReadOnly ? "true" : "false") + "}";
+                _editor.PostJson(json);
+                MonacoSpikeLog.Write("overlay external watch: readOnly=" + nowReadOnly + " contentChanged=" + contentChanged + " (" + _filePath + ")");
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("CheckDiskState error: " + ex.Message); }
+        }
+
+        /// <summary>{action:"diffWithDisk"} from the external-change toast's "Show diff" button — routed
+        /// via OnUnknownAction (like toggleBreakpoint) rather than a new IMonacoEditorHost method, so
+        /// ModernEmbeditorViewContent (CA Embeditor) — which implements the same shared interface — is
+        /// completely untouched by this CA-Editor-only feature.</summary>
+        private void ShowDiskDiff(string rawJson)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath)) return;
+                var data = new JavaScriptSerializer { MaxJsonLength = int.MaxValue }.DeserializeObject(rawJson) as Dictionary<string, object>;
+                string liveText = (data != null && data.ContainsKey("text")) ? (data["text"] as string ?? "") : (_overlayLiveText ?? "");
+                Encoding enc = EncodingHelper.DetectFileEncoding(_filePath);
+                string diskText = File.ReadAllText(_filePath, enc);
+                var diff = new MonacoDiffViewContent(
+                    "External change: " + Path.GetFileName(_filePath), diskText, liveText, "clarion", false, Services.CaEditorSettings.MonacoThemeDark);
+                // This is a read-only comparison, not a code-review workflow — there's nothing to "apply"
+                // (unlike show_diff's usual Approve/Cancel meaning). Live testing confirmed both buttons were
+                // otherwise dead clicks with no wired handler; closing the tab either way is the only
+                // sensible behavior here.
+                diff.Applied += modifiedText => CloseDiffView(diff);
+                diff.Cancelled += () => CloseDiffView(diff);
+                ICSharpCode.SharpDevelop.Gui.WorkbenchSingleton.Workbench.ShowView(diff);
+                MonacoSpikeLog.Write("overlay external watch: opened disk-vs-editor diff for " + _filePath);
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("ShowDiskDiff error: " + ex.Message); }
+        }
+
+        private static void CloseDiffView(MonacoDiffViewContent diff)
+        {
+            try { var ww = diff.WorkbenchWindow; if (ww != null) ww.CloseWindow(true); }
+            catch (Exception ex) { MonacoSpikeLog.Write("CloseDiffView error: " + ex.Message); }
+        }
+
+        /// <summary>{action:"closeTab"} from the "file deleted externally" toast's "Close tab" button.
+        /// Closes via CloseWindow(false) — NOT forced — so this routes through the exact same cancellable
+        /// ClosingEvent that EnsureCloseHook already wires to OnWorkbenchClosing, meaning an unsaved-edits
+        /// prompt still fires exactly as it would for a normal tab-close click (Save there still recreates
+        /// the now-deleted file via WriteToDisk, same as clicking Save directly).</summary>
+        private void CloseWorkbenchTab()
+        {
+            try
+            {
+                object wbw = _wbWindow;
+                if (wbw == null) { try { wbw = GetType().GetProperty("WorkbenchWindow")?.GetValue(this, null); } catch { } }
+                if (wbw == null) { MonacoSpikeLog.Write("closeTab: WorkbenchWindow not available"); return; }
+                var m = wbw.GetType().GetMethod("CloseWindow", new[] { typeof(bool) });
+                if (m == null)
+                    foreach (var itf in wbw.GetType().GetInterfaces()) { m = itf.GetMethod("CloseWindow", new[] { typeof(bool) }); if (m != null) break; }
+                if (m == null) { MonacoSpikeLog.Write("closeTab: CloseWindow method not found on " + wbw.GetType().FullName); return; }
+                m.Invoke(wbw, new object[] { false });
+                MonacoSpikeLog.Write("overlay external watch: closeTab requested for " + (_filePath ?? "?"));
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("CloseWorkbenchTab error: " + ex.Message); }
         }
 
         private static void EnsureLsp()
@@ -1659,6 +1893,12 @@ namespace ClarionAssistant
             StopCaptureTimer();
             try { if (_hookRetry != null) { _hookRetry.Stop(); _hookRetry.Dispose(); _hookRetry = null; } } catch { }
             UnwireBreakpoints();
+            // Set BEFORE tearing down: a watcher/Error event can already be queued via BeginInvoke onto the
+            // (long-lived) workbench form before this Dispose runs and only execute after it — this flag is
+            // what stops that queued callback from resurrecting a live FileSystemWatcher/Timer (see WireDiskWatch/
+            // ArmDiskWatchDebounce's own guards).
+            _diskWatchDisposed = true;
+            try { UnwireDiskWatch(); } catch { }
             try { ClarionAssistant.Services.CaFindBroker.UnregisterHost(this); } catch { }
             try { MonacoSourceNavigator.Unregister(_filePath, this); } catch { }
             try { if (_closingEvt != null && _wbWindow != null && _closingHandler != null) _closingEvt.RemoveEventHandler(_wbWindow, _closingHandler); } catch { }

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -1498,8 +1498,10 @@ namespace ClarionAssistant
         }
 
         /// <summary>Re-stat the file against the last known baseline and tell the page what actually
-        /// changed. A readonly-only flip is applied silently (no user interaction, per the request that
-        /// started this); a content change always surfaces a toast (Reload / Show diff) — never a silent
+        /// changed. A readonly-only flip is applied silently UNLESS the tab has unsaved edits at that
+        /// moment — those edits can no longer be saved once the file is read-only, so the page surfaces a
+        /// Show-diff toast instead of letting them vanish without notice on close (see readOnlyChanged
+        /// below). A content change always surfaces a toast (Reload / Show diff) — never a silent
         /// auto-reload, so an open tab's content/scroll never shifts out from under the developer.</summary>
         private void CheckDiskState()
         {
@@ -1524,7 +1526,8 @@ namespace ClarionAssistant
 
                 string json = "{\"type\":\"externalFileState\",\"deleted\":false,"
                     + "\"contentChanged\":" + (contentChanged ? "true" : "false") + ","
-                    + "\"readOnly\":" + (nowReadOnly ? "true" : "false") + "}";
+                    + "\"readOnly\":" + (nowReadOnly ? "true" : "false") + ","
+                    + "\"readOnlyChanged\":" + (readOnlyChanged ? "true" : "false") + "}";
                 _editor.PostJson(json);
                 MonacoSpikeLog.Write("overlay external watch: readOnly=" + nowReadOnly + " contentChanged=" + contentChanged + " (" + _filePath + ")");
             }
@@ -1870,14 +1873,26 @@ namespace ClarionAssistant
                 if (e.Cancel) return;
                 if (!(_overlayDirty && _overlayLiveText != null && !string.IsNullOrEmpty(_filePath))) return;
 
+                // This may be a background tab (closed via its own [x] while another tab is active) — bring
+                // it to the foreground before asking anything, so the developer can actually see which file
+                // the prompt is about, and so the read-only toast (lives inside this tab's own Monaco page)
+                // is visible rather than painting unseen behind the active tab.
+                try { _wbWindow?.GetType().GetMethod("SelectWindow", Type.EmptyTypes)?.Invoke(_wbWindow, null); } catch { }
+
                 var owner = _wbWindow as IWin32Window;
+                // WinForms' MessageBox can't disable a single button, so a read-only file gets a Close/Cancel-
+                // only dialog instead — no "Yes" option that would just throw on WriteToDisk (see the toast in
+                // handleExternalFileState for the real recovery path: Show diff, then re-check-out and save).
+                bool readOnly = IsFileReadOnly();
+                string message = readOnly
+                    ? Path.GetFileName(_filePath) + " is read-only — its unsaved changes can't be saved here.\n\nClose anyway?"
+                    : "Save changes to " + Path.GetFileName(_filePath) + " before closing?";
+                var buttons = readOnly ? MessageBoxButtons.OKCancel : MessageBoxButtons.YesNoCancel;
                 var r = owner != null
-                    ? MessageBox.Show(owner, "Save changes to " + Path.GetFileName(_filePath) + " before closing?",
-                        "CA Editor — unsaved changes", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning)
-                    : MessageBox.Show("Save changes to " + Path.GetFileName(_filePath) + " before closing?",
-                        "CA Editor — unsaved changes", MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
+                    ? MessageBox.Show(owner, message, "CA Editor — unsaved changes", buttons, MessageBoxIcon.Warning)
+                    : MessageBox.Show(message, "CA Editor — unsaved changes", buttons, MessageBoxIcon.Warning);
                 if (r == DialogResult.Cancel) { e.Cancel = true; return; }
-                if (r == DialogResult.Yes)
+                if (r == DialogResult.Yes)   // only reachable when !readOnly
                 {
                     int n = WriteToDisk(_overlayLiveText);
                     MonacoSpikeLog.Write("overlay close-save wrote: " + _filePath + " (" + n + " chars)");

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -1586,10 +1586,22 @@
         if (t && t.classList.contains('actionable') && t.classList.contains('show')) t.className = '';
     });
 
+    // Shared "Show diff" toast action (live buffer, including unsaved edits, vs. disk) — used by both the
+    // content-changed toast and the became-read-only-while-dirty toast below.
+    function postDiffWithDisk() {
+        var ed = activeEd(), model = ed && ed.getModel();
+        // Fall back to whatever the host last mirrored (_overlayLiveText) rather than sending
+        // no text at all if the model is transiently unavailable.
+        postToHost({ action: 'diffWithDisk', text: model ? model.getValue() : undefined });
+    }
+
     // {"type":"externalFileState",...} from the host's disk watcher (CA Editor / file mode only — the
-    // embeditor never sends this). Readonly/readwrite flips are applied silently (no user interaction,
-    // by design); a content change always surfaces an actionable toast — see showActionToast above for
-    // why it never auto-dismisses. Deleted/moved is a simple warning with no action (rare edge case).
+    // embeditor never sends this). Readonly/readwrite flips are applied silently UNLESS the tab has
+    // unsaved edits at the moment of the flip — those can no longer be saved once the file is read-only
+    // (e.g. a SourceSafe check-in with no unsaved edits should stay invisible; the same check-in while a
+    // tab is dirty should not let that edit vanish on close without ever telling the developer). A content
+    // change always surfaces an actionable toast — see showActionToast above for why it never auto-
+    // dismisses. Deleted/moved is a simple warning with no action (rare edge case).
     function handleExternalFileState(msg) {
         if (!fileMode) return;
         if (msg.deleted) {
@@ -1599,21 +1611,25 @@
             ]);
             return;
         }
+        var justWentReadOnlyDirty = !!msg.readOnly && !!msg.readOnlyChanged && isDirty;
         applyExternalReadOnly(!!msg.readOnly);
         if (msg.contentChanged) {
             var warn = isDirty
                 ? 'File changed on disk outside the editor. You have unsaved changes — Reload will discard them.'
                 : 'File changed on disk outside the editor.';
+            if (justWentReadOnlyDirty) warn = 'File changed on disk and is now read-only outside the editor. ' +
+                'Your unsaved changes can no longer be saved here — Reload will discard them.';
             showActionToast(warn, false, [
                 { label: 'Reload', onClick: function () { postToHost({ action: 'reload' }); } },
-                {
-                    label: 'Show diff', dismiss: false, onClick: function () {
-                        var ed = activeEd(), model = ed && ed.getModel();
-                        // Fall back to whatever the host last mirrored (_overlayLiveText) rather than sending
-                        // no text at all if the model is transiently unavailable.
-                        postToHost({ action: 'diffWithDisk', text: model ? model.getValue() : undefined });
-                    }
-                }
+                { label: 'Show diff', dismiss: false, onClick: postDiffWithDisk }
+            ]);
+        } else if (justWentReadOnlyDirty) {
+            // No content change, just the attribute flip (e.g. a plain check-in) — the file itself didn't
+            // diverge, only its writability did, so there's nothing to Reload from. Show diff only, so an
+            // edit that can no longer be saved is at least surfaced instead of silently lost on close.
+            showActionToast('This file just became read-only outside the editor. Your unsaved changes can ' +
+                'no longer be saved here.', false, [
+                { label: 'Show diff', dismiss: false, onClick: postDiffWithDisk }
             ]);
         }
     }

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -130,6 +130,23 @@
     }
     #toast.show { opacity: 1; transform: translateY(0); }
     #toast.err { background: #f38ba8; color: #1e1e2e; }
+    /* Actionable toast (external-change notice): has real buttons, so it must accept pointer events —
+       unlike the plain message toast above, which is deliberately click-through. */
+    #toast.actionable { pointer-events: auto; display: flex; align-items: center; gap: 10px; white-space: normal; }
+    #toast.actionable .toast-action-btn {
+        flex: none; border: 1px solid rgba(255,255,255,0.35); border-radius: 4px; background: rgba(255,255,255,0.12);
+        color: inherit; font-size: 11px; padding: 3px 9px; cursor: pointer;
+    }
+    #toast.actionable .toast-action-btn:hover { background: rgba(255,255,255,0.24); }
+    #toast.err.actionable .toast-action-btn { border-color: rgba(30,30,46,0.35); background: rgba(30,30,46,0.1); }
+    #toast.err.actionable .toast-action-btn:hover { background: rgba(30,30,46,0.2); }
+    /* Manual dismiss — visually subordinate to the real actions (no border, tighter padding) so it doesn't
+       compete with Reload/Show diff/Close tab, but still an obvious click target. */
+    #toast.actionable .toast-dismiss-btn {
+        margin-left: auto; border: none; background: transparent; padding: 3px 6px; opacity: 0.7; font-size: 12px;
+    }
+    #toast.actionable .toast-dismiss-btn:hover { opacity: 1; background: rgba(255,255,255,0.16); border-radius: 4px; }
+    #toast.err.actionable .toast-dismiss-btn:hover { background: rgba(30,30,46,0.16); }
 
     #toolbar #settingsBtn { padding: 3px 8px; font-size: 14px; line-height: 1; }
     #toolbar .tb-sep { width: 1px; align-self: stretch; margin: 4px 2px; background: var(--toolbar-border); }
@@ -1518,6 +1535,101 @@
         if (toastTimer) { clearTimeout(toastTimer); toastTimer = null; }
         if (!persist)
             toastTimer = setTimeout(function () { t.className = ''; }, ok === false ? 8000 : 6000);
+    }
+
+    // A toast with real, clickable buttons (external-change notice: Reload / Show diff / Close tab). Unlike
+    // showToast, this never auto-dismisses on a timer — it stays up until the developer resolves it (or
+    // explicitly dismisses it) or another toast replaces it, since silently discarding the notice would leave
+    // a stale-content tab with no indication the file actually diverged from disk.
+    // Each action may set `dismiss: false` to opt out of auto-closing the toast on click — used by "Show
+    // diff", which is just a peek: the notice is still unresolved after looking, so Reload/Close tab must
+    // still be there afterward (confirmed via live testing: without this, clicking Show diff silently
+    // extinguished the notice with nothing actually decided).
+    // Always adds a manual "✕" dismiss button (not part of `actions`) plus Escape-to-dismiss, since there was
+    // previously no way to acknowledge-and-defer without committing to one of the offered actions.
+    function showActionToast(message, ok, actions) {
+        var t = document.getElementById('toast');
+        if (!t) return;
+        if (toastTimer) { clearTimeout(toastTimer); toastTimer = null; }
+        t.textContent = '';
+        var span = document.createElement('span');
+        span.textContent = message;
+        t.appendChild(span);
+        (actions || []).forEach(function (a) {
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'toast-action-btn';
+            btn.textContent = a.label;
+            btn.addEventListener('click', function (ev) {
+                ev.stopPropagation();
+                if (a.dismiss !== false) t.className = '';   // resolving actions dismiss; a peek (dismiss:false) doesn't
+                // The toast may already be gone by the time onClick runs, so a throwing handler would
+                // otherwise leave the user with no toast, no error, and no way to retry.
+                try { a.onClick(); } catch (ex) { showToast('Action failed: ' + ex.message, false); }
+            });
+            t.appendChild(btn);
+        });
+        var dismissBtn = document.createElement('button');
+        dismissBtn.type = 'button';
+        dismissBtn.className = 'toast-action-btn toast-dismiss-btn';
+        dismissBtn.title = 'Dismiss';
+        dismissBtn.textContent = '✕';
+        dismissBtn.addEventListener('click', function (ev) { ev.stopPropagation(); t.className = ''; });
+        t.appendChild(dismissBtn);
+        t.className = 'show actionable' + (ok === false ? ' err' : '');
+    }
+    // Escape dismisses the actionable toast (a plain showToast is click-through/non-interactive and doesn't
+    // need this — only the actionable variant has pointer-events enabled and real focusable buttons).
+    document.addEventListener('keydown', function (ev) {
+        if (ev.key !== 'Escape') return;
+        var t = document.getElementById('toast');
+        if (t && t.classList.contains('actionable') && t.classList.contains('show')) t.className = '';
+    });
+
+    // {"type":"externalFileState",...} from the host's disk watcher (CA Editor / file mode only — the
+    // embeditor never sends this). Readonly/readwrite flips are applied silently (no user interaction,
+    // by design); a content change always surfaces an actionable toast — see showActionToast above for
+    // why it never auto-dismisses. Deleted/moved is a simple warning with no action (rare edge case).
+    function handleExternalFileState(msg) {
+        if (!fileMode) return;
+        if (msg.deleted) {
+            showActionToast('File was deleted or moved outside the editor. You can keep editing — Save will ' +
+                'recreate it — or close this tab.', false, [
+                { label: 'Close tab', onClick: function () { postToHost({ action: 'closeTab' }); } }
+            ]);
+            return;
+        }
+        applyExternalReadOnly(!!msg.readOnly);
+        if (msg.contentChanged) {
+            var warn = isDirty
+                ? 'File changed on disk outside the editor. You have unsaved changes — Reload will discard them.'
+                : 'File changed on disk outside the editor.';
+            showActionToast(warn, false, [
+                { label: 'Reload', onClick: function () { postToHost({ action: 'reload' }); } },
+                {
+                    label: 'Show diff', dismiss: false, onClick: function () {
+                        var ed = activeEd(), model = ed && ed.getModel();
+                        // Fall back to whatever the host last mirrored (_overlayLiveText) rather than sending
+                        // no text at all if the model is transiently unavailable.
+                        postToHost({ action: 'diffWithDisk', text: model ? model.getValue() : undefined });
+                    }
+                }
+            ]);
+        }
+    }
+
+    // Applies a readonly/readwrite flip WITHOUT touching content, cursor, or scroll — unlike a reload,
+    // this must be invisible to anything but the readOnly-dependent UI (editor options, Save button,
+    // title suffix). baseTitle already carries any "(read-only)" suffix set by the host at open/reload
+    // time, so strip-then-reapply keeps this idempotent no matter how it was set originally.
+    function applyExternalReadOnly(ro) {
+        try { editor.updateOptions({ readOnly: ro }); } catch (e) { }
+        try { if (editor2) editor2.updateOptions({ readOnly: ro }); } catch (e) { }
+        saveEnabled = !ro;
+        var sb = document.getElementById('saveBtn');
+        if (sb) sb.style.display = saveEnabled ? '' : 'none';
+        baseTitle = (baseTitle || '').replace(/ \(read-only\)$/, '') + (ro ? ' (read-only)' : '');
+        renderTitle();
     }
 
     // Clarion-style Ctrl+X: with a selection, cut it. With NO selection, REMOVE the whole current line —
@@ -5715,6 +5827,8 @@
                 snippetsList = msg.snippets || [];
                 if (snippetPickerOpen) renderSnippetPickerList();   // keep an open picker live if Settings was edited concurrently
                 renderGearSnippets();                               // refresh the gear-panel manager list
+            } else if (msg.type === 'externalFileState') {
+                handleExternalFileState(msg);
             }
         });
     }


### PR DESCRIPTION
## Summary

The CA Editor had no way to notice a file changing outside the IDE while its tab was open — neither its Windows read-only attribute flipping (e.g. a SourceSafe checkout/checkin) nor its content changing (another editor, another tool). The developer would keep editing a stale buffer, or keep believing a file was still writable/read-only after it had actually changed, with no indication until they happened to close and reopen the tab.

## Fix

Each CA Editor tab now runs its own `FileSystemWatcher` (wired in `OnReady`, torn down in `Dispose`) on the file it's showing, debounced ~350ms before re-stat'ing (SourceSafe/antivirus/atomic-replace saves often fire several raw filesystem events per real change).

- **Readonly ↔ readwrite only, content unchanged:** applied silently — Monaco's `readOnly` option, the Save button, and the title's `(read-only)` suffix update with no popup. This was the original, explicit ask: no user interaction for this case.

- **Content changed on disk:** a toast with **Reload** and **Show diff** (disk vs. the live editor buffer — including any unsaved edits — via `MonacoDiffViewContent`, the same diff surface `show_diff` uses). If there are unsaved local edits, the toast text says so.<br/>
&emsp;&emsp;<img width="410" height="38" alt="Toast_FileChanged" src="https://github.com/user-attachments/assets/ebfdf5cb-4051-40dd-a3ec-188a97e36594" />
&emsp;&emsp;<img width="705" height="40" alt="Toast_BothPartiedModifiedFile" src="https://github.com/user-attachments/assets/a4b9df29-0181-4551-a8d4-920664f6c569" />

- **File deleted/moved externally:** a toast with **Close tab** (closes via the same cancellable `ClosingEvent` path a normal tab-close uses, so an unsaved-edits prompt still fires; Save still recreates the file either way).<br/>
&emsp;&emsp;<img width="716" height="39" alt="Toast_FileDeleted" src="https://github.com/user-attachments/assets/146d7125-d027-4921-b0b8-fee7940348ed" />


- The toast never auto-dismisses on its own — silently losing the notice would leave a stale tab with no visible sign anything changed. A manual **✕** dismiss and **Escape** are provided instead, since neither Reload/Close tab is always the right immediate choice.
- Self-writes (interactive save, the existing build-triggered save, Reload) refresh an internal baseline immediately after writing, so they're never mistaken for an external change — even a watcher event for our own write arriving late will re-stat and find nothing different from the baseline. No suppress-flag/timing-window needed.
- The watcher observes the whole containing directory (`FileSystemWatcher.Filter` is applied client-side, not by the OS), so unrelated heavy churn there could overflow its internal buffer; on that `Error` it disposes and recreates itself rather than silently going dark.
- The two new page→host actions (`diffWithDisk`, `closeTab`) are routed through the existing `OnUnknownAction` catch-all (same mechanism `toggleBreakpoint` already uses) rather than adding new `IMonacoEditorHost` methods — so `ModernEmbeditorViewContent` (CA Embeditor, which implements the same shared interface) is completely untouched. This is scoped to the CA Editor (whole-file overlay) only.

Also fixed two dead buttons found while live-testing this:
- `MonacoDiffViewContent`'s Approve/Cancel had no handler wired for this comparison-only use — both now just close the diff tab.
- The toast's "Show diff" button used to dismiss the toast on click even though nothing was actually resolved (any button click dismissed). It now opts out via `dismiss:false`, so Reload/Close tab are still there after you've looked at the diff.

## Abandoned: background-tab title marker

Also attempted: prefixing the native tab's title (e.g. `⚠ filename.clw`) when a change notice fires while that tab isn't the active one, so it's visible from the tab strip without switching to it. Confirmed the underlying data change was correct (title string genuinely updated, correct repaint call invoked with no error) but the visible tab label itself never updated in testing, across several different approaches. Dropped it rather than keep guessing at what turned out to be a deeper rendering question than expected — the toast itself is unconditional and reliable regardless, so the substantive notification isn't lost, just this one visual enhancement on top of it. If you've run into something like this before, or have a pointer, that'd be very welcome — happy to pick it back up.

## Verification

Live-tested extensively against a real file outside the project (edited/saved from Notepad++, deleted, recreated via Save) covering: readonly flip while open (silent, both directions), content change with and without local unsaved edits, delete + Close tab + unsaved-edit prompt, Save recreating a deleted file without falsely re-triggering the watcher, Reload from the toolbar correctly failing on a genuinely-deleted file, and self-writes (interactive save, Reload) never producing a false external-change notice. An independent code-reviewer pass caught and fixed a real post-`Dispose` resurrection race in the watcher/debounce-timer teardown before this was finalized.
