### PR TITLE
fix(monaco): client-side wiring for ?Ctrl field-equate completion

### DIFF
--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -1417,8 +1417,9 @@
             case 5: return M.Field; case 6: return M.Variable; case 7: return M.Class;
             case 8: return M.Interface; case 9: return M.Module; case 10: return M.Property;
             case 12: return M.Value; case 13: return M.Enum; case 14: return M.Keyword;
-            case 15: return M.Snippet; case 20: return M.EnumMember; case 21: return M.Constant;
-            case 22: return M.Struct; case 25: return M.TypeParameter; default: return M.Text;
+            case 15: return M.Snippet; case 18: return M.Reference; case 20: return M.EnumMember;
+            case 21: return M.Constant; case 22: return M.Struct; case 25: return M.TypeParameter;
+            default: return M.Text;
         }
     }
 
@@ -3366,7 +3367,7 @@
             return out;
         }
         monaco.languages.registerCompletionItemProvider('clarion', {
-            triggerCharacters: ['.', ':'],
+            triggerCharacters: ['.', ':', '?'],
             provideCompletionItems: function (model, position) {
                 // Completion replace-range = the trailing identifier chars only, breaking on ':' and '.'.
                 // We intentionally do NOT use getWordUntilPosition here: the Clarion wordPattern keeps ':'


### PR DESCRIPTION
## Summary

Companion PR for a new Clarion-Extension LSP feature: `?Ctrl` field-equate completion (typing `?` inside a procedure now offers that procedure's control equates, e.g. `?OkButton`). The server-side change alone had no visible effect here, because Monaco doesn't read `triggerCharacters` off the LSP server's advertised capabilities — `Terminal/monaco-embeditor.html` registers its
own completion provider with a hardcoded trigger-character list, so the editor never even asked the server for completions when `?` was typed.

Two isolated one-line fixes in `monaco-embeditor.html`:

- `registerCompletionItemProvider`'s `triggerCharacters` — added `'?'` alongside the   existing `'.'`/`':'`, so Monaco actually invokes the provider on that keystroke. The   request-forwarding path (`ModernEmbeditorViewContent.HandleCompletion` →
  `SharedLspBridge.GetCompletion`) is already generic (line/column/buffer only, no   character-specific filtering), so no C# change was needed for this part.
- `lspKindToMonaco()`'s LSP→Monaco `CompletionItemKind` mapping — added the missing case   for LSP kind `18` (`Reference`), which previously fell through to `default: M.Text`   (the generic "abc" icon). Kept for completeness even though the field-equate items   themselves ended up using `Constant` (21, already mapped) after a follow-up review —   a field equate is a compiler-generated `EQUATE`, the same construct a hand-written one  is, so it made more sense to share that icon than invent a new one.

## Testing

- Live-verified end to end through the real embedded Monaco editor: typing `?` inside a
  procedure with a WINDOW now pops the control-equate list, scoped to that procedure only
  (confirmed a second procedure's controls do not leak in), with the same icon as other
  equate completions.
- No C#/.NET files touched — pure JS/HTML change, no build required to verify (client-side
  logic only; the request/response wire format is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
