### PR TITLE
fix(completion): CodeCompletion shows duplicate entries 

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -547,8 +547,18 @@ namespace ClarionAssistant.Services
             {
                 if (memberScope != null && memberScope.Count > 0)
                 {
+                    // memberScope holds bare identifiers (see MergeMemberAccessCompletions/MergeDbMembers),
+                    // so match against each item's bare InsertText rather than its typed Label — the same
+                    // Label-vs-bare-identifier mismatch as the completion-merge dedupe fix above. Currently
+                    // a dormant edge case (post-fix, primary's items already carry typed Labels here so this
+                    // predicate matches nothing and the guard below leaves primary untouched) but kept
+                    // consistent so a future bare-labeled addition here can't silently drop typed members.
                     var scoped = primary.FindAll(it =>
-                        it != null && !string.IsNullOrEmpty(it.Label) && memberScope.Contains(it.Label));
+                    {
+                        if (it == null) return false;
+                        string key = !string.IsNullOrEmpty(it.InsertText) ? it.InsertText : it.Label;
+                        return !string.IsNullOrEmpty(key) && memberScope.Contains(key);
+                    });
                     if (scoped.Count > 0) primary = scoped;
                 }
             }

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -2299,9 +2299,18 @@ namespace ClarionAssistant.Services
             string className = ResolveInstanceType(lines, line, instance, filePath, out isInlineClass);
             if (string.IsNullOrEmpty(className)) return null;
 
+            // Dedupe key is each item's bare identifier (InsertText), not its display Label — the LSP labels
+            // a member with its type/signature attached (e.g. "MyField STRING", "MyMethod( LONG pField, ...)"),
+            // while MergeDbMembers below adds bare-name items ("MyField"). Keying on Label let a real LSP
+            // member slip past this dedup check and get re-added under its bare name — a visible duplicate
+            // row for any member the LSP already resolved correctly (e.g. a project-local class field).
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var it in primary)
-                if (it != null && !string.IsNullOrEmpty(it.Label)) seen.Add(it.Label);
+            {
+                if (it == null) continue;
+                string key = !string.IsNullOrEmpty(it.InsertText) ? it.InsertText : it.Label;
+                if (!string.IsNullOrEmpty(key)) seen.Add(key);
+            }
 
             // Add members from the project CodeGraph (most specific) then the ClarionGraph library DB; dedupe
             // across both. Collect them (unfiltered by partial) into two sets for the scoping decision below.


### PR DESCRIPTION
## Summary

Dot-triggered member completion could show a real class member **twice**: once correctly
(name + type, e.g. `MyField STRING`) from the LSP, and once as a bare, type-less duplicate
(`MyField`) from ClarionAssistant's own supplemental completion source.

Example: "Sign" and "SignLen" are duplicated 

&emsp;&emsp;<img width="433" height="132" alt="image" src="https://github.com/user-attachments/assets/3f73251d-b9fc-4b6f-a3d1-c4cbd48a27f3" />


## Root cause

`SharedLspBridge.MergeMemberAccessCompletions` supplements the bundled LSP's dot-triggered
member completion with members pulled from ClarionAssistant's own CodeGraph DB — originally
added to cover library/ABC classes the LSP couldn't fully resolve server-side. It's designed to
be purely additive: build a `seen` set from whatever the LSP already returned, then only add a
CodeGraph member if its name isn't already `seen`.

The `seen` set was built from each existing item's full `Label` — but the LSP labels a member
with its type/signature attached (`"MyField STRING"`, `"MyMethod( LONG pField, ...)"`), while the
CodeGraph-sourced additions (`MergeDbMembers`) use the bare identifier as both label and de-dup
key (`"MyField"`). `"myfield string"` and `"myfield"` never match as strings, so a member the LSP
had *already* resolved correctly slipped straight past the "is this already present" check and
got added a second time under its bare name.

This surfaces for any class resolved via single-level member access (`oInstance.`, not a
multi-level chain like `oInstance.Sub.`) whose name turns up in *either* the project CodeGraph DB
or the `ClarionGraphService` library-scoped DB — `MergeDbMembers` adds a bare-name item from
whichever DB(s) have it, independent of the other. It does not require a hit in both.

## Fix

Build the `seen` set from each item's `InsertText` — the bare identifier both the LSP and the
CodeGraph merge actually agree on — falling back to `Label` only when `InsertText` is empty.
No change to the merge/scoping logic itself, only the key used to detect "this member is already
present".

```csharp
var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
foreach (var it in primary)
{
    if (it == null) continue;
    string key = !string.IsNullOrEmpty(it.InsertText) ? it.InsertText : it.Label;
    if (!string.IsNullOrEmpty(key)) seen.Add(key);
}
```

## Testing

- Reproduced against a real project-local class with a plain data member (e.g. `MyField STRING`)
  where the LSP already resolves member access correctly: before the fix, the completion popup
  showed the member twice — once typed, once bare. After the fix, once, correctly typed.
- Confirmed the LSP's own response was never at fault — replayed the exact completion request
  directly against the bundled server and it returned the member exactly once; the duplicate was
  only ever introduced by this merge step.
- Verified overloaded methods (multiple signatures for the same name) are unaffected — they were
  never duplicated by this bug in the first place (their LSP labels include full signatures, and
  they hadn't hit the affected code path the same way in this repro), and remain untouched after
  the fix.
- Clean `Debug-C11` build, no other files touched.

## Follow-up commit: same fix for the member-access scoping guard

`GetCompletion`'s scoping step (right after `MergeMemberAccessCompletions` returns a non-null
`memberScope`) has the identical Label-vs-bare-identifier mismatch, in a different spot:

```csharp
var scoped = primary.FindAll(it =>
    it != null && !string.IsNullOrEmpty(it.Label) && memberScope.Contains(it.Label));
if (scoped.Count > 0) primary = scoped;
```

`memberScope` holds bare identifiers; a real LSP item's typed `Label` never equals one. Before
the first commit, this was a live risk specifically for **library-backed classes** (any class
with a hit in `ClarionGraphService`'s DB, e.g. genuine ABC/library types like `FileManager`):
`primary` could contain the bare-labeled duplicates the first commit fixes, those *do* match
`memberScope`, so `scoped.Count > 0` and the guard would replace `primary` with **only the bare
items** — silently dropping every correctly-typed LSP completion for that class, not just
duplicating.

After the first commit, this is a dormant edge case rather than a live one: `primary` no longer
picks up bare-labeled duplicates in the first place, so this predicate now matches nothing,
`scoped.Count == 0`, and the guard leaves `primary` untouched. Fixed anyway, defensively, for
consistency — so a future bare-labeled addition anywhere in this pipeline can't silently
resurrect the drop.

Verified manually: a `primary` list of typed labels (e.g. `{"Opener &IFileOpenServer", "Open()"}`)
against a bare `memberScope` (e.g. `{"Opener", "Open", ...}`) — 0 matches under the old `Label`
comparison would have replaced `primary` with the (wrong) bare set; under the new `InsertText`
comparison the real typed items match correctly and nothing is incorrectly dropped.

No existing unit tests cover `MergeMemberAccessCompletions` or this scoping block.