### PR TITLE
feat(editor): expose live Monaco cursor via a new cross-addin reflection contract

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -918,6 +918,15 @@ namespace ClarionAssistant
             }
             catch { }
         }
+
+        /// <summary>Cross-addin entry point (via MonacoSourceNavigator.TryGetActiveCursor): this editor's
+        /// live Monaco cursor position, kept current by OnSelectionChanged above. Returns false if Monaco
+        /// hasn't reported a position yet (e.g. the overlay just attached, before the first cursor move).</summary>
+        internal bool TryGetLiveCursor(out string filePath, out int line, out int column)
+        {
+            filePath = _filePath; line = _lastCursorLine; column = _lastCursorCol;
+            return line >= 1 && !string.IsNullOrEmpty(_filePath);
+        }
         void IMonacoEditorHost.OnFocusEditor(MonacoEditorControl editor) { }
 
         // Reload button (fileMode page, two-click confirm): discards the overlay's in-buffer edits and

--- a/ClarionAssistant/Services/MonacoSourceNavigator.cs
+++ b/ClarionAssistant/Services/MonacoSourceNavigator.cs
@@ -104,6 +104,41 @@ namespace ClarionAssistant.Services
             }
         }
 
+        /// <summary>
+        /// Cross-addin entry point (reflection, same pattern as <see cref="NavigateToFileAndLine"/>): the
+        /// ACTIVE document's live Monaco cursor position — file path + 1-based line/column — for callers
+        /// (e.g. the standalone ClarionDebugger's "Run to cursor") that need "wherever the developer's
+        /// cursor actually is right now" rather than a specific known file/line. Frozen contract:
+        ///   bool ClarionAssistant.Services.MonacoSourceNavigator.TryGetActiveCursor(out string filePath, out int line, out int column)
+        /// Returns false if the active workbench window isn't a Monaco-hosted Clarion source editor, or
+        /// Monaco hasn't reported a cursor position yet (overlay just attached, before the first move) —
+        /// callers should treat false as "no usable cursor", not retry blindly.
+        /// </summary>
+        public static bool TryGetActiveCursor(out string filePath, out int line, out int column)
+        {
+            string fp = null; int ln = 0, col = 0; bool ok = false;
+            try
+            {
+                var form = WorkbenchSingleton.Workbench as Form;
+                if (form != null && form.InvokeRequired)
+                    form.Invoke(new Action(() => ok = TryGetActiveCursorOnUiThread(out fp, out ln, out col)));
+                else
+                    ok = TryGetActiveCursorOnUiThread(out fp, out ln, out col);
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("TryGetActiveCursor error: " + ex.Message); ok = false; }
+            filePath = fp; line = ln; column = col;
+            return ok;
+        }
+
+        private static bool TryGetActiveCursorOnUiThread(out string filePath, out int line, out int column)
+        {
+            filePath = null; line = 0; column = 0;
+            var window = WorkbenchSingleton.Workbench?.ActiveWorkbenchWindow;
+            var editor = (window?.ActiveViewContent ?? window?.ViewContent) as MonacoClarionEditor;
+            if (editor == null) return false;
+            return editor.TryGetLiveCursor(out filePath, out line, out column);
+        }
+
         /// <summary>Pop a parked navigation for <paramref name="filePath"/> (the editor applies it on load).</summary>
         internal static bool TryConsumePending(string filePath, out int line, out int column)
         {


### PR DESCRIPTION
## Summary

Adds a new cross-addin reflection contract, `MonacoSourceNavigator.TryGetActiveCursor(out string filePath, out int line, out int column)`, that reports the **active document's live Monaco cursor position** (file path + 1-based line/column).

This is the read-direction counterpart to the existing `NavigateToFileAndLine` contract: that one drives the editor *to* a known position; this one reports *where the cursor currently is*, for a caller that has no compile-time reference to ClarionAssistant. The motivating caller is the standalone ClarionDebugger addin's "Run to cursor" feature — it needs "wherever the developer's cursor actually is right now" in whatever Monaco-hosted Clarion source tab is active, not a specific known file/line.

## Changes

- `Services/MonacoSourceNavigator.cs`: new `public static bool TryGetActiveCursor(out string filePath, out int line, out int column)`. Resolves `WorkbenchSingleton.Workbench.ActiveWorkbenchWindow`, gets its `MonacoClarionEditor` view content, and delegates to the editor's own `TryGetLiveCursor`. Marshals onto the UI thread via `form.Invoke` when required — same pattern as `NavigateToFileAndLine` a few lines above it in the same file.
- `MonacoClarionSourceEditor.cs`: new `internal bool TryGetLiveCursor(out string filePath, out int line, out int column)`, added directly after `OnSelectionChanged`. Reuses the existing `_lastCursorLine`/`_lastCursorCol`/`_filePath` fields already kept live by that handler (previously only used to persist the cursor on tab close) — no new state, no behavior change to any existing path.

Both methods return `false` if the active window isn't a Monaco-hosted Clarion source editor, or Monaco hasn't reported a cursor position yet (e.g. the overlay just attached, before the first cursor move) — callers should treat `false` as "no usable cursor," not retry blindly.

## Verification

- Clean build (`ClarionAssistant.csproj`, Debug, ClarionVersion=11) with no warnings introduced.
- Pure addition: 2 files touched, 44 lines added, 0 removed. No existing call path is modified.
- Frozen-contract signature matches the calling convention already established by `NavigateToFileAndLine` (primitive `(out string, out int, out int) -> bool`, reflection-friendly, no ClarionAssistant types crossing the addin boundary).
