### PR TITLE
fix(editor): close two cold-open navigation races into the Monaco overlay

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -455,6 +455,22 @@ namespace ClarionAssistant
                 try { int nl, nc; if (MonacoSourceNavigator.TryConsumePending(_filePath, out nl, out nc)) { navLine = nl; navCol = nc; } }
                 catch (Exception nex) { MonacoSpikeLog.Write("overlay OnReady consume-pending error: " + nex.Message); }
 
+                // Same cold-open race, second source (2026-07-30): _navPendingLine is JumpTo/NavigateToLine's
+                // OWN park field, set by any native, closed-source caller that moves the hidden Caret directly
+                // — the Errors pane, Bookmarks next/prev, Find Next — when JumpTo fires before this view's
+                // Monaco page exists yet (a genuinely cold open). Until now it was only ever applied as the
+                // exact same kind of racy revealLine-after-setSource follow-up further down, even though by
+                // THIS point (OnReady already running) whatever set it fired strictly before the page existed
+                // — there's no reason to treat it differently from a MonacoSourceNavigator-parked nav. Folding
+                // it into navLine here closes the identical race for those callers too, not just
+                // MonacoSourceNavigator-originated ones (CA Debugger / breakpoint clicks, hover-footer links).
+                if (_navPendingLine >= 1)
+                {
+                    navLine = _navPendingLine;
+                    navCol = _navPendingCol > 0 ? _navPendingCol : 1;
+                    _navPendingLine = 0;
+                }
+
                 // Carry the current breakpoints INSIDE setSource so the page paints them after the content loads
                 // (a standalone setBreakpoints sent right after would race the async content fetch on a cold open).
                 string bpCsv = BreakpointLinesCsv();

--- a/ClarionAssistant/Services/MonacoSourceNavigator.cs
+++ b/ClarionAssistant/Services/MonacoSourceNavigator.cs
@@ -67,20 +67,40 @@ namespace ClarionAssistant.Services
             return DoNavigate(full, line, column);
         }
 
-        // Always on the UI thread. Open (or focus) the file, park the desired position, then drive the editor
-        // if it is already live — otherwise it self-applies via ApplyPendingNavigation on capture/ready.
+        // Always on the UI thread. Park the desired position FIRST, THEN open (or focus) the file, then
+        // drive the editor if it is already live — otherwise it self-applies via ApplyPendingNavigation
+        // on capture/ready.
+        //
+        // Ordering fix (2026-07-30): this used to call FileService.OpenFile() BEFORE writing _pending.
+        // For a COLD open, OpenFile() drives the entire view-creation sequence — CaptureTick →
+        // AttachOverlay → the WebView2 page's own "ready" round-trip — and that sequence reads _pending
+        // for this exact file (MonacoClarionSourceEditor's OnReady, via TryConsumePending) to seed the
+        // initial cursor position into the very first setSource payload. If any part of that chain
+        // completes before OpenFile() returns, _pending was still empty at read time — the file opened at
+        // whatever position it last had, silently dropping the requested line (confirmed via
+        // monaco-spike.log: a cold open logged with no ", nav->line N" suffix, which the log line only
+        // appends when a pending nav was actually found). Writing _pending before OpenFile() closes that
+        // window entirely. Same failure class as the historical "memento-restore race" (PR #111).
         private static bool DoNavigate(string full, int line, int column)
         {
-            try { ICSharpCode.SharpDevelop.FileService.OpenFile(full); }
-            catch (Exception ex) { MonacoSpikeLog.Write("Navigator OpenFile error: " + ex.Message); return false; }
-
-            MonacoClarionEditor ed;
+            MonacoClarionEditor liveBefore;
             lock (_gate)
             {
                 _pending[full] = new[] { line, column };
-                _live.TryGetValue(full, out ed);
+                _live.TryGetValue(full, out liveBefore);
             }
-            if (ed != null) ed.ApplyPendingNavigation();
+
+            try { ICSharpCode.SharpDevelop.FileService.OpenFile(full); }
+            catch (Exception ex)
+            {
+                MonacoSpikeLog.Write("Navigator OpenFile error: " + ex.Message);
+                lock (_gate) { _pending.Remove(full); }   // don't leave a stale entry for a later unrelated open
+                return false;
+            }
+
+            // If it was ALREADY live before OpenFile (a no-op re-open/focus), drive it directly — the
+            // cold-open path above only fires for a file that wasn't loaded yet.
+            if (liveBefore != null) liveBefore.ApplyPendingNavigation();
             return true;
         }
 


### PR DESCRIPTION
## Summary

Two independent navigation call sites into the Monaco source overlay share the same race, and both were
reproduced live: opening a file that isn't already loaded and jumping to a specific line in it lands on
the file's last-remembered position instead — the Errors pane, Bookmarks, Find Next, and (in a
companion, GUI-facing patch) a new hover-footer "jump to declaration/implementation" feature all hit
this on a cold open. Once the target file is already open, every one of these navigates correctly.

## Root cause

Both callers park a target line for a file, then either open it or wait for it to finish loading, then
apply the parked line. On a cold open, "apply the parked line" happens as a `revealLine` message sent to
the WebView2 page right after its initial `setSource` payload — and that message races the page's own
async content fetch. If the race is lost, the page finishes loading before the reveal arrives, or the
reveal arrives before the page's model exists to reveal into, and the parked line is silently dropped.

Two separate mechanisms hit this independently:

1. **`MonacoSourceNavigator.DoNavigate`** (used by CA Debugger navigation, breakpoint clicks, and now a
   hover-footer link feature) wrote the parked `{line, column}` into its `_pending` dictionary *after*
   calling `FileService.OpenFile(full)`. For a cold open, `OpenFile()` can drive the entire view-creation
   sequence — capture → attach the overlay → the WebView2 page's own "ready" round-trip, which reads
   `_pending` for this exact file to seed the initial cursor into `setSource` — before the write to
   `_pending` ever happens. The seed-into-setSource path (which avoids the race entirely) found nothing;
   the file opened at whatever position it last had.

2. **`MonacoClarionSourceEditor`'s `IPositionable.JumpTo` override** (added by task d19c036d / PR #144's
   follow-up, for the Errors pane, Bookmarks, and Find Next — native, closed-source IDE navigation that
   moves the hidden Caret directly) parks into its own, separate `_navPendingLine`/`_navPendingCol`
   fields. Unlike `MonacoSourceNavigator`'s pending value, these were only ever applied as the exact same
   kind of racy follow-up reveal — never folded into the initial `setSource` seed. So this caller hit the
   identical race on every cold open, unconditionally.

Confirmed directly via `monaco-spike.log` rather than assumed: `MonacoClarionSourceEditor.OnReady`'s own
log line only appends `", nav->line N"` when a pending nav was found at read time — a cold open that
missed its parked nav logs with that suffix absent.

## Fix

1. `MonacoSourceNavigator.DoNavigate` now writes `_pending` *before* calling `FileService.OpenFile()`,
   closing the window entirely — by the time anything downstream can possibly read it, it's already
   there. (On the `OpenFile` failure path, the now-stale entry is removed rather than left for a later
   unrelated open of the same path.)
2. `MonacoClarionSourceEditor.OnReady` now folds `_navPendingLine`/`_navPendingCol` into the same
   `navLine`/`navCol` that gets seeded into the FIRST `setSource` payload, right alongside the
   `MonacoSourceNavigator`-sourced value — one seeding point now covers both native-caret-driven callers
   (Errors pane, Bookmarks, Find Next) and `MonacoSourceNavigator`-driven ones (CA Debugger, breakpoints).
   The existing follow-up `RevealLine` further down is now a true no-op for this path — same idempotent
   "redundant safety net" the `MonacoSourceNavigator` case already relied on.

## Verification

- Builds clean against `upstream/master` (restored NuGet packages fresh; no other changes needed).
- Live-tested against the running IDE across several rounds: Errors-pane clicks, and (via a companion
  hover-link feature developed alongside this fix) hover-footer "declaration"/"implementation" links,
  each on both a cold file and an already-open file. All land on the correct line now; previously each
  landed correctly only once the target file was already open.
- Confirmed via direct log evidence (`monaco-spike.log`), not just static reasoning, before applying
  fix #1; fix #2's root cause was reconstructed the same way after the developer noticed the Errors pane
  regressing during that same testing round.
