### PR TITLE
fix(diagnostics): Variables named MENU/MENUBAR/SHEET/TAB/OPTION identified correctly

### DIFF
--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -44,7 +44,7 @@ namespace ClarionAssistant.Services
         // The lookahead (not [,(]|$ like BandOpen) deliberately allows code structures that take an
         // expression: LOOP I = 1 TO 10, CASE SomeVar, EXECUTE n.
         private static readonly Regex StructOpen = new Regex(
-            @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|MENUBAR|MENU|SHEET|TAB|OPTION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)(?=\s|,|\(|$)",
+            @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)(?=\s|,|\(|$)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
         // TOOLBAR is nested inside WINDOW/APPLICATION bodies and legitimately written bare
         // ("TOOLBAR,USE(?Toolbar1)"), so StructOpen's generic lookahead (which accepts any
@@ -55,6 +55,15 @@ namespace ClarionAssistant.Services
         // TOOLBAR pattern (PR #378's companion fix in the real LSP).
         private static readonly Regex ToolbarOpen = new Regex(
             @"^\s*TOOLBAR\b(?=\s*(?:[(,!]|$))",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // MENU/MENUBAR/SHEET/TAB/OPTION share TOOLBAR's exact ambiguity: all are nested inside
+        // WINDOW/APPLICATION/REPORT bodies and legitimately written bare (e.g. "OPTION,USE(?opt)",
+        // "TAB,USE(?tab1)"), so StructOpen's old generic lookahead also matched a bare LABEL
+        // declaration of the same name — e.g. "option     LONG(0)" (a plain local variable) or
+        // "Tab &TabClass". Deferred alongside TOOLBAR's fix (PR #136) at the time; now given the
+        // same tight lookahead ('(', ',', '!' or end-of-line right after the keyword).
+        private static readonly Regex NestedBandOpen = new Regex(
+            @"^\s*(MENUBAR|MENU|SHEET|TAB|OPTION)\b(?=\s*(?:[(,!]|$))",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex StructWordRx = new Regex(
             @"\b(IF|GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|MENUBAR|MENU|TOOLBAR|SHEET|TAB|OPTION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)\b",
@@ -76,9 +85,13 @@ namespace ClarionAssistant.Services
         // "MAP" / "MODULE('')" in a plain MAP...END prototype block):
         //   MAP, MODULE       — namespace-like scoping constructs, never labeled.
         //   ITEMIZE, JOIN     — nested inside LIST/VIEW bodies, never labeled.
-        //   HEADER, FOOTER, FORM, DETAIL, MENUBAR, MENU, TOOLBAR, SHEET, TAB, OPTION
+        //   HEADER, FOOTER, FORM, DETAIL
         //                     — nested inside WINDOW/REPORT bodies; identified by an optional
         //                       ?field-equate via USE(), not a plain leading label.
+        //   TOOLBAR, MENUBAR, MENU, SHEET, TAB, OPTION
+        //                     — same as above, but ALSO given their own tight-lookahead regex
+        //                       (ToolbarOpen / NestedBandOpen) so a bare label of the same name
+        //                       is never even offered to this set in the first place.
         // Execution structures (LOOP/CASE/BEGIN/EXECUTE/ACCEPT) legitimately have no preceding label
         // either and were never in this set.
         private static readonly HashSet<string> DeclarationStructKeywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -211,6 +224,15 @@ namespace ClarionAssistant.Services
                             // capture group, Groups[1] is empty and never in DeclarationStructKeywords.
                             Match toolbarMatch = ToolbarOpen.Match(u);
                             if (toolbarMatch.Success) openMatch = toolbarMatch;
+                        }
+                        if (openMatch == null || !openMatch.Success)
+                        {
+                            // Same reasoning as ToolbarOpen, for MENU/MENUBAR/SHEET/TAB/OPTION: matched
+                            // keyword never takes a label, so the label gate below can't apply — its
+                            // Groups[1] value isn't checked against DeclarationStructKeywords here either
+                            // (none of these five are in that set).
+                            Match nestedMatch = NestedBandOpen.Match(u);
+                            if (nestedMatch.Success) openMatch = nestedMatch;
                         }
 
                         if (openMatch != null && openMatch.Success)

--- a/ClarionAssistant/Terminal/clarion-language.js
+++ b/ClarionAssistant/Terminal/clarion-language.js
@@ -33,7 +33,11 @@ function registerClarionLanguage() {
             // otherwise misread as opening a block and auto-indent the next line. Mirrors the
             // same fix in ModernEmbeditorDiagnostics.cs (C#) and Clarion-Extension's
             // TokenPatterns.ts (PR #378).
-            increaseIndentPattern: /^\s*(?:(?:IF|LOOP|CASE|BEGIN|EXECUTE|ACCEPT|GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|MENUBAR|MENU|SHEET|TAB|OPTION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|OF|OROF|ELSE|ELSIF)\b|TOOLBAR\b(?=\s*(?:[(,!]|$)))(?![^!]*\.\s*$).*$/i,
+            // MENUBAR/MENU/SHEET/TAB/OPTION share TOOLBAR's exact ambiguity (nested inside
+            // WINDOW/REPORT bodies, legitimately bare — e.g. "OPTION,USE(?opt)") and are split
+            // out alongside it for the same reason (e.g. "option     LONG(0)", a plain local
+            // variable named "option", was misread as opening a block).
+            increaseIndentPattern: /^\s*(?:(?:IF|LOOP|CASE|BEGIN|EXECUTE|ACCEPT|GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|OF|OROF|ELSE|ELSIF)\b|(?:TOOLBAR|MENUBAR|MENU|SHEET|TAB|OPTION)\b(?=\s*(?:[(,!]|$)))(?![^!]*\.\s*$).*$/i,
             decreaseIndentPattern: /^\s*(END\b|\.\s*$|OF\b|OROF\b|ELSE\b|ELSIF\b|UNTIL\b|WHILE\b)/i
         }
     });
@@ -43,8 +47,8 @@ function registerClarionLanguage() {
             'PROGRAM', 'MEMBER', 'MAP', 'MODULE', 'CLASS', 'INTERFACE', 'PROCEDURE', 'FUNCTION',
             'ROUTINE', 'CODE', 'DATA', 'END', 'RETURN', 'EXIT', 'IF', 'THEN', 'ELSE', 'ELSIF',
             'CASE', 'OF', 'OROF', 'LOOP', 'WHILE', 'UNTIL', 'BREAK', 'CYCLE', 'DO', 'BEGIN',
-            'EXECUTE', 'GROUP', 'QUEUE', 'RECORD', 'FILE', 'VIEW', 'WINDOW', 'REPORT', 'MENU',
-            'MENUBAR', 'SHEET', 'TAB', 'OPTION', 'APPLICATION', 'DETAIL', 'HEADER',
+            'EXECUTE', 'GROUP', 'QUEUE', 'RECORD', 'FILE', 'VIEW', 'WINDOW', 'REPORT',
+            'APPLICATION', 'DETAIL', 'HEADER',
             'FOOTER', 'BREAK', 'FORM', 'SELF', 'PARENT', 'NEW', 'DISPOSE', 'THREAD', 'NULL',
             'TRUE', 'FALSE', 'AND', 'OR', 'XOR', 'NOT', 'CHOOSE', 'OMIT', 'COMPILE', 'INCLUDE',
             'EQUATE', 'ITEMIZE', 'TYPE', 'LIKE', 'DIM', 'OVER', 'NAME', 'PRE', 'STATIC', 'THREAD'
@@ -61,10 +65,11 @@ function registerClarionLanguage() {
                 [/\b\d+(?:\.\d+)?\b/, 'number'],
                 [/\b[0-9A-Fa-f]+[Hh]\b/, 'number.hex'],
                 [/[A-Za-z_][A-Za-z0-9_]*:/, 'type.identifier'],
-                // TOOLBAR is handled by its own rule (ahead of the generic identifier rule
-                // below) rather than the flat @keywords list — it needs a position-aware
-                // lookahead, not a bare \b match. See indentationRules comment above for why.
-                [/\bTOOLBAR\b(?=\s*(?:[(,!]|$))/i, 'keyword'],
+                // TOOLBAR/MENUBAR/MENU/SHEET/TAB/OPTION are handled by their own rule (ahead of
+                // the generic identifier rule below) rather than the flat @keywords list — they
+                // need a position-aware lookahead, not a bare \b match. See indentationRules
+                // comment above for why.
+                [/\b(?:TOOLBAR|MENUBAR|MENU|SHEET|TAB|OPTION)\b(?=\s*(?:[(,!]|$))/i, 'keyword'],
                 [/[A-Za-z_][A-Za-z0-9_]*/, {
                     cases: {
                         '@keywords': 'keyword',
@@ -84,13 +89,15 @@ function registerClarionLanguage() {
 // Register once per Monaco page (folding providers are global per language id, but each WebView2
 // page hosts its own Monaco instance).
 function registerClarionFolding() {
-    var STRUCT = /\b(GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|MENUBAR|MENU|SHEET|TAB|OPTION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)\b/;
+    var STRUCT = /\b(GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)\b/;
     // TOOLBAR split out with its own tight lookahead ('(', ',', '!' or end-of-line right after
     // the keyword) — STRUCT's bare \b would otherwise push the ABC toolbar template's ubiquitous
     // "Toolbar ToolbarClass" variable declaration onto the fold stack as a never-closed opener,
     // silently swallowing a later real END/'.' and folding unrelated code into it. Same fix as
     // ModernEmbeditorDiagnostics.cs (C#) and Clarion-Extension's TokenPatterns.ts (PR #378).
-    var TOOLBAR_OPEN = /^\s*TOOLBAR\b(?=\s*(?:[(,!]|$))/i;
+    // MENUBAR/MENU/SHEET/TAB/OPTION share the identical ambiguity (nested inside WINDOW/REPORT
+    // bodies, legitimately bare) and are split out alongside TOOLBAR for the same reason.
+    var TOOLBAR_OPEN = /^\s*(?:TOOLBAR|MENUBAR|MENU|SHEET|TAB|OPTION)\b(?=\s*(?:[(,!]|$))/i;
     monaco.languages.registerFoldingRangeProvider('clarion', {
         provideFoldingRanges: function (model) {
             var ranges = [];


### PR DESCRIPTION
## Summary

Same keyword-as-label bug class as #132 (REPORT/WINDOW/GROUP/etc.) and #136 (TOOLBAR) — a Clarion structure keyword used as a plain variable name breaks the per-slot structure-balance heuristic — but for **MENU, MENUBAR, SHEET, TAB, and OPTION**, which were explicitly identified as sharing TOOLBAR's exact risk when #136 was written, and deliberately deferred at the time ("TOOLBAR only, not now") since no equally ubiquitous ABC-template trigger was known for them.

Now confirmed hit in real code: a plain local variable declared as

```clarion
option     LONG(0)
```

was misread as opening a bare `OPTION` structure, producing a false `OPTION is not terminated with END or '.' in this embed slot.` error — plus a cascading false positive on the next real, correctly-terminated structure in the same slot, the same failure mode #132/#136 already documented for this bug class.

`StructOpen`'s shared lookahead (`(?=\s|,|\(|$)`) accepts any whitespace right after a matched keyword — safe for keywords that are never legitimately bare (#132's column-0 label gate), but MENU/MENUBAR/SHEET/TAB/OPTION, like TOOLBAR, are legitimately written bare when opening a real nested structure (`OPTION,USE(?opt1)`, `TAB,USE(?tab1)`), so that gate can't be reused for them either.

## Changes

Same shape as #136, for all five keywords:

- **`Services/ModernEmbeditorDiagnostics.cs`**: split MENU/MENUBAR/SHEET/TAB/OPTION out of the shared `StructOpen` regex into a new `NestedBandOpen` regex with the same tight lookahead `ToolbarOpen` uses (`(`, `,`, `!`, or end-of-line immediately after the keyword); wired into the per-line opener check alongside `StructOpen`/`BandOpen`/`ToolbarOpen`.
- **`Terminal/clarion-language.js`** (shared Monaco grammar): the same three sub-bugs #136 found for TOOLBAR in this file also applied to these five keywords —
  - Syntax coloring (`keywords` array) — removed all five; added to the existing position-aware `TOOLBAR` coloring rule.
  - Auto-indent (`indentationRules.increaseIndentPattern`) — moved all five into the existing tight-lookahead alternative alongside `TOOLBAR`.
  - Code folding (`registerClarionFolding`'s `STRUCT`/`TOOLBAR_OPEN` regexes) — removed all five from `STRUCT`, added to `TOOLBAR_OPEN`'s alternation.

## Tested

- [x] Standalone regex harness (isolated copy of the exact `StructOpen`/`ToolbarOpen`/`NestedBandOpen`/`DeclarationStructKeywords` logic, no IDE round-trip needed) — 18/18 passed:
  - The reported false positive (`option     LONG(0)`) and the equivalent for MENU/MENUBAR/SHEET/TAB — none open a structure
  - Real bare nested usage for all five (`OPTION,USE(...)`, `TAB,USE(...)`, `MENU,USE(...)`, `MENUBAR,USE(...)`, `SHEET,USE(...)`, `OPTION('name')`) — all still correctly open
  - No regression on untouched siblings: bare `MAP`/`MODULE('')` still open, a labeled `GROUP` still opens, `Report &STRING`/`Toolbar ToolbarClass` (the #132/#136 false positives) stay fixed, real bare `TOOLBAR,USE(...)` still opens
- Live-verified in the running IDE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
