### PR TITLE
feat(editor): reposition hover, shrink its font, and make footer links clickable (go to file)

### DIFF
--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -264,6 +264,39 @@ namespace ClarionAssistant.Terminal
                         try { Services.CaEditorSettings.MonacoThemeDark = json.IndexOf("\"dark\":true", StringComparison.Ordinal) >= 0; }
                         catch { }
                         break;
+                    case "openLocation":
+                        // A hover-footer location link was clicked ("Foo.inc:12 → Foo.clw:340"). Handled
+                        // HERE rather than on IMonacoEditorHost — like "themeChanged" above — so every
+                        // Monaco surface gets it without each host implementing anything.
+                        //
+                        // Services.MonacoSourceNavigator, NOT Services.EditorService (2026-07-30, second
+                        // pass) — EditorService.NavigateToFileAndLine (what open_file uses) drives
+                        // FileService.JumpToFilePosition, which IS the historically-fixed, race-free way
+                        // to position the NATIVE caret — but on a Monaco-overlay COLD open, the surface
+                        // the developer actually sees is seeded from a SEPARATE place entirely:
+                        // MonacoClarionSourceEditor.OnReady calls MonacoSourceNavigator.TryConsumePending
+                        // to bake the target line into the very FIRST setSource payload (deliberately —
+                        // see that method's own comment: a follow-up revealLine sent after setSource races
+                        // the async content fetch on a cold open and loses). JumpTo's own Monaco mirror
+                        // (_navPendingLine) is exactly that losing follow-up path when the file wasn't
+                        // already open. EditorService never touches MonacoSourceNavigator's pending dict,
+                        // so a cold open through it landed on the file's last-remembered position instead
+                        // — reproduced live: first click on a not-yet-open target opened at the wrong
+                        // line, a second click (file now already live) worked, matching this mechanism
+                        // exactly. MonacoSourceNavigator.NavigateToFileAndLine already routes correctly to
+                        // BOTH surfaces (NativeGoTo → EditorService.GoToLine when the overlay is off), so
+                        // it alone is the right call here — the same one OnDefinition's F12/Ctrl+F12
+                        // cross-file jump already uses for this identical scenario.
+                        try
+                        {
+                            string locPath = ExtractJsonValue(json, "path");
+                            int locLine;
+                            if (!int.TryParse(ExtractJsonValue(json, "line"), out locLine)) locLine = 1;
+                            if (!string.IsNullOrEmpty(locPath))
+                                Services.MonacoSourceNavigator.NavigateToFileAndLine(locPath, locLine, 1);
+                        }
+                        catch (Exception lex) { System.Diagnostics.Debug.WriteLine("[MonacoEditorControl] openLocation error: " + lex.Message); }
+                        break;
                     case "ready":             h.OnReady(this); break;
                     case "save":              h.OnSave(this, json); break;
                     case "cancel":            h.OnCancel(this); break;

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -605,6 +605,21 @@
     .monaco-editor .ca-dnd-target { border-right: 2px solid var(--find-accent); }
     body.ca-dragging, body.ca-dragging * { cursor: copy !important; }
     body.ca-dragging.ca-drag-blocked, body.ca-dragging.ca-drag-blocked * { cursor: no-drop !important; }
+
+    /* Hover tooltip readability (word hover, squiggle hover, glyph-margin hover — all .monaco-hover).
+       1) Monaco left-aligns the hover at the hovered word and prefers rendering it ABOVE the line, so it
+          lands squarely on the lines above. In Clarion that hides the LABEL column, which is exactly the
+          context you're reading. Nudge it right; hover.above:false (see the editor options) also drops it
+          below the line. Transform is visual only — Monaco's positioning math is untouched, and
+          getBoundingClientRect still reflects it, so mouse-into-hover (hover.sticky) keeps working.
+       2) The widget inherits the editor's inline font-size, so a code-heavy tooltip renders as loud as the
+          source. Pin it one px smaller; --ca-hover-font-size is refreshed from fontInfo on every editor
+          configuration change (gear panel AND Ctrl+wheel zoom) so it tracks the editor font rather than a
+          constant. Fenced code inside the hover sets no size of its own, so it scales along. */
+    .monaco-editor .monaco-hover {
+        transform: translateX(30px);
+        font-size: var(--ca-hover-font-size, 12px);
+    }
 </style>
 </head>
 <body>
@@ -1155,10 +1170,15 @@
                     wordSeparators: "`~!@#$%^&*()-=+[{]}\\|;'\",.<>/?",
                     // We handle Data-pad drops ourselves (see installDropInsert) — Monaco's built-in
                     // dropIntoEditor snippet-expands the text and leaves "$0" artifacts.
-                    dropIntoEditor: { enabled: false }
+                    dropIntoEditor: { enabled: false },
+                    // above:false — render the hover BELOW the hovered line. Monaco's default prefers
+                    // above, which covers the lines you were just reading (Clarion labels sit in column 0
+                    // there). Paired with the 30px nudge + smaller font in the .monaco-hover CSS.
+                    hover: { above: false }
                 });
                 installReadOnlyGuard();        // also marks the buffer dirty on each legal edit
                 installDropInsert(editor);     // accept Data-pad drops (plain text, at the drop point)
+                installHoverFontSizeSync(editor);  // keep the hover tooltip one px under the editor font
                 activeEditor = editor;         // commands target the focused pane; primary by default (#15)
                 editor.onDidFocusEditorText(function () { activeEditor = editor; });
                 // Flush the live buffer to the host immediately on blur (file mode), so the host's close-time copy
@@ -2696,7 +2716,8 @@
             wordWrap: s.wordWrap ? 'on' : 'off',
             autoIndent: s.autoIndent ? 'full' : 'keep',
             wordSeparators: "`~!@#$%^&*()-=+[{]}\\|;'\",.<>/?", // see primary editor: keep ':' in-word
-            dropIntoEditor: { enabled: false }                  // split pane: custom drop handler (installDropInsert)
+            dropIntoEditor: { enabled: false },                 // split pane: custom drop handler (installDropInsert)
+            hover: { above: false }                             // same as primary: hover below the line
         };
     }
 
@@ -3254,6 +3275,26 @@
         ed.focus();
     }
 
+    // Hover tooltips read one px smaller than the source text (--ca-hover-font-size, consumed by the
+    // .monaco-hover rule). Monaco has no hover-font option and the widget inherits the editor's inline
+    // font-size, so the value is mirrored here from fontInfo — which covers BOTH the gear panel's font
+    // size and Ctrl+wheel zoom, since either one raises onDidChangeConfiguration. Set on the root element
+    // because hovers can render outside the editor's own subtree (overflowing content widgets).
+    function installHoverFontSizeSync(ed) {
+        if (!ed) return;
+        var apply = function () {
+            try {
+                var fi = ed.getOption(monaco.editor.EditorOption.fontInfo);
+                var px = (fi && fi.fontSize) ? fi.fontSize : 13;
+                document.documentElement.style.setProperty('--ca-hover-font-size', Math.max(6, Math.round(px - 1)) + 'px');
+            } catch (e) { }
+        };
+        apply();
+        // Any option flip re-reads fontInfo — cheap, and avoids depending on which EditorOption id
+        // a given Monaco version reports for a font change.
+        ed.onDidChangeConfiguration(apply);
+    }
+
     // Native OS drop from the Data pad. We do NOT use Monaco's dropIntoEditor (it snippet-expands the
     // dropped text → "$0" artifacts). Insert plain text at the DROP POINT via the same executeEdits path
     // as the double-click insert, validated against the editable-slot guard.
@@ -3674,6 +3715,27 @@
                         return { contents: [{ value: resp.contents }] };
                     })
                     .catch(function () { return null; });
+            }
+        });
+        // Hover footers arrive from the LSP as markdown links to a location — "Foo.inc:12 → Foo.clw:340"
+        // is two independent links, each targeting file:///…#L<line>. Monaco parses the #L fragment into a
+        // selection itself, but then hands the file: URI to its DEFAULT opener, which treats it as an
+        // external link (window.open) — useless for a Clarion source file. Intercept and let the IDE
+        // navigate. Registered here (once, with the other providers) though link openers are global, not
+        // per-language; non-file schemes fall through to the default opener untouched.
+        monaco.editor.registerLinkOpener({
+            open: function (uri) {
+                if (!uri || uri.scheme !== 'file') return false;
+                // Hover footers only ever emit a bare #L<line> (see HoverFormatter.locationLink on the
+                // language-server side) — no column — matching what the host's navigation (EditorService.
+                // NavigateToFileAndLine, same as the open_file MCP tool) accepts.
+                var m = /^L?(\d+)/.exec(uri.fragment || '');
+                postToHost({
+                    action: 'openLocation',
+                    path: uri.fsPath,
+                    line: m ? (parseInt(m[1], 10) || 1) : 1
+                });
+                return true;   // handled — suppresses the external-open fallback
             }
         });
         // Signature help — parameter hints when typing '(' or ',' at a call site (mirrors VS Code).


### PR DESCRIPTION
# Monaco hover: reposition it, size it under the editor font, and make LSP location footers clickable

Three small, mostly-independent changes to the Monaco editor surface.

The main reason for moving the hover below the word and a bit to the right is that the eye movement to see the info is short and follows the left to right, top to bottom reading pattern. The first you focus on in the hover is the most relevant info. If placed above, a long description will force the eye to move out of the focus area.

&emsp;&emsp;<img width="535" height="130" alt="image" src="https://github.com/user-attachments/assets/0716ca6f-edd9-4973-947e-cb3e5e6b0bef" />

Additionally, as the file references (.clw/.inc) are there, why not make them clickable. 

**Companion PR**: `geircodes/Clarion-Extension#feat/hover-clickable-locations` (language-server side —
renders hover footer locations as clickable markdown links instead of plain text). This PR is inert but
harmless without it: nothing emits `file:` links today, so the link opener added here never fires until
the companion PR is deployed too. Originally scoped as a look-and-feel Issue+patch; re-scoped to a PR
given the combined size of the two changes.

---

## A. The hover covers the lines you were just reading

Monaco left-aligns the hover at the hovered word and, by default, prefers rendering it **above** the
line. when hovering a label the tooltip lands directly on the label column of the preceding lines — the context you were reading when you hovered.

Two coordinated fixes:

```js
hover: { above: false }        // in the editor options (primary + split pane)
```

```css
.monaco-editor .monaco-hover { transform: translateX(30px); }
```

`above: false` drops the tooltip below the hovered line; the 30px nudge keeps the column-0 label area
clear either way. The transform is visual only — Monaco's positioning math is untouched, and
`getBoundingClientRect` still reflects it, so mouse-into-hover (`hover.sticky`) keeps working.

**Known trade-off, retested and not reproduced**: Monaco doesn't know about the extra 30px when it fits
the widget horizontally, so a very wide hover near the right edge could in theory clip. Live-tested
hovering a variable close to the right edge — rendered correctly, not indented or clipped. Leaving the
trade-off note in place since the nudge genuinely isn't fit-aware, but no live repro found.

## B. The hover renders as loud as the source

The hover widget inherits the editor's inline `font-size`, so a code-heavy tooltip is exactly as big as
the code behind it. Monaco has no hover-font option, so:

```css
.monaco-editor .monaco-hover { font-size: var(--ca-hover-font-size, 12px); }
```

`--ca-hover-font-size` is mirrored from `fontInfo.fontSize - 1` by a small
`installHoverFontSizeSync(editor)` helper, refreshed on `onDidChangeConfiguration` — so it tracks
**both** the gear panel's font size and Ctrl+wheel zoom instead of pinning a constant. The variable is
set on the root element because hovers can render outside the editor's own subtree (overflowing content
widgets). Fenced code inside the hover declares no size of its own, so it scales along.

Note the non-code prose inside a hover (including a builtin's `**Built-in Function: X**` title line)
still renders in the page's UI font (Segoe UI), not the editor's monospace font — Monaco only assigns
the monospace font to actual `<code>` elements inside a hover. Same pixel size as the rest of the hover
either way; a bold/uppercase title next to regular-weight sans-serif text can still *look* bigger even
at an identical font-size, which is a font-metrics illusion, not a bug in this change.

## C. Hover location footers are now clickable

With the companion language-server change, hover footers arrive as markdown links —
`[demo.inc:2](file:///…/demo.inc#L2) → [demo.clw:3](file:///…/demo.clw#L3)`, each location its own
link. Monaco parses the `#L<line>` fragment into a selection itself, but then hands the `file:` URI to
its **default** opener, which treats it as an external link (`window.open`) — useless for a Clarion
source file.

Page side — intercept and hand it to the host (link openers are global, not per-language; non-file
schemes fall through to the default opener untouched):

```js
monaco.editor.registerLinkOpener({
    open: function (uri) {
        if (!uri || uri.scheme !== 'file') return false;
        var m = /^L?(\d+)/.exec(uri.fragment || '');
        postToHost({ action: 'openLocation', path: uri.fsPath, line: m ? (parseInt(m[1], 10) || 1) : 1 });
        return true;
    }
});
```

Host side — a new `openLocation` case in `MonacoEditorControl.OnWebMessageReceived`, handled **in the
control** rather than on `IMonacoEditorHost` (same reasoning as the existing `themeChanged` case), so
every Monaco surface gets it without each host implementing anything. It calls
`Services.MonacoSourceNavigator.NavigateToFileAndLine(path, line, 1)` — **not**
`Services.EditorService.NavigateToFileAndLine` (what `open_file` uses): that drives the *native* caret
correctly via `FileService.JumpToFilePosition`, but on a cold open the Monaco overlay's own first paint
is seeded from a separate mechanism entirely (`MonacoClarionSourceEditor.OnReady` →
`MonacoSourceNavigator.TryConsumePending`), which `EditorService` never touches — confirmed live: a
first click on a not-yet-open target landed on the wrong line, a second click (file now already open)
worked. `MonacoSourceNavigator.NavigateToFileAndLine` is the same method F12/Ctrl+F12 cross-file jump
already uses for this identical scenario, and routes correctly to both surfaces.

This mechanism depended on a separate cold-open navigation-race fix
(`fix/monaco-cold-open-navigation`, already merged upstream) for links to land on the right line on a
cold open. Already merged, so no outstanding dependency for this PR.

## Known gap, deliberately not chased here

Live testing surfaced a hover (a plain procedure call) showing a bare filename with no line number and
not clickable, where the filename itself was also wrong (gated behind a `COMPILE`/`OMIT` section the
resolver isn't aware of). One concrete non-linked spot was found directly on the language-server side:
`HoverRouter.ts`'s `handleImplementsHover` (hovering an interface name in `IMPLEMENTS(...)`) pushes a
bare filename string straight into the markdown, bypassing the link-rendering path entirely. Whether
that's the same root cause as the other case, or a separate symbol-resolution bug, wasn't chased down —
out of scope for this UI-focused PR, flagged for separate follow-up.

## Verification

- Builds clean.
- Monaco API surface confirmed against the bundled 0.52.2 (by extracting and reading the actual
  minified renderer, not assumed): `registerLinkOpener` exists; `OpenerService.registerOpener`
  **unshifts**, so our opener runs ahead of the default external one; hover-content anchors have their
  real `href` stripped and replaced with a `data-href`-driven click delegate that passes the FULL href
  string — fragment intact — through to `URI.parse()` before any registered opener sees it; the
  fragment parser is `/^L?(\d+)(?:,(\d+))?(-L?(\d+)(?:,(\d+))?)?/`; `Schemas.file` is in the sanitizer's
  default allowed scheme list unconditionally (only `command:` needs `isTrusted`); `hover.above` is a
  real editor option; `.monaco-hover` carries no `font-size` of its own, which is why it inherits the
  editor's.
- Live-tested by the developer across several rounds on a real deployment: position, font tracking
  (gear panel + Ctrl+wheel zoom), single- and multi-location link clickability, drive-letter/space
  encoding, and cold-open line landing all confirmed working correctly together.

## Scope

Two files: `Terminal/monaco-embeditor.html`, `Terminal/MonacoEditorControl.cs`.
