### PR TITLE
Fix/diagnostics warnings related to GROUP and RECORD not starting a structure

### DIFF
--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -44,7 +44,7 @@ namespace ClarionAssistant.Services
         // The lookahead (not [,(]|$ like BandOpen) deliberately allows code structures that take an
         // expression: LOOP I = 1 TO 10, CASE SomeVar, EXECUTE n.
         private static readonly Regex StructOpen = new Regex(
-            @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)(?=\s|,|\(|$)",
+            @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(QUEUE|FILE|VIEW|REPORT|WINDOW|APPLICATION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)(?=\s|,|\(|$)",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
         // TOOLBAR is nested inside WINDOW/APPLICATION bodies and legitimately written bare
         // ("TOOLBAR,USE(?Toolbar1)"), so StructOpen's generic lookahead (which accepts any
@@ -64,6 +64,25 @@ namespace ClarionAssistant.Services
         // same tight lookahead ('(', ',', '!' or end-of-line right after the keyword).
         private static readonly Regex NestedBandOpen = new Regex(
             @"^\s*(MENUBAR|MENU|SHEET|TAB|OPTION)\b(?=\s*(?:[(,!]|$))",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // GROUP shares TOOLBAR/OPTION's ambiguity — legitimately bare as a nested WINDOW/
+        // APPLICATION/REPORT screen control ("GROUP('Title'),AT(...),USE(?G1),BOXED") and as a
+        // fully anonymous DATA group ("GROUP,PRE(x)") — but UNLIKE Toolbar/Option it is ALSO
+        // legitimately LABELED ("MyGroup GROUP,PRE(x)"). A plain identifier named "Group"
+        // declared bare ("Group &STRING", confirmed live next to the analogous "Window &STRING")
+        // must not match. Keep StructOpen's optional-label prefix, but require '(', ',', '!' or
+        // end-of-line after optional whitespace — real code puts a space before the paren too
+        // (e.g. "SysInfo GROUP (SysDescrGroupType), NAME(...)"), so the lookahead allows that gap.
+        private static readonly Regex GroupOpen = new Regex(
+            @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(GROUP)(?=\s*(?:[(,!]|$))",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        // RECORD shares GROUP's exact ambiguity — legitimately bare inside a FILE
+        // ("RECORD, PRE()", an anonymous record) and legitimately labeled ("Rec RECORD"). A plain
+        // identifier named "Record" declared bare ("Record &STRING") must not match. Confirmed
+        // live: an anonymous RECORD inside a FILE, unfixed, desyncs the balance stack the same
+        // way a bare screen GROUP did (same root cause, different keyword).
+        private static readonly Regex RecordOpen = new Regex(
+            @"^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(RECORD)(?=\s*(?:[(,!]|$))",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex StructWordRx = new Regex(
             @"\b(IF|GROUP|QUEUE|RECORD|FILE|VIEW|REPORT|WINDOW|APPLICATION|MENUBAR|MENU|TOOLBAR|SHEET|TAB|OPTION|CLASS|INTERFACE|MAP|MODULE|ITEMIZE|JOIN|LOOP|CASE|BEGIN|EXECUTE|ACCEPT)\b",
@@ -92,11 +111,15 @@ namespace ClarionAssistant.Services
         //                     — same as above, but ALSO given their own tight-lookahead regex
         //                       (ToolbarOpen / NestedBandOpen) so a bare label of the same name
         //                       is never even offered to this set in the first place.
+        //   GROUP, RECORD     — legitimately bare AND legitimately labeled (unlike Toolbar/Option,
+        //                       which are never labeled): each gets its own tight-lookahead regex
+        //                       (GroupOpen / RecordOpen) instead of this label gate, so both are
+        //                       matched correctly either way without ever landing here.
         // Execution structures (LOOP/CASE/BEGIN/EXECUTE/ACCEPT) legitimately have no preceding label
         // either and were never in this set.
         private static readonly HashSet<string> DeclarationStructKeywords = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "GROUP", "QUEUE", "RECORD", "FILE", "VIEW", "REPORT", "WINDOW", "APPLICATION",
+            "QUEUE", "FILE", "VIEW", "REPORT", "WINDOW", "APPLICATION",
             "CLASS", "INTERFACE"
         };
         private static readonly Regex EndRx = new Regex(@"^END\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -217,6 +240,20 @@ namespace ClarionAssistant.Services
                         Match structMatch = StructOpen.Match(u);
                         Match bandMatch = structMatch.Success ? null : BandOpen.Match(u);
                         Match openMatch = structMatch.Success ? structMatch : bandMatch;
+                        if (openMatch == null || !openMatch.Success)
+                        {
+                            // GROUP was pulled out of StructOpen's alternation (see GroupOpen's
+                            // comment) — this is its own match slot, same shape as ToolbarOpen below.
+                            Match groupMatch = GroupOpen.Match(u);
+                            if (groupMatch.Success) openMatch = groupMatch;
+                        }
+                        if (openMatch == null || !openMatch.Success)
+                        {
+                            // RECORD was pulled out of StructOpen's alternation too (see RecordOpen's
+                            // comment) — same shape as GroupOpen above.
+                            Match recordMatch = RecordOpen.Match(u);
+                            if (recordMatch.Success) openMatch = recordMatch;
+                        }
                         if (openMatch == null || !openMatch.Success)
                         {
                             // TOOLBAR has its own tight pattern (see ToolbarOpen) and never takes a

--- a/ClarionAssistant/indexer/test-fixtures/group-record-diagnostics-repro/GroupRecordRepro.clw
+++ b/ClarionAssistant/indexer/test-fixtures/group-record-diagnostics-repro/GroupRecordRepro.clw
@@ -1,0 +1,137 @@
+!--------------------------------------------------------------------------------------------------
+! Repro/test source for the GROUP (and RECORD) keyword-as-label ambiguity in
+! ModernEmbeditorDiagnostics.cs's per-slot structure-balance checker.
+!
+! Every structure below is CORRECTLY terminated and this file compiles. With the bug present
+! (GROUP still listed in DeclarationStructKeywords, no dedicated GroupOpen regex), cases B/B2/C/D
+! are wrongly treated as "used as a label" and their openers are never pushed -- this desyncs the
+! balance stack and makes a later, genuinely-terminated END misreport as:
+!     "END has no matching structure in this embed slot."
+! Case F (the ORIGINAL bug this whole thing started from) must NOT push an opener -- "Group" here
+! is a plain reference variable, not a structure. With the naive blunt fix (just deleting "GROUP"
+! from DeclarationStructKeywords, no dedicated regex), case F regresses and gets falsely flagged
+! as an unterminated GROUP.
+!
+! Expected result once the GroupOpen-regex fix is correctly applied: ZERO diagnostics anywhere in
+! this file.
+! - Before the fix (current committed state): the WINDOW's screen GROUP controls (cases A/A2)
+!   desync the stack and produce a phantom "END has no matching structure" warning further down.
+! - With only the blunt fix (GROUP deleted from DeclarationStructKeywords, no GroupOpen regex):
+!   case F starts falsely flagging instead.
+! - With the full GroupOpen-regex fix: zero diagnostics.
+!--------------------------------------------------------------------------------------------------
+
+ PROGRAM
+
+ MAP 
+Group PROCEDURE()    
+ END   
+
+
+
+! --- Case E: anonymous RECORD inside a FILE, no label at all ---
+! FILE is always labeled (safe, unaffected). The RECORD immediately inside it can legitimately be
+! bare -- same class of ambiguity as GROUP, flagged as a follow-up (not yet fixed).
+ReproFile          FILE,DRIVER('TOPSPEED'),PRE(RPF),CREATE,BINDABLE
+                       RECORD, PRE()
+Field1                    STRING(20)
+Field2                    LONG
+                       END
+                   END
+ 
+! --- Case E2: labeled RECORD, for contrast (already worked before, must keep working) ---
+ReproFile2         FILE,DRIVER('TOPSPEED'),PRE(RP2),CREATE,BINDABLE
+ReproRecord            RECORD
+Field1                    STRING(20)
+                       END
+                   END
+
+! --- Case H: CLASS method named Group() -- exercises LabelDiagnostics.ts's EXISTING exception
+!     (a structure-only keyword used as a method label INSIDE an enclosing CLASS/INTERFACE is
+!     already allowed by findEnclosingStructure()). Unlike case G (a global, non-nested
+!     Group PROCEDURE()), this is assumed but NOT YET independently confirmed to compile/run.
+GroupTestClass     CLASS
+Group                  PROCEDURE()
+                   END
+
+GTC                GroupTestClass
+
+! --- main ---
+  CODE
+    !ReproGroupRecordTest()
+    Group()
+    GTC.Group()
+  RETURN
+
+GroupTestClass.Group PROCEDURE()
+  CODE
+  RETURN
+
+
+Group PROCEDURE()
+
+
+! --- Case B: labeled DATA group, keyword immediately followed by ',' (no space before punctuation) ---
+MyGroup            GROUP,PRE(GRP)
+GroupField            LONG
+                   END
+
+! --- Case B2: labeled DATA group, SPACE before the paren -- a real syntax variant that breaks a
+!     too-tight candidate regex if it doesn't allow whitespace before the punctuation ---
+InfoGroupType      GROUP, TYPE
+Field                 LONG
+                   END 
+
+
+InfoGroup          GROUP (InfoGroupType), NAME('InfoGroup')
+                   END
+
+! --- Case C: bare, attribute-less, labeled group ---
+BareLabeledGroup   GROUP
+BareField             STRING(4)
+                   END
+
+! --- Case D: labeled group with a trailing inline comment after the opener ---
+CommentedGroup     GROUP,PRE(CMT)              !CommentedGroup instance
+CommentField          LONG
+                   END
+
+! --- Case F: THE ORIGINAL BUG -- "Group" used purely as a plain identifier/label, no structure at
+!     all (mirrors the confirmed "Report &STRING" / "Window &STRING" / "Group &STRING" pattern,
+!     three unrelated reference variables declared back-to-back). Must NOT be treated as an
+!     opener -- there is no matching END for this line, and there must not be one.
+
+Window             &STRING
+Group              &STRING
+Report             &STRING
+
+Result             LONG(0)
+
+
+
+! --- Case A / A2: bare screen GROUP controls nested in a WINDOW -- unlabeled, identified by
+!     USE(), the actual regression pattern (confirmed against real production Clarion source).
+ReproWindow WINDOW('Repro'),AT(,,300,200),GRAY,FONT('MS Sans Serif',8,,FONT:regular)
+      GROUP('Group One'),AT(3,18,153,28),USE(?Group1),BOXED
+        STRING('Id:'),AT(10,30),USE(?String1)
+         ENTRY(@s6),AT(21,29,,10),USE(Result)
+      END
+      GROUP('Group Two'),AT(160,20,120,26),USE(?Group2),BOXED
+         STRING('Start'),AT(163,32),USE(?String2)
+         BUTTON('Refresh'),AT(230,29),USE(?RefreshButton)
+      END
+      BUTTON('Close'),AT(230,170,52,17),USE(?CloseButton)
+    END
+
+
+ CODE 
+
+  OPEN(ReproWindow)
+  ACCEPT
+    CASE FIELD()
+    OF ?CloseButton
+      IF EVENT() = EVENT:Accepted THEN POST(EVENT:CloseWindow). 
+    END
+  END
+  CLOSE(ReproWindow)
+  RETURN

--- a/ClarionAssistant/indexer/test-fixtures/group-record-diagnostics-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/group-record-diagnostics-repro/README.md
@@ -1,0 +1,111 @@
+# GROUP/RECORD keyword-as-label diagnostics regression fixture
+
+Repro for `ModernEmbeditorDiagnostics.cs`'s per-slot structure-balance checker (`Compute()`,
+Pass 2). Covers the `GROUP`-keyword regression found while reviewing the
+`fix/structure-keyword-as-label-embed-diagnostics` branch (the same fix that resolved the original
+`REPORT`/`WINDOW`/`QUEUE`/`RECORD` false positives): `GROUP` was added to `DeclarationStructKeywords`
+on the same "always requires a label" assumption as those nine keywords, but unlike them `GROUP` is
+also legitimately written **bare**, nested inside a `WINDOW`/`APPLICATION`/`REPORT` body as a screen
+control (identified by `USE()`, not a leading label) — the exact ambiguity already carved out for
+`TOOLBAR`/`MENU`/`MENUBAR`/`SHEET`/`TAB`/`OPTION`, just missed for `GROUP`.
+
+Confirmed against real production Clarion source: two bare `GROUP('...'),AT(...),USE(?X),BOXED`
+screen controls nested in the same `WINDOW` desync the per-slot balance stack, making the second
+`GROUP`'s own, genuinely-terminated `END` misreport as
+`"END has no matching structure in this embed slot."`. This fixture reproduces that shape without
+any project-specific names, paths, or control layout.
+
+## Why this fixture exists
+
+The blunt fix (just deleting `"GROUP"` from `DeclarationStructKeywords`) resolves the regression
+above but **reopens** the original bug for `GROUP` specifically: a plain identifier declared bare
+as `Group           &STRING` (mirroring the confirmed `Report &STRING` / `Window &STRING` pattern
+that motivated the original fix) would then get treated as an unterminated structure opener. The
+validated fix instead gives `GROUP` its own tight-lookahead regex (`GroupOpen`, modeled on
+`ToolbarOpen`/`NestedBandOpen` but keeping `StructOpen`'s optional leading-label group, since unlike
+Toolbar/Option, `GROUP` **can** legitimately be labeled) and removes it from both `StructOpen`'s
+alternation and `DeclarationStructKeywords`.
+
+Due-diligence during the same review found `RECORD` has the identical class of gap — an
+anonymous `RECORD, PRE()` inside a `FILE`. **Confirmed and fixed** (2026-07-28): the Clarion
+Language Reference lists the `RECORD` label as optional, the fixture (restructured into a full
+compiling `PROGRAM`) was built and run successfully confirming cases E/E2 are valid syntax, and the
+live IDE reproduced the exact predicted symptom — an anonymous `RECORD` inside a `FILE` desyncing
+the balance stack the same way a bare screen `GROUP` did, making the `FILE`'s own closing `END`
+misreport as unmatched. Fixed with the same shape as `GROUP`: a dedicated `RecordOpen` regex
+(`^\s*(?:[A-Za-z_][A-Za-z0-9_:]*\s+)?(RECORD)(?=\s*(?:[(,!]|$))`), `RECORD` removed from both
+`StructOpen`'s alternation and `DeclarationStructKeywords`.
+
+The fixture is now a complete, compiling, runnable Clarion `PROGRAM` (not just an isolated
+procedure fragment) — build and run it directly to sanity-check any candidate fix against the real
+compiler, not just the diagnostics checker.
+
+### Related finding: `Group PROCEDURE()` as a global procedure label (different component)
+
+Case G exercises a **separate component entirely** — not `ModernEmbeditorDiagnostics.cs` in
+`ClarionAssistant`, but `LabelDiagnostics.ts` (`validateReservedKeywordLabels`) in the
+**`Clarion-Extension`** language server. A top-level, non-nested `Group PROCEDURE()` (declared in
+`MAP` and defined normally, called as `Group()`) **compiles and runs correctly** in real Clarion —
+confirmed by building and running this fixture — but the LSP flags it as an error:
+
+> `'Group' cannot be the label of a PROCEDURE or FUNCTION declaration.`
+
+Root cause: `LabelDiagnostics.ts`'s `STRUCTURE_ONLY` set includes `GROUP` (alongside 27 other
+keywords: `APPLICATION, CLASS, CODE, DATA, DETAIL, FILE, FOOTER, FORM, HEADER, ITEM, ITEMIZE, JOIN,
+MAP, MENU, MENUBAR, MODULE, OLE, OPTION, QUEUE, PARENT, RECORD, REPORT, SELF, SHEET, TAB, TOOLBAR,
+VIEW, WINDOW`), and only suppresses the "cannot be the label of a PROCEDURE or FUNCTION
+declaration" diagnostic when the label sits **inside an enclosing structure** (e.g. a method
+declared inside a `CLASS`/`INTERFACE`). It doesn't account for the label being legal at **global,
+non-nested** scope too — the same underlying misconception as the `ModernEmbeditorDiagnostics.cs`
+bug (treating a context-disambiguated identifier as reserved-except-in-one-specific-context), just
+manifesting in a different checker, in a different repo.
+
+**Scope note**: only `GROUP` has been confirmed here via an actual compile+run. The other 27
+`STRUCTURE_ONLY` keywords have NOT been individually re-verified for this same global-PROCEDURE-
+label behavior — do not assume they share it without testing each one; some (e.g. `SELF`, `PARENT`)
+seem unlikely to. Not yet fixed; likely warrants its own `Clarion-Extension` PR rather than folding
+into the `ClarionAssistant` `GroupOpen` fix, since it's a different repo and a different checker.
+
+Case H (`GroupTestClass.Group`, a `CLASS` method literally named `Group`) exercises the checker's
+OWN existing, already-documented exception for this ambiguity (`findEnclosingStructure` — the code
+comments already give `Join PROCEDURE()` inside a `CLASS` as an example of allowed usage). **Confirmed**
+(2026-07-28, compiled + zero diagnostics on the method label): this path already works correctly —
+the bug is specifically the global/non-nested case (G), not the in-structure case (H).
+
+## Contents (`GroupRecordRepro.clw`)
+
+Every structure in the fixture is correctly terminated — the checker must produce **zero**
+diagnostics once the fix is correctly applied.
+
+| Case | What it exercises | Must NOT be flagged because |
+|---|---|---|
+| A / A2 | Bare screen `GROUP('Title'),AT(...),USE(?X),BOXED` nested in a `WINDOW` | The actual regression — opener must be pushed |
+| B | Labeled group, `GROUP` immediately followed by `,` | Already worked pre-regression — must keep working |
+| B2 | Labeled group, space before the paren (`GROUP (Type), NAME(...)`) | Real syntax variant that breaks a too-tight candidate regex if `\s*` isn't allowed before the punctuation |
+| C | Bare, attribute-less labeled group (`Label GROUP` then fields) | Trailing lookahead must accept end-of-line, not just punctuation |
+| D | Labeled group with a trailing inline comment on the opener line | `Sanitize()` must blank the comment before the regex runs |
+| E | Anonymous `RECORD, PRE()` inside a `FILE` | Same bare-structure ambiguity as GROUP — **confirmed and fixed** via a dedicated `RecordOpen` regex, same shape as `GroupOpen` |
+| E2 | Labeled `RECORD` inside a `FILE` | Contrast/negative control — already correct |
+| F | `Window &STRING` / `Group &STRING` / `Report &STRING` — plain identifiers, no structure | **The original bug.** Must NOT push an opener. Regresses under the blunt "just delete from the set" fix |
+| G | `Group PROCEDURE()` — a global, non-nested procedure named `Group` | **Different bug, different component** (`Clarion-Extension`'s `LabelDiagnostics.ts`, not `ModernEmbeditorDiagnostics.cs`). Compiles and runs; the LSP incorrectly flags it as an error — see below |
+| H | `Group PROCEDURE()` declared/implemented as a `CLASS` method (`GroupTestClass.Group`) | Exercises `LabelDiagnostics.ts`'s EXISTING `findEnclosingStructure` exception — **confirmed**: compiles cleanly, zero diagnostics on the method label (unlike case G) |
+
+## Verify
+
+Open `GroupRecordRepro.clw` in the Clarion IDE (native Monaco source-code editor runs the same
+per-slot heuristic as the Modern Embeditor for plain `.clw`/`.inc` files) and confirm there are no
+"END has no matching structure in this embed slot" (or any other structure-balance) diagnostics
+anywhere in the file.
+
+- **Before either fix**: cases A/A2 desync the stack (phantom diagnostic on the `END` closing the
+  second `GROUP` control, confirmed live), and case E's anonymous `RECORD` desyncs it too (phantom
+  diagnostic on the `FILE`'s own closing `END`, also confirmed live).
+- **With only the blunt fix** (keyword deleted from `DeclarationStructKeywords`, no dedicated
+  regex): case F (`Group &STRING`) starts falsely flagging as an unterminated structure.
+- **With the full `GroupOpen` + `RecordOpen` fix**: zero diagnostics (confirmed live, 2026-07-28).
+
+Case G is verified separately, against `Clarion-Extension`'s language server (e.g. its VS Code
+extension host) rather than the ClarionAssistant Modern Embeditor/native editor: open the fixture
+where that LSP is active and confirm whether `Group PROCEDURE()`'s label is flagged as
+`'Group' cannot be the label of a PROCEDURE or FUNCTION declaration.` — a real compiler build+run
+(as done for this fixture) confirms it should NOT be an error.


### PR DESCRIPTION
## Summary

- `GROUP` and `RECORD` are not reserved words in Clarion, but `ModernEmbeditorDiagnostics.cs`'s
  `DeclarationStructKeywords` treated them as always requiring a leading label — the same class of
  bug already fixed for `TOOLBAR`/`MENU`/`MENUBAR`/`SHEET`/`TAB`/`OPTION`.
- A bare screen `GROUP` control nested in a `WINDOW` (`GROUP('Title'),AT(...),USE(?X),BOXED`) or an
  anonymous `RECORD` inside a `FILE` (`RECORD, PRE()`) desyncs the per-slot structure-balance stack,
  making an unrelated, genuinely-terminated `END` further down misreport as
  `"END has no matching structure in this embed slot."`
- Fix: give each keyword its own tight-lookahead regex (`GroupOpen` / `RecordOpen`), modeled on
  `ToolbarOpen`/`NestedBandOpen` but keeping `StructOpen`'s optional leading-label group — unlike
  Toolbar/Option, `GROUP` and `RECORD` can also legitimately be labeled. Removed both from
  `StructOpen`'s alternation and from `DeclarationStructKeywords`.
- A naive "just delete the keyword from the set" fix would reopen the original bug (a plain
  identifier declared bare, e.g. `Group &STRING`, getting mistaken for a structure opener) — the
  dedicated regexes avoid that by requiring the keyword be immediately followed (allowing optional
  whitespace) by `(`, `,`, `!`, or end-of-line, which a bare-identifier declaration never is.

## Test plan

- [x] Added `test-fixtures/group-record-diagnostics-repro/` — a complete, compiling, runnable
      Clarion `PROGRAM` covering: bare screen `GROUP` controls in a `WINDOW`, labeled `GROUP` (with
      and without a space before the paren), bare attribute-less labeled `GROUP`, `GROUP` with a
      trailing inline comment, anonymous `RECORD` in a `FILE`, labeled `RECORD`, and the original
      false-positive case (`Window`/`Group`/`Report` declared bare as plain reference variables).
- [x] Built and ran the fixture directly against the real Clarion compiler to confirm every case is
      valid, compiling syntax (not just a plausible-looking regex test case).
- [x] Confirmed live in the IDE, before the fix: the fixture produces 3 false "END has no matching
      structure" warnings (the `WINDOW`'s two `GROUP` controls, and the `FILE`'s anonymous
      `RECORD`).
- [x] Confirmed live in the IDE, after the fix: zero diagnostics anywhere in the fixture.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
