### PR TITLE
fix(completion): don't merge bare-prefix globals into ? control field-equate completion list

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -1617,7 +1617,11 @@ namespace ClarionAssistant.Services
             string prefix = m.Value;
             if (prefix.Length < CgCompletionMinPrefix) return;
             // Qualified access (Class.Member, PROP:/EVENT:/prefixed field) → LSP-only, no global noise.
-            if (m.Index > 0) { char before = upToCursor[m.Index - 1]; if (before == '.' || before == ':') return; }
+            // '?' is a field-equate (?Ctrl) context — those are handled entirely by the bundled LSP's
+            // own scoped completion; merging bare-prefix globals/locals here just pollutes and outranks
+            // the real ?Ctrl item (a variable named e.g. "LDField" prefix-matches the replace range,
+            // while "?LdapButton" only substring-matches it, so it loses the client-side ranking tie).
+            if (m.Index > 0) { char before = upToCursor[m.Index - 1]; if (before == '.' || before == ':' || before == '?') return; }
 
             // Labels already returned by the LSP — don't double-list (case-insensitive).
             var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary

Follow-up to the `?` control field-equate completion work (Clarion-Extension server-side feature +
this repo's [monaco-embeditor.html trigger-character/icon companion fix](../..)). Live testing
surfaced a real bug once the control name got long enough:

- Type `?` → correct, scoped field-equate list. ✓
- Type `?L` → still correct. ✓
- Type `?LD` (e.g. towards `?LdapButton`) → the list fills with unrelated local
  variables/globals/procedures starting with "LD", with the actual `?LdapButton` item pushed to
  the bottom.

## Root cause

`SharedLspBridge.GetCompletion()` always calls `MergeBarePrefixCompletions()` after the pure LSP
call, to backfill locals/globals/procedures for bare-word completion (upstream Clarion-Extension
only completes after `.`). That merge already guards against firing in qualified contexts:

```csharp
if (m.Index > 0) { char before = upToCursor[m.Index - 1]; if (before == '.' || before == ':') return; }
```

`?` was never added to this check. Combined with the merge's own minimum-prefix-length gate
(`CgCompletionMinPrefix = 2`), this exactly explains the repro: `?` and `?L` never reach the
2-character prefix threshold so the merge bails out on length alone; at `?LD` the prefix is long
enough and the character before it (`?`) isn't `.` or `:`, so the guard doesn't catch it and the
merge proceeds — appending every local/global/procedure symbol starting with "LD".

The merged items then also *outrank* the real `?Ctrl` item in Monaco's client-side fuzzy sort: a
variable literally named e.g. `LDField` prefix-matches the replace range (`"LD"`), while
`"?LdapButton"` only substring-matches it (the `?` sits before the match range), so it loses the
ranking tie-break and sinks to the bottom of the list — even though it's the only genuinely
correct suggestion.

## Fix

One-line addition to the existing guard, `Services/SharedLspBridge.cs`:

```csharp
if (m.Index > 0) { char before = upToCursor[m.Index - 1]; if (before == '.' || before == ':' || before == '?') return; }
```

`?`-context bare-prefix requests now bail out of the merge entirely at any partial length,
leaving `primary` exactly as the bundled LSP returned it — which also fixes the ranking issue as
a side effect, since there's nothing left to lose the tie-break against.

## Testing

- Clean `Debug-C11` build, only `Services/SharedLspBridge.cs` touched.
- Live-verified through the embedded Monaco editor: `?`, `?L`, `?LD`, and the full
  `?LdapButton` all now show only the current procedure's field equates, correctly ranked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
