### PR TITLE
fix/split-editor pane and added horizontal split to the monaco editor

### DIFF
--- a/ClarionAssistant/Services/ModernEmbeditorSettings.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorSettings.cs
@@ -41,6 +41,8 @@ namespace ClarionAssistant.Services
         // Horizontal scrollbar visibility → Monaco editor option scrollbar.horizontal:
         //   "auto" (show when needed) | "visible" (show always) | "hidden" (show never). Default auto.
         public string HorizontalScrollbar = "auto";
+        // Split-editor pane orientation: "v" (side by side) | "h" (top / bottom). Default v.
+        public string SplitOrientation = "v";
 
         /// <summary>
         /// User key-binding OVERRIDES only: command id → canonical chord string (e.g. "Ctrl+Shift+Y").
@@ -99,6 +101,7 @@ namespace ClarionAssistant.Services
                 s.FontFamily = SanitizeFontFamily(sv.Get(Prefix + "FontFamily"));
                 s.OccurrenceHighlight = GetBool(sv, "OccurrenceHighlight", s.OccurrenceHighlight);
                 s.HorizontalScrollbar = NormalizeScrollbar(sv.Get(Prefix + "HorizontalScrollbar"));
+                s.SplitOrientation = NormalizeSplitOrientation(sv.Get(Prefix + "SplitOrientation"));
                 s.KeyBindings = ParseKeyBindings(sv.Get(Prefix + "KeyBindings"));
                 s.Formatter = ParseFormatter(sv.Get(Prefix + "Formatter"));
             }
@@ -121,6 +124,7 @@ namespace ClarionAssistant.Services
             sv.Set(Prefix + "FontFamily", SanitizeFontFamily(FontFamily));
             sv.Set(Prefix + "OccurrenceHighlight", OccurrenceHighlight ? "true" : "false");
             sv.Set(Prefix + "HorizontalScrollbar", NormalizeScrollbar(HorizontalScrollbar));
+            sv.Set(Prefix + "SplitOrientation", NormalizeSplitOrientation(SplitOrientation));
             // Compact JSON, single line — SettingsService rejects CR/LF in values, and the serializer
             // never emits them. Empty map persists as "{}" (clears any prior overrides).
             sv.Set(Prefix + "KeyBindings", new JavaScriptSerializer().Serialize(SanitizeBindings(KeyBindings)));
@@ -149,6 +153,9 @@ namespace ClarionAssistant.Services
             object hs;
             if (d.TryGetValue("horizontalScrollbar", out hs) && hs != null)
                 s.HorizontalScrollbar = NormalizeScrollbar(hs.ToString());
+            object so;
+            if (d.TryGetValue("splitOrientation", out so) && so != null)
+                s.SplitOrientation = NormalizeSplitOrientation(so.ToString());
             object kb;
             if (d.TryGetValue("keyBindings", out kb) && kb is IDictionary<string, object>)
             {
@@ -184,6 +191,7 @@ namespace ClarionAssistant.Services
                 { "fontFamily", SanitizeFontFamily(FontFamily) },
                 { "occurrenceHighlight", OccurrenceHighlight },
                 { "horizontalScrollbar", HorizontalScrollbar },
+                { "splitOrientation", SplitOrientation },
                 { "keyBindings", SanitizeBindings(KeyBindings) }
             };
             // Merge the formatter pass-through bag so the bridge payload (load + cross-tab broadcast) carries
@@ -348,6 +356,11 @@ namespace ClarionAssistant.Services
         private static string NormalizeScrollbar(string v)
         {
             return (v == "visible" || v == "hidden") ? v : "auto";
+        }
+
+        private static string NormalizeSplitOrientation(string v)
+        {
+            return (v == "h") ? "h" : "v";
         }
 
         private static int GetInt(SettingsService sv, string key, int dflt, int lo, int hi)

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -263,20 +263,29 @@
     .breakpoint-glyph { background: #e51400; border-radius: 50%;
         width: 11px !important; height: 11px !important; margin-left: 3px; margin-top: 4px; box-shadow: 0 0 0 1px rgba(255,255,255,0.5); cursor: pointer; }
 
-    /* Status-bar height: SINGLE SOURCE OF TRUTH. The editors/Find panel reserve it as their resting bottom,
-       and setEditorBottom() reads it from JS (getComputedStyle) so the live layout math can't drift. */
+    /* Status-bar height: SINGLE SOURCE OF TRUTH. The editors/Find panel reserve it as their resting bottom. */
     :root { --status-bar-h: 22px; }
     /* Overlay-mode clickable header strip height (b1e05287): 0 unless the header is shown, so every element
        anchored below the toolbar (editors, panels, loading, dropdowns) shifts down by exactly the header. */
     :root { --header-h: 0px; }
     body.has-embheader { --header-h: 24px; }
-    /* Editors rest above the bottom to clear the status bar; the Find panel docks above it too.
-       setEditorBottom() adds --status-bar-h on top of any Find-panel clearance. */
-    #editor { position: absolute; top: calc(38px + var(--header-h)); left: 0; right: 0; bottom: var(--status-bar-h); }
+    /* Live Find-panel/grip clearance (0 when the Find panel reserves no editor space). Exposed as a CSS var
+       (set by setEditorBottom()) rather than an inline .style.bottom, so both panes AND the split-h midpoint
+       calc() below can derive from one source without an inline-style vs. CSS-class specificity fight. */
+    :root { --panel-clearance: 0px; }
+    /* Editors rest above the bottom to clear the status bar; the Find panel docks above it too. */
+    #editor { position: absolute; top: calc(38px + var(--header-h)); left: 0; right: 0; bottom: calc(var(--status-bar-h) + var(--panel-clearance)); }
     /* Split view (#15): second pane occupies the right half; primary shrinks to the left half. */
-    #editor2 { display: none; position: absolute; top: calc(38px + var(--header-h)); left: 50%; right: 0; bottom: var(--status-bar-h); }
+    #editor2 { display: none; position: absolute; top: calc(38px + var(--header-h)); left: 50%; right: 0; bottom: calc(var(--status-bar-h) + var(--panel-clearance)); }
     body.split #editor { right: 50%; border-right: 1px solid var(--toolbar-border); }
     body.split #editor2 { display: block; }
+    /* Horizontal split: second pane occupies the bottom half. The midpoint is computed (not a flat 50%) so
+       it lands on the true center of the EDITING area — accounting for the top toolbar/header inset and the
+       bottom status-bar/Find-panel inset — rather than the center of the raw window. */
+    body.split-h #editor { right: 0; border-right: none; border-bottom: 1px solid var(--toolbar-border);
+        bottom: calc(50% + (var(--status-bar-h) + var(--panel-clearance) - 38px - var(--header-h)) / 2); }
+    body.split-h #editor2 { display: block; left: 0;
+        top: calc(50% + (38px + var(--header-h) - var(--status-bar-h) - var(--panel-clearance)) / 2); }
     /* Notepad++-style status bar: live Ln / Col / Pos + selection + totals for the active pane. */
     #statusBar {
         position: absolute; left: 0; right: 0; bottom: 0; height: var(--status-bar-h); z-index: 16;
@@ -287,6 +296,11 @@
     }
     #toolbar #splitBtn { padding: 3px 8px; font-size: 14px; line-height: 1; }
     #toolbar #splitBtn.on { background: var(--title-accent); color: #fff; }
+    /* The icon's stroke/fill are hardcoded #475569 (a dark slate), which is nearly the same tone as
+       --title-accent in light theme — on a plain background swap the icon reads as a solid black square.
+       Recolor it explicitly for the pressed state (a real CSS rule beats the SVG's presentation attributes). */
+    #toolbar #splitBtn.on svg rect, #toolbar #splitBtn.on svg path { stroke: #fff; }
+    #toolbar #splitBtn.on svg rect[fill]:not([fill="none"]) { fill: #fff; opacity: .35; }
     #toolbar .embed-nav:disabled { opacity: 0.35; cursor: default; }
     /* Navigation history dropdown (#14) */
     #navHist {
@@ -811,8 +825,11 @@
             </table>
             <div class="find-empty" id="findEmpty">No results.</div>
         </div>
-        <div id="ftabMenu" class="hidden"></div>
     </div>
+    <!-- Top-level (not nested inside #findPanel): findPanel is display:none while Find is closed, which would
+         hide this menu too if it stayed nested — even though it's also used by the Split button's right-click
+         menu, which needs to show regardless of whether Find is open. -->
+    <div id="ftabMenu" class="hidden"></div>
     <div id="loading">Loading editor…</div>
     <div id="toast"></div>
 
@@ -1188,6 +1205,9 @@
                 });
                 var splitBtn = document.getElementById('splitBtn');
                 if (splitBtn) splitBtn.addEventListener('click', toggleSplit);   // split toggle (#15)
+                if (splitBtn) splitBtn.addEventListener('contextmenu', function (ev) {
+                    ev.preventDefault(); showSplitMenu(ev.clientX, ev.clientY);   // pick vertical/horizontal
+                });
                 installNavTracking(editor);    // record cursor jumps for Back/Forward (#14)
                 wireNavButtons();
                 wireSettingsPanel();
@@ -2631,6 +2651,7 @@
     // primary-bound for v1. When not split, activeEd() === editor, so single-pane behavior is unchanged.
     var editor2 = null;        // second pane instance while split; null otherwise
     var activeEditor = null;   // the focused pane; commands target this (defaults to the primary editor)
+    var splitOrientation = 'v';   // 'v' (side by side) | 'h' (top / bottom) — persisted via settings
     function activeEd() { return activeEditor || editor; }
 
     function editorOptionsForSplit() {
@@ -2670,7 +2691,12 @@
     }
 
     function doSplit() {
-        document.body.classList.add('split');
+        document.body.classList.add(splitOrientation === 'h' ? 'split-h' : 'split');
+        // #editor/#editor2's inline left/right may still carry stale values from a PRIOR split session
+        // (the divs persist across split/unsplit — only the Monaco instance inside editor2 is torn down).
+        // Recompute them now that the correct class is in place, so a fresh split never inherits geometry
+        // left over from a different orientation or a different Outline/Find-All inset.
+        setEditorInsets();
         editor2 = monaco.editor.create(document.getElementById('editor2'), editorOptionsForSplit());
         editor2.onDidFocusEditorText(function () { activeEditor = editor2; });
         installCommandPalette(editor2); // F1 / Ctrl+Shift+P in the split pane too
@@ -2681,8 +2707,6 @@
         wireGlyphBookmark(editor2);
         wireCtrlClickDefinition(editor2);   // Ctrl+Click go-to-definition in the split pane too (#40)
         installNavTracking(editor2);   // cursor jumps in the split pane feed the shared history (#14)
-        var ebottom = document.getElementById('editor').style.bottom;   // match the Find-panel clearance
-        if (ebottom) document.getElementById('editor2').style.bottom = ebottom;
         var pos = editor.getPosition();
         if (pos) editor2.revealLineInCenter(pos.lineNumber);
         activeEditor = editor2;
@@ -2692,16 +2716,64 @@
     }
 
     function doUnsplit() {
-        document.body.classList.remove('split');
+        document.body.classList.remove('split', 'split-h');
         if (editor2) {
             try { editor2.setModel(null); } catch (e) { }   // detach the SHARED model so dispose can't free it
             try { editor2.dispose(); } catch (e) { }
             editor2 = null;
         }
+        // setEditorInsets() sets editor.style.right INLINE while a vertical split is active (to keep the
+        // divider aligned with editor2's midpoint); that inline value outlives the split's CSS class removal
+        // above, so without recomputing it editor stays stuck at half-width after unsplitting.
+        setEditorInsets();
         activeEditor = editor;
         updateStatusBar(activeEd());   // bar follows the sole remaining pane after unsplit
         updateSplitBtn();
         editor.focus();
+    }
+
+    // Apply an orientation choice from the right-click menu. If a split is already open, reposition the
+    // existing panes in place (keeps both panes' content/scroll/cursor intact) — otherwise OPEN a split in
+    // that orientation immediately (like VS Code's Split Right / Split Down), rather than just silently
+    // recording a preference for next time with no visible effect.
+    function setSplitOrientation(o) {
+        if (o !== 'v' && o !== 'h') return;
+        splitOrientation = o;
+        if (!editor2) {
+            doSplit();   // not split yet — open it immediately in the chosen orientation
+        } else if (!document.body.classList.contains(o === 'h' ? 'split-h' : 'split')) {
+            document.body.classList.remove('split', 'split-h');
+            document.body.classList.add(o === 'h' ? 'split-h' : 'split');
+            // Re-derive left/right for the NEW orientation — otherwise the inline values setEditorInsets()
+            // left behind for the OLD orientation keep fighting the new CSS class (quadrant-clipping bug:
+            // both axes end up constrained at once, since inline styles always beat class rules).
+            setEditorInsets();
+            editor.layout();
+            editor2.layout();
+        }
+        persistSettings();   // remember the choice for the next time Split is opened
+    }
+
+    // Right-click menu on the Split toolbar button — reuses the same #ftabMenu element the Find-tab
+    // context menu uses (showTabMenu), just with different items.
+    function showSplitMenu(x, y) {
+        var menu = document.getElementById('ftabMenu');
+        if (!menu) return;
+        menu.innerHTML = '';
+        var items = [
+            ['Vertical split (side by side)', 'v'],
+            ['Horizontal split (top / bottom)', 'h']
+        ];
+        items.forEach(function (it) {
+            var d = document.createElement('div');
+            d.className = 'ftab-menu-item';
+            d.textContent = (splitOrientation === it[1] ? '✓ ' : '   ') + it[0];
+            d.addEventListener('click', function () { hideTabMenu(); setSplitOrientation(it[1]); });
+            menu.appendChild(d);
+        });
+        menu.style.left = Math.min(x, window.innerWidth - 220) + 'px';
+        menu.style.top = Math.min(y, window.innerHeight - 80) + 'px';
+        menu.classList.remove('hidden');
     }
 
     function updateSplitBtn() {
@@ -3537,6 +3609,7 @@
         // Capture BEFORE the editor-ready guard so a settings broadcast that races Monaco init isn't lost for
         // formatterOptions() (Ctrl+I can't fire pre-init anyway, but the next one will then honor it). (deac3d16 adversary LOW)
         lastSettings = s;
+        if (s.splitOrientation === 'v' || s.splitOrientation === 'h') splitOrientation = s.splitOrientation;
         if (!editor) return;
         var opts = {};
         if (typeof s.fontSize === 'number') opts.fontSize = s.fontSize;
@@ -3779,6 +3852,7 @@
         var s = readSettingsPanel();
         s.keyBindings = {};
         for (var id in keyBindings) if (keyBindings.hasOwnProperty(id)) s.keyBindings[id] = keyBindings[id];
+        s.splitOrientation = splitOrientation;   // not a gear-panel control — set via the Split button's right-click menu
         return s;
     }
 
@@ -4128,20 +4202,11 @@
             .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
 
-    // Read the status-bar height from its single CSS source of truth (--status-bar-h) so this and the CSS
-    // can't drift; fall back to 22 if the var can't be resolved.
-    var STATUS_BAR_H = (function () {
-        try { var v = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--status-bar-h'), 10); return isFinite(v) ? v : 22; }
-        catch (e) { return 22; }
-    })();
     function setEditorBottom(px) {
-        // Callers pass the Find-panel clearance (0 when closed); always add the status bar's height so
-        // the editors never sit under it. Resting bottom = STATUS_BAR_H; with Find open = panel + bar.
-        var bottom = (px + STATUS_BAR_H) + 'px';
-        var ed = document.getElementById('editor');
-        if (ed) ed.style.bottom = bottom;   // automaticLayout picks up the resize
-        var e2 = document.getElementById('editor2');   // keep the split pane clear of the Find panel too
-        if (e2) e2.style.bottom = bottom;
+        // Callers pass the Find-panel clearance (0 when closed). Both panes' CSS derive their resting
+        // bottom (and split-h's midpoint) from this var, so a single update keeps everything in sync —
+        // no inline .style.bottom needed, and automaticLayout still picks up the resulting resize.
+        document.documentElement.style.setProperty('--panel-clearance', px + 'px');
     }
 
     // Monaco binds Ctrl+F / Ctrl+H to its built-in find/replace widgets at a keybinding weight that
@@ -4915,7 +4980,16 @@
         // Both are left columns; the outline takes precedence if somehow both are open.
         var left = outline ? (op.offsetWidth + 'px') : (findAll ? (fp.offsetWidth + 'px') : '0px');
         var ed = document.getElementById('editor'); if (ed) ed.style.left = left;
-        var e2 = document.getElementById('editor2'); if (e2) e2.style.left = left;
+        var e2 = document.getElementById('editor2');
+        var vertical = document.body.classList.contains('split');
+        // In a VERTICAL split, the divider must sit at the midpoint of the REMAINING (post-inset) width, not
+        // a flat 50% of the whole container — editor's right edge AND editor2's left edge both need the SAME
+        // adjusted midpoint, or a gap/overlap opens up whenever Outline/Find-All is toggled while split is
+        // active (editor's right previously stayed at the static CSS 50%, ignoring the inset entirely, which
+        // left a gap the width of half the inset). Horizontal split doesn't have this problem: both panes are
+        // full-width, so they share the same left inset (the ed/e2 left = left above already covers it).
+        if (ed) ed.style.right = vertical ? ('calc((100% - ' + left + ') / 2)') : '';
+        if (e2) e2.style.left = vertical ? ('calc((100% + ' + left + ') / 2)') : left;
     }
     // ---- Document structure fly-out (Phase-1 outline prototype) ----
     var outlineSeq = 0;


### PR DESCRIPTION
## Summary

The Monaco editor "Split editor" toolbar button set up a visible split but always showed the same line in both panes, with no way to scroll them independently — effectively non-functional.

## Fix

Two Monaco editors now share one `ITextModel`. Model-level things (edits, decorations, LSP providers) show in both panes automatically; each pane keeps its own scroll/cursor/viewport independently.

- **Left-click** the Split button toggles split on/off, in whichever orientation was last used.
- **Right-click** opens a small menu to pick orientation — vertical (side by side) or horizontal (top/bottom) — reusing the existing Find-tab context-menu element. Picking an orientation opens a split immediately if none is active yet, or repositions the existing panes in place if one already is.
- Orientation is persisted (`ModernEmbeditorSettings.SplitOrientation`, round-tripped through `Load`/`Save`/`FromDict`/`ToDict` the same way `HorizontalScrollbar` already was) so the next Split press reopens the same way.
- Horizontal split's midpoint is computed via CSS `calc()` from the toolbar/header/status-bar/Find-panel insets, so the divider sits at the true center of the editing area rather than the center of the raw window.

## Root cause behind most of the bugs found while building this

`setEditorBottom()`/`setEditorInsets()` used to write layout geometry (`left`/`right`/`bottom`) directly as **inline styles** on `#editor`/`#editor2`. Inline styles always beat CSS class rules, and those two DOM elements persist across split/unsplit cycles (only the Monaco instance inside `#editor2` is torn down) — so a value written for one split state/orientation could silently outlive it and fight the next one's CSS class. Concretely, this produced (all now fixed):

- Toggling Outline or Find while a vertical split was active made the second pane overlap the first entirely (both panes' `left` ended up identical).
- Switching orientation in place while an Outline/Find-All inset was active left stale inline `left`/`right` from the old orientation fighting the new orientation's CSS class — visually a quadrant-clipped layout (small pane top-left, small pane bottom-right).
- Unsplitting after Outline had been opened left the remaining pane stuck at half-width (`editor.style.right` never got cleared).
- The right-click menu never appeared at all in one case: the shared menu element (`#ftabMenu`) was nested inside `#findPanel`, which is `display:none` while Find is closed — invisible regardless of its own class. Moved it to a top-level sibling.

Fix: `setEditorBottom()` now sets a single CSS custom property (`--panel-clearance`) instead of inline `.style.bottom`, and every place that changes split state or orientation (`doSplit`, `doUnsplit`, `setSplitOrientation`) now re-derives `left`/`right` via `setEditorInsets()` instead of leaving a previous call's values in place.

Also fixed while testing: the Split button's icon (hardcoded `#475569` SVG stroke) was nearly invisible against the pressed-state accent background in light theme — added an explicit white recolor for `.on`.

## Verification

Manually tested in a live IDE session across many rounds, working through each bug above as it was found: vertical/horizontal split, opening/closing Document Structure and Find while split (both orders), switching orientation mid-split, repeated split/unsplit, and the pressed-button icon contrast — all confirmed working after the fixes above. Also exercised a small real APP through the editor, jumping between embeds with split + Document Structure open in every combination — no issues, though this wasn't an exhaustive/authoritative pass. An independent adversarial review pass (Find-All-specific paths, Outline+Find-All together, theme toggling, close/reopen, cross-tab settings broadcast, legacy settings values, rapid-click re-entrancy) found nothing further.

Known, deliberate limitation: Ctrl+F/Find only searches the primary pane in this first version — extending it to the focused pane is straightforward follow-up work but out of scope here.

Branched fresh off `upstream/master`: 2 files, 112 insertions / 25 deletions.
