### PR TITLE
fix(completion,hover): scope exact-match identifiers and local variables correctly around procedure boundaries

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -1447,6 +1447,24 @@ namespace ClarionAssistant.Services
                 // Bare word (class name, equate) — exact-name lookup.
                 string word = CgWordAt(filePath, line, character, bufferText);
                 if (string.IsNullOrEmpty(word)) return null;
+
+                // Buffer-local resolution FIRST: a local/routine/module var or a module-local procedure
+                // declared right here in the file must win over a same-named symbol anywhere else in the
+                // indexed solution or library. CgHoverFromDb below is a global, UNSCOPED exact-name lookup —
+                // without this, an in-scope local (e.g. "PRO") or a brand-new, not-yet-indexed procedure
+                // (e.g. "Test") can resolve to an unrelated class member elsewhere that merely shares the name.
+                string[] lines = CgGetLines(bufferText, filePath);
+                var localHover = BufferLocalHover(lines, line, word, filePath);
+                if (localHover != null) return localHover;
+
+                // BufferLocalHover just searched this file's ENTIRE local/routine/module/local-procedure
+                // scope at this exact cursor and found nothing — so a "variable"-kind exact-name match from
+                // the global DB can only be a procedure- or routine-local declared somewhere else entirely
+                // (a different procedure, possibly a different file). Clarion has no mechanism for such a
+                // variable to be in scope here, regardless of whether the word sits in a declaration's type
+                // slot ("Test PRO" typed before "PROCEDURE" finishes) or is just referenced in CODE (a typo
+                // or a not-yet-declared local, e.g. "PRO = 12" inside a procedure that never declared it) —
+                // so CgHoverFromDb always rejects a procedure/routine-scoped "variable" match here.
                 var hov = CgHoverFromDb(word, ResolveCodeGraphDb(filePath), "CodeGraph")
                     ?? CgHoverFromDb(word, ClarionGraphService.ResolveDbPath(), "ClarionGraph");
                 if (hov != null) return hov;
@@ -1456,6 +1474,83 @@ namespace ClarionAssistant.Services
                 return AbcGlobalHover(word);
             }
             catch { return null; }
+        }
+
+        /// <summary>Exact-name hover for a word declared right here in the buffer — a local/routine/module
+        /// variable (via the same scope ranges completion uses, so it honors the column-1-declaration-in-
+        /// progress guard) or a module-local procedure (MAP prototype or in-buffer implementation). Tried
+        /// BEFORE the global CodeGraph/ClarionGraph exact-name lookup so an in-scope local always outranks a
+        /// same-named symbol declared elsewhere in the solution or library. Null when nothing in the buffer
+        /// matches — the global lookup then proceeds as before. Never throws.</summary>
+        private static Dictionary<string, object> BufferLocalHover(string[] lines, int line, string word, string filePath)
+        {
+            try
+            {
+                if (lines == null || string.IsNullOrEmpty(word)) return null;
+                string fileName = string.IsNullOrEmpty(filePath) ? null : Path.GetFileName(filePath);
+
+                foreach (var rg in GetScopeDataRanges(lines, line))
+                {
+                    string restOfLine = FindDataLabelInRange(lines, rg[0], rg[1], word);
+                    if (restOfLine == null) continue;
+                    string detail, doc;
+                    BuildVarDetail(restOfLine, null, out detail, out doc);
+                    var bits = new List<string> { "local" };
+                    if (fileName != null) bits.Add(fileName);
+                    string sig = string.IsNullOrEmpty(detail) ? word : word + "  " + detail;
+                    return WrapResult(new Dictionary<string, object> {
+                        { "contents", "```clarion\n" + sig + "\n```\n\n" + string.Join(" · ", bits) } });
+                }
+
+                foreach (var kv in GetModuleMapProcedures(lines))
+                {
+                    if (!string.Equals(kv.Key, word, StringComparison.OrdinalIgnoreCase)) continue;
+                    var bits = new List<string> { "local procedure" };
+                    if (fileName != null) bits.Add(fileName);
+                    string sig = string.IsNullOrEmpty(kv.Value) ? word : kv.Value;
+                    return WrapResult(new Dictionary<string, object> {
+                        { "contents", "```clarion\n" + sig + "\n```\n\n" + string.Join(" · ", bits) } });
+                }
+
+                foreach (var ln in lines)
+                {
+                    var hm = CgProcHeaderLabel.Match(ln);
+                    if (!hm.Success) continue;
+                    if (hm.Groups[1].Value.IndexOf('.') >= 0 || hm.Groups[1].Value.IndexOf(':') >= 0) continue;
+                    if (!string.Equals(hm.Groups[1].Value, word, StringComparison.OrdinalIgnoreCase)) continue;
+                    var bits = new List<string> { "local procedure" };
+                    if (fileName != null) bits.Add(fileName);
+                    string sig = CgTrailingComment.Replace(ln.Trim(), "").Trim();
+                    return WrapResult(new Dictionary<string, object> {
+                        { "contents", "```clarion\n" + sig + "\n```\n\n" + string.Join(" · ", bits) } });
+                }
+
+                return null;
+            }
+            catch { return null; }
+        }
+
+        /// <summary>First depth-0 data declaration in [start, end) whose label exactly matches <paramref
+        /// name="word"/> (case-insensitive) — its rest-of-line (type + optional trailing '!' comment), or
+        /// null. Mirrors CollectDataLabels'/MergeModuleVarCompletions' depth tracking so a struct's own
+        /// field names don't false-positive as bare locals.</summary>
+        private static string FindDataLabelInRange(string[] lines, int start, int end, string word)
+        {
+            int depth = 0;
+            for (int i = start; i < end && i < lines.Length; i++)
+            {
+                string ln = lines[i];
+                bool isEnd = CgEndLine.IsMatch(ln) || CgPeriodEnd.IsMatch(ln);
+                if (depth == 0 && !isEnd)
+                {
+                    var lm = CgDataLabelPattern.Match(ln);
+                    if (lm.Success && string.Equals(lm.Groups[1].Value, word, StringComparison.OrdinalIgnoreCase))
+                        return lm.Groups[2].Value;
+                }
+                if (CgGroupQueueOpen.IsMatch(ln)) depth++;
+                else if (isEnd && depth > 0) depth--;
+            }
+            return null;
         }
 
         /// <summary>Hover for a well-known ABC standard global/equate (GlobalRequest, GlobalResponse,
@@ -1474,8 +1569,11 @@ namespace ClarionAssistant.Services
         }
 
         /// <summary>Exact-name hover from one CodeGraph-schema DB → an LSP hover dict ({contents}), or null
-        /// when the DB is missing/unopenable or the symbol isn't found. <paramref name="sourceLabel"/> names
-        /// the DB (e.g. "ClarionGraph") for the detail line when the symbol has no project name. Never throws.</summary>
+        /// when the DB is missing/unopenable, the symbol isn't found, or the only match is a "variable"
+        /// scoped to a PROCEDURE/ROUTINE elsewhere (see IsUnreachableLocalVariable — never a legitimate hit,
+        /// since the caller already exhausted this file's own local/routine/module scope via
+        /// BufferLocalHover before falling back here). <paramref name="sourceLabel"/> names the DB (e.g.
+        /// "ClarionGraph") for the detail line when the symbol has no project name. Never throws.</summary>
         private static Dictionary<string, object> CgHoverFromDb(string word, string db, string sourceLabel)
         {
             try
@@ -1486,12 +1584,31 @@ namespace ClarionAssistant.Services
                     if (!p.Open(db)) return null;
                     var sym = p.FindSymbolByName(word);
                     if (sym == null) return null;
+                    if (IsUnreachableLocalVariable(p, sym)) return null;
                     string contents = CgHoverText(sym, sourceLabel);
                     if (string.IsNullOrEmpty(contents)) return null;
                     return WrapResult(new Dictionary<string, object> { { "contents", contents } });
                 }
             }
             catch { return null; }
+        }
+
+        /// <summary>True when <paramref name="sym"/> is a "variable" whose ParentName resolves to a
+        /// PROCEDURE or ROUTINE symbol — i.e. a local declared inside some OTHER procedure/routine.
+        /// Clarion has no mechanism for such a variable to be referenced from outside its own owning
+        /// procedure, so a match like this from the global exact-name lookup is never legitimate (the
+        /// caller only reaches this after BufferLocalHover already searched the current file's own
+        /// local/routine/module scope and found nothing). A plain module/program-scope variable (no
+        /// parent, or a parent that isn't itself a procedure/routine) is NOT filtered — those can
+        /// legitimately be out of BufferLocalHover's reach (a different file's module-level global).</summary>
+        private static bool IsUnreachableLocalVariable(CodeGraphProvider p, CodeGraphSymbol sym)
+        {
+            if (!string.Equals(sym.Type, "variable", StringComparison.OrdinalIgnoreCase)) return false;
+            if (string.IsNullOrEmpty(sym.ParentName)) return false;
+            var parent = p.FindSymbolByName(sym.ParentName);
+            return parent != null &&
+                (string.Equals(parent.Type, "procedure", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(parent.Type, "routine", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>Markdown hover text for a CodeGraph symbol: a fenced signature line (name + params +
@@ -1841,6 +1958,20 @@ namespace ClarionAssistant.Services
             if (lines == null || line < 0 || line >= lines.Length) return;
             int from = Math.Min(line, lines.Length - 1);
 
+            // The cursor's own line is a column-1 declaration in progress (e.g. "Test PRO", about to become
+            // "Test PROCEDURE") that ISN'T a complete PROCEDURE/ROUTINE header yet. Column 1 always starts a
+            // new top-level construct in Clarion, implicitly ending whatever procedure precedes it in the
+            // text — UNLESS that procedure's DATA section is still open (no CODE line yet), in which case
+            // this is just a sibling declaration within it. Without this check the plain backward scan below
+            // ignores CODE lines entirely and walks straight past the PREVIOUS procedure's CODE into its
+            // header, surfacing ITS locals while a brand-new procedure header is still being typed.
+            if (CgDataLabelPattern.IsMatch(lines[from]) && !CgProcHeaderPattern.IsMatch(lines[from]) && !CgRoutineHeaderPattern.IsMatch(lines[from]))
+            {
+                int openHeader = FindOpenDataSectionHeader(lines, from);
+                if (openHeader < 0) return;   // past any procedure's CODE line → brand-new construct, no locals
+                from = openHeader;
+            }
+
             // (a) Enclosing ROUTINE (most specific). Scanning up, an enclosing routine is one whose header
             // we reach BEFORE any PROCEDURE header — otherwise the cursor is in the procedure's main body.
             // Added first so a routine-private var shadows a same-named procedure local (via `seen`).
@@ -1853,6 +1984,21 @@ namespace ClarionAssistant.Services
             // (b) Enclosing PROCEDURE main locals — in scope everywhere in the proc, incl. its routines.
             for (int i = from; i >= 0; i--)
                 if (CgProcHeaderPattern.IsMatch(lines[i])) { CollectDataLabels(lines, i, prefix, seen, primary, "(local)"); break; }
+        }
+
+        /// <summary>Scans upward from just above <paramref name="from"/> for the nearest PROCEDURE/ROUTINE
+        /// header whose DATA section is still open. Returns its line index, or -1 if a CODE line (or the top
+        /// of the file) is reached first — meaning <paramref name="from"/> sits past that construct's DATA
+        /// section entirely (e.g. a brand-new top-level declaration starting there). Used to disambiguate a
+        /// column-1 declaration-in-progress from a genuine sibling DATA declaration.</summary>
+        private static int FindOpenDataSectionHeader(string[] lines, int from)
+        {
+            for (int i = from - 1; i >= 0; i--)
+            {
+                if (CgProcHeaderPattern.IsMatch(lines[i]) || CgRoutineHeaderPattern.IsMatch(lines[i])) return i;
+                if (CgCodeLinePattern.IsMatch(lines[i])) return -1;
+            }
+            return -1;
         }
 
         /// <summary>Phase 2 refinement (task a47a6cac item #5): merge module-scope (file-scope) scalar and
@@ -1973,6 +2119,15 @@ namespace ClarionAssistant.Services
         {
             var ranges = new List<int[]>();
             int from = Math.Min(line, lines.Length - 1);
+
+            // Same column-1-declaration-in-progress guard as MergeLocalVarCompletions — see its comment.
+            if (CgDataLabelPattern.IsMatch(lines[from]) && !CgProcHeaderPattern.IsMatch(lines[from]) && !CgRoutineHeaderPattern.IsMatch(lines[from]))
+            {
+                int openHeader = FindOpenDataSectionHeader(lines, from);
+                if (openHeader < 0) { ranges.AddRange(GetModuleDataRanges(lines)); return ranges; }
+                from = openHeader;
+            }
+
             for (int i = from; i >= 0; i--)   // enclosing routine (only if reached before any procedure header)
             {
                 if (CgRoutineHeaderPattern.IsMatch(lines[i])) { ranges.Add(new[] { i + 1, FindCodeAfter(lines, i) }); break; }

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -3375,6 +3375,14 @@
                                     // no-op so 'smart' Enter inserts a newline instead of re-casing in place.
                                     if (String(hi.insertText || hi.label).toUpperCase() === lu) hi.insertText = typedW;
                                 }
+                            } else if (typedW && lu === TWU) {
+                                // Exact-match identifier (e.g. local "PRO") must outrank a keyword that merely
+                                // PREFIXES it ("PROCEDURE"/"PROGRAM" both start with "PRO") — otherwise the
+                                // keyword's '0kw_' sortText wins, PROCEDURE stays highlighted, and a commit
+                                // char like '.' inserts "PROCEDURE." instead of completing "PRO.".
+                                hi.preselect = true;
+                                hi.sortText = '00_' + lu;              // ranks before '0kw_' and other '1_' items
+                                hi.filterText = typedW;
                             }
                         }
                         var kws = clarionKeywordSuggestions(before, range, seen);


### PR DESCRIPTION
## Summary

Four related bugs, all the same underlying pattern: a same-named keyword, local, or unrelated symbol elsewhere in the solution winning over the correct in-scope answer, because scoping wasn't precise enough around procedure boundaries — especially while a procedure declaration is still incomplete.

Reported starting from: typing `PRO` (an exact-match local, `PRO SomeClass`) into the completion popup showed `{"PROCEDURE", "PROGRAM", "PRO", ...}` with `PROCEDURE` auto-selected. Typing `.` to continue with `PRO.SomeProperty` committed `PROCEDURE.` instead.

## Example

Given an existing procedure earlier in the same file:

```clarion
OtherProcedure PROCEDURE( LONG pParam )
PRO            SomeClass
  CODE
  PRO.Init()
  RETURN
```

...and a brand-new procedure being typed at the end of the file:

```clarion
Test PRO             ! still typing "Test PROCEDURE" — header not complete yet
```

- **Fix 1** — when writing OtherProcedure, completion for `PRO` here listed `PROCEDURE`/`PROGRAM` highlighted above the exact match `PRO`; typing `.` inserted `PROCEDURE.`.
- **Fix 2** — even after finishing the header (`Test PROCEDURE()`), completion for any local typed inside `Test`'s own body incorrectly still offered `OtherProcedure`'s `PRO` as if it were in scope.

Now suppose `Test` is finished and its body actually looks like this (`PRO` never declared in `Test`, e.g. a typo for `Result`):

```clarion
Test PROCEDURE()
Result         LONG(0)
  CODE
     PRO = 12          ! PRO isn't declared anywhere in Test
  RETURN(Result)
```

- **Fix 3 / 4** — hovering `PRO` on that line showed `PRO  SOMECLASS   variable · member of OtherProcedure · MyProject` — a real symbol, just from the *other*, unrelated procedure above. After the fix, hovering `PRO` here shows nothing, since it genuinely isn't declared in `Test`'s scope.

## Fixes

**1. Completion popup — exact match losing to a prefix-matching keyword** (`monaco-embeditor.html`)
Clarion keywords that prefix the typed text (`PROCEDURE`, `PROGRAM` both start with `PRO`) always got a higher-ranked `sortText` tier than an ordinary identifier, even when the identifier is an *exact* match and the keyword is only a prefix match. `suggestSelection: 'first'` then highlighted the keyword. Added a branch so an exact-match, non-keyword identifier is promoted to `preselect: true` with a `sortText` tier ahead of keywords.

**2. Completion scope leak — new procedure header still in progress** (`SharedLspBridge.cs`, `MergeLocalVarCompletions` / `GetScopeDataRanges`)
Starting a brand-new procedure (`Test PRO`, not yet `Test PROCEDURE`) doesn't match the header regex yet, so the backward scope-scan just kept walking upward, straight past the *previous* procedure's `CODE` line, and locked onto that procedure's header as "enclosing" — surfacing its locals in the new procedure's completion list. Added `FindOpenDataSectionHeader`: when the cursor's own line is a column-1 declaration-in-progress (not yet a complete `PROCEDURE`/`ROUTINE` header), the enclosing header must now be found *before* any `CODE` line, or there's no enclosing scope at all.

**3. Hover — no buffer-local resolution before the global DB lookup** (`SharedLspBridge.cs`, `BufferLocalHover` + `FindDataLabelInRange`)
`CodeGraphHover`'s fallback (used whenever the primary LSP hover comes back empty) went straight to a global, unscoped exact-name lookup across the whole indexed solution/library. A real local/routine/module variable, or a module-local procedure, declared right in the buffer had no chance to win first. Added `BufferLocalHover`, reusing the same scope-range logic as fix #2, tried before the global lookup.

**4. Hover — unrelated same-named variable from elsewhere** (`SharedLspBridge.cs`, `CgHoverFromDb` + `IsUnreachableLocalVariable`)
Even with #3, a genuinely undeclared identifier (typo, or a variable referenced before it's declared) still fell through to the global lookup and could resolve to some *other* procedure's same-named local anywhere in the solution — e.g. hovering `PRO` inside a new `Test` procedure that never declared it showed `PRO` from an unrelated `OtherProcedure` procedure. Since a Clarion procedure/routine-local variable is never reachable outside its own owning procedure, `CgHoverFromDb` now rejects a `"variable"`-kind match whenever its parent symbol is itself a `procedure` or `routine` — regardless of whether the word sits in a declaration's type slot or is just referenced in code. A plain module/program-scope variable (no procedure/routine parent) is left alone, since that's legitimately outside `BufferLocalHover`'s single-file reach.

## Verification

All four confirmed live in the IDE against a real multi-thousand-line production `.clw` file: exact-match completion ranking, no leaked locals when starting a new procedure mid-declaration, hover resolving the buffer's own local correctly, and hover returning nothing (rather than a misleading unrelated match) for an undeclared/in-progress identifier. Iterated through several rounds against live repro cases before landing on the final, more general rule in fix #4.
