### PR TITLE
fix(codegraph): resolve caller attribution for overloaded procedures/methods

### DIFF
--- a/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/CodeGraph/Graph/CodeGraphIndexer.cs
@@ -563,16 +563,29 @@ namespace ClarionCodeGraph.Graph
             var procNames = new List<string>(); // ordered list for matching
             // File-specific lookup: filePath → (name → id) — resolves ambiguous names
             var symbolByFile = new Dictionary<string, Dictionary<string, long>>(StringComparer.OrdinalIgnoreCase);
+            // File-specific lookup: filePath → (definition line → id). Clarion allows several
+            // procedures/methods to share the exact same name via parameter-type overloading
+            // (e.g. a method declared once per parameter type) -- symbolByFile and
+            // symbolNameToId can only ever hold ONE id per name, so they silently collapse every
+            // overload onto whichever one happened to be inserted last (see the "Last wins"
+            // comment below). A procedure's own definition line is always unique per file, so
+            // it's used below to pick out the exact overload currentProcId/currentProcName
+            // should track while scanning that overload's own body.
+            var symbolLineByFile = new Dictionary<string, Dictionary<int, long>>(StringComparer.OrdinalIgnoreCase);
 
             var allSymDt = _db.ExecuteQuery(
-                "SELECT id, name, type, file_path FROM symbols WHERE type IN ('procedure','function','routine')");
+                "SELECT id, name, type, file_path, line_number FROM symbols WHERE type IN ('procedure','function','routine')");
 
             foreach (System.Data.DataRow row in allSymDt.Rows)
             {
                 string name = row["name"].ToString();
                 long id = Convert.ToInt64(row["id"]);
                 string filePath = row["file_path"].ToString();
-                // Last wins — implementation in member file overwrites MAP declaration
+                int lineNumber = row["line_number"] != DBNull.Value ? Convert.ToInt32(row["line_number"]) : -1;
+                // Last wins — implementation in member file overwrites MAP declaration. Also the
+                // known limitation this fix works around: for genuine overloads sharing a name,
+                // only the last-loaded one survives here. symbolLineByFile above is the
+                // disambiguated path for anything that needs the correct per-overload id.
                 symbolNameToId[name] = id;
 
                 // Build per-file symbol lookup
@@ -583,6 +596,17 @@ namespace ClarionCodeGraph.Graph
                     symbolByFile[filePath] = fileSymbols;
                 }
                 fileSymbols[name] = id;
+
+                if (lineNumber > 0)
+                {
+                    Dictionary<int, long> fileSymbolsByLine;
+                    if (!symbolLineByFile.TryGetValue(filePath, out fileSymbolsByLine))
+                    {
+                        fileSymbolsByLine = new Dictionary<int, long>();
+                        symbolLineByFile[filePath] = fileSymbolsByLine;
+                    }
+                    fileSymbolsByLine[lineNumber] = id;
+                }
 
                 // Only add procedures/functions from .clw files to the match list.
                 // Skip: routines, dotted names (class method implementations),
@@ -757,13 +781,18 @@ namespace ClarionCodeGraph.Graph
                     int localClassEndDepth = 0;
                     // The parent (first) procedure in each member file owns all calls
                     long parentProcId = -1;
+                    string parentProcName = null;
                     // Track local MAP procedure names — skip these as call targets
                     var localMapNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                    // Get file-specific symbol lookup for this file
-                    Dictionary<string, long> currentFileSymbols;
-                    if (!symbolByFile.TryGetValue(target.Path, out currentFileSymbols))
-                        currentFileSymbols = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+                    // Get file-specific (definition line → id) lookup. Used (instead of a
+                    // name-keyed lookup) everywhere the exact overload matters, since
+                    // symbolByFile/symbolNameToId can only hold one id per name and would
+                    // collapse same-named overloads onto whichever loaded last (see
+                    // symbolLineByFile's comment above).
+                    Dictionary<int, long> currentFileSymbolsByLine;
+                    if (!symbolLineByFile.TryGetValue(target.Path, out currentFileSymbolsByLine))
+                        currentFileSymbolsByLine = new Dictionary<int, long>();
 
                     // Load variables for this file
                     List<VariableInfo> currentFileVars;
@@ -783,11 +812,14 @@ namespace ClarionCodeGraph.Graph
                             {
                                 foundFirstProc = true;
                                 string matchName = firstMatch.Groups[1].Value;
-                                // Use ONLY file-specific lookup to avoid cross-file name collisions.
-                                // symbolNameToId may return a symbol from a different file if names collide.
+                                // Resolve by (file, definition line), not name alone -- see the
+                                // overload note where currentProcId is updated the same way below.
                                 long id;
-                                if (currentFileSymbols.TryGetValue(matchName, out id))
+                                if (currentFileSymbolsByLine.TryGetValue(p + 1, out id))
+                                {
                                     parentProcId = id;
+                                    parentProcName = matchName;
+                                }
                             }
                             continue;
                         }
@@ -817,6 +849,7 @@ namespace ClarionCodeGraph.Graph
                     if (parentProcId < 0) continue;
 
                     long currentProcId = parentProcId;
+                    string currentProcName = parentProcName;
                     bool seenFirstCode = false;
 
                     for (int i = target.StartLine; i < lines.Length; i++)
@@ -906,7 +939,7 @@ namespace ClarionCodeGraph.Graph
                             string matchedName = procMatch.Groups[1].Value;
                             // Update currentProcId for both top-level procedures AND class method
                             // implementations (ClassName.Method). Dotted method names resolve through
-                            // currentFileSymbols (the same lookup SELF.Method uses), so calls made
+                            // currentFileSymbolsByLine (the same lookup SELF.Method uses), so calls made
                             // inside a class method are attributed to that method — not to whatever
                             // procedure was recognized before it (issue #54, Bug 2). The old
                             // `!matchedName.Contains(".")` guard skipped every class-method
@@ -928,16 +961,28 @@ namespace ClarionCodeGraph.Graph
                             if (localMapNames.Contains(matchedName))
                             {
                                 currentProcId = parentProcId;
+                                currentProcName = parentProcName;
                                 continue;
                             }
-                            // Use ONLY file-specific lookup to avoid cross-file name collisions.
-                            // If the symbol isn't in this file's symbols, reset to parentProcId
-                            // rather than risking a match to a same-named symbol in another file.
+                            // Resolve by (file, exact definition line) rather than name alone --
+                            // Clarion allows multiple procedures/methods to share the same name via
+                            // parameter-type overloading (e.g. several same-named overloads
+                            // differing only by parameter type), which a name-keyed lookup can't
+                            // distinguish: it silently collapses onto whichever overload happened
+                            // to load last (see symbolLineByFile's comment above). procDefRegex only
+                            // ever matches a procedure's own definition line, so (file, line) is
+                            // unambiguous here.
                             long id;
-                            if (currentFileSymbols.TryGetValue(matchedName, out id))
+                            if (currentFileSymbolsByLine.TryGetValue(i + 1, out id))
+                            {
                                 currentProcId = id;
+                                currentProcName = matchedName;
+                            }
                             else
+                            {
                                 currentProcId = parentProcId;
+                                currentProcName = parentProcName;
+                            }
                             continue;
                         }
 
@@ -996,17 +1041,14 @@ namespace ClarionCodeGraph.Graph
                             // procedure symbol, so this can't manufacture a false "calls" edge -- it only
                             // stops erasing real ones.
 
-                            // Try to resolve as ClassName.MethodName using the current procedure's class
-                            string callerName = null;
-                            // Look up current proc name to find its class prefix
-                            foreach (var kvp2 in symbolNameToId)
-                            {
-                                if (kvp2.Value == currentProcId && kvp2.Key.Contains("."))
-                                {
-                                    callerName = kvp2.Key;
-                                    break;
-                                }
-                            }
+                            // Try to resolve as ClassName.MethodName using the current procedure's
+                            // class. currentProcName is tracked directly alongside currentProcId
+                            // (overload-safe -- see the update above) rather than reverse-scanned
+                            // from symbolNameToId: a reverse scan can't tell which of several
+                            // same-named overloads currentProcId actually refers to.
+                            string callerName = (currentProcName != null && currentProcName.Contains("."))
+                                ? currentProcName
+                                : null;
                             if (callerName != null)
                             {
                                 string className = callerName.Substring(0, callerName.LastIndexOf('.'));
@@ -1058,8 +1100,6 @@ namespace ClarionCodeGraph.Graph
                             bool foundLocalVar = false;
                             if (currentFileVars != null)
                             {
-                                string currentProcNameForParamScope = null;
-                                bool triedCurrentProcNameForParamScope = false;
                                 foreach (var varInfo in currentFileVars)
                                 {
                                     if (!string.Equals(varInfo.Name, objName, StringComparison.OrdinalIgnoreCase))
@@ -1069,18 +1109,12 @@ namespace ClarionCodeGraph.Graph
                                     // same parameter name can carry a different type in a different
                                     // procedure in the same file, so the file-wide-by-name matching
                                     // that's safe for DATA locals (see Bug 1/#54) is not safe here.
+                                    // currentProcName is tracked directly alongside currentProcId
+                                    // (overload-safe -- see the update above), not reverse-scanned.
                                     if (string.Equals(varInfo.Scope, "parameter", StringComparison.OrdinalIgnoreCase))
                                     {
-                                        if (!triedCurrentProcNameForParamScope)
-                                        {
-                                            triedCurrentProcNameForParamScope = true;
-                                            foreach (var kvp4 in currentFileSymbols)
-                                            {
-                                                if (kvp4.Value == currentProcId) { currentProcNameForParamScope = kvp4.Key; break; }
-                                            }
-                                        }
-                                        if (currentProcNameForParamScope == null ||
-                                            !string.Equals(varInfo.ParentName, currentProcNameForParamScope, StringComparison.OrdinalIgnoreCase))
+                                        if (currentProcName == null ||
+                                            !string.Equals(varInfo.ParentName, currentProcName, StringComparison.OrdinalIgnoreCase))
                                             continue; // wrong procedure's parameter of the same name -- skip
                                     }
 
@@ -1100,15 +1134,12 @@ namespace ClarionCodeGraph.Graph
                             // class-name derivation already used for SELF.Method resolution above.
                             if (!foundLocalVar)
                             {
-                                string ownerClassName = null;
-                                foreach (var kvp3 in symbolNameToId)
-                                {
-                                    if (kvp3.Value == currentProcId && kvp3.Key.Contains("."))
-                                    {
-                                        ownerClassName = kvp3.Key.Substring(0, kvp3.Key.LastIndexOf('.'));
-                                        break;
-                                    }
-                                }
+                                // currentProcName is tracked directly alongside currentProcId
+                                // (overload-safe -- see the update above), not reverse-scanned
+                                // from symbolNameToId.
+                                string ownerClassName = (currentProcName != null && currentProcName.Contains("."))
+                                    ? currentProcName.Substring(0, currentProcName.LastIndexOf('.'))
+                                    : null;
                                 if (ownerClassName != null)
                                 {
                                     // Walk the inheritance chain: try the current class first, then
@@ -1193,17 +1224,10 @@ namespace ClarionCodeGraph.Graph
                                 // - local vars and parameters are only visible to their owning procedure
                                 if ((varInfo.Scope == "local" || varInfo.Scope == "parameter") && varInfo.ParentName != null)
                                 {
-                                    // Check if this var belongs to the current procedure
-                                    // currentProcId must match the procedure that owns this variable
-                                    string currentProcName = null;
-                                    foreach (var kvp2 in currentFileSymbols)
-                                    {
-                                        if (kvp2.Value == currentProcId)
-                                        {
-                                            currentProcName = kvp2.Key;
-                                            break;
-                                        }
-                                    }
+                                    // Check if this var belongs to the current procedure.
+                                    // currentProcName is tracked directly alongside currentProcId
+                                    // (overload-safe -- see the update above), not reverse-scanned
+                                    // from a name-keyed symbol lookup.
                                     if (currentProcName == null ||
                                         !string.Equals(varInfo.ParentName, currentProcName, StringComparison.OrdinalIgnoreCase))
                                         continue;

--- a/ClarionAssistant/indexer/Graph/CodeGraphIndexer.cs
+++ b/ClarionAssistant/indexer/Graph/CodeGraphIndexer.cs
@@ -559,16 +559,29 @@ namespace ClarionCodeGraph.Graph
             var procNames = new List<string>(); // ordered list for matching
             // File-specific lookup: filePath → (name → id) — resolves ambiguous names
             var symbolByFile = new Dictionary<string, Dictionary<string, long>>(StringComparer.OrdinalIgnoreCase);
+            // File-specific lookup: filePath → (definition line → id). Clarion allows several
+            // procedures/methods to share the exact same name via parameter-type overloading
+            // (e.g. a method declared once per parameter type) -- symbolByFile and
+            // symbolNameToId can only ever hold ONE id per name, so they silently collapse every
+            // overload onto whichever one happened to be inserted last (see the "Last wins"
+            // comment below). A procedure's own definition line is always unique per file, so
+            // it's used below to pick out the exact overload currentProcId/currentProcName
+            // should track while scanning that overload's own body.
+            var symbolLineByFile = new Dictionary<string, Dictionary<int, long>>(StringComparer.OrdinalIgnoreCase);
 
             var allSymDt = _db.ExecuteQuery(
-                "SELECT id, name, type, file_path FROM symbols WHERE type IN ('procedure','function','routine')");
+                "SELECT id, name, type, file_path, line_number FROM symbols WHERE type IN ('procedure','function','routine')");
 
             foreach (System.Data.DataRow row in allSymDt.Rows)
             {
                 string name = row["name"].ToString();
                 long id = Convert.ToInt64(row["id"]);
                 string filePath = row["file_path"].ToString();
-                // Last wins — implementation in member file overwrites MAP declaration
+                int lineNumber = row["line_number"] != DBNull.Value ? Convert.ToInt32(row["line_number"]) : -1;
+                // Last wins — implementation in member file overwrites MAP declaration. Also the
+                // known limitation this fix works around: for genuine overloads sharing a name,
+                // only the last-loaded one survives here. symbolLineByFile above is the
+                // disambiguated path for anything that needs the correct per-overload id.
                 symbolNameToId[name] = id;
 
                 // Build per-file symbol lookup
@@ -579,6 +592,17 @@ namespace ClarionCodeGraph.Graph
                     symbolByFile[filePath] = fileSymbols;
                 }
                 fileSymbols[name] = id;
+
+                if (lineNumber > 0)
+                {
+                    Dictionary<int, long> fileSymbolsByLine;
+                    if (!symbolLineByFile.TryGetValue(filePath, out fileSymbolsByLine))
+                    {
+                        fileSymbolsByLine = new Dictionary<int, long>();
+                        symbolLineByFile[filePath] = fileSymbolsByLine;
+                    }
+                    fileSymbolsByLine[lineNumber] = id;
+                }
 
                 // Only add procedures/functions from .clw files to the match list.
                 // Skip: routines, dotted names (class method implementations),
@@ -753,13 +777,18 @@ namespace ClarionCodeGraph.Graph
                     int localClassEndDepth = 0;
                     // The parent (first) procedure in each member file owns all calls
                     long parentProcId = -1;
+                    string parentProcName = null;
                     // Track local MAP procedure names — skip these as call targets
                     var localMapNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                    // Get file-specific symbol lookup for this file
-                    Dictionary<string, long> currentFileSymbols;
-                    if (!symbolByFile.TryGetValue(target.Path, out currentFileSymbols))
-                        currentFileSymbols = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+                    // Get file-specific (definition line → id) lookup. Used (instead of a
+                    // name-keyed lookup) everywhere the exact overload matters, since
+                    // symbolByFile/symbolNameToId can only hold one id per name and would
+                    // collapse same-named overloads onto whichever loaded last (see
+                    // symbolLineByFile's comment above).
+                    Dictionary<int, long> currentFileSymbolsByLine;
+                    if (!symbolLineByFile.TryGetValue(target.Path, out currentFileSymbolsByLine))
+                        currentFileSymbolsByLine = new Dictionary<int, long>();
 
                     // Load variables for this file
                     List<VariableInfo> currentFileVars;
@@ -779,11 +808,14 @@ namespace ClarionCodeGraph.Graph
                             {
                                 foundFirstProc = true;
                                 string matchName = firstMatch.Groups[1].Value;
-                                // Use ONLY file-specific lookup to avoid cross-file name collisions.
-                                // symbolNameToId may return a symbol from a different file if names collide.
+                                // Resolve by (file, definition line), not name alone -- see the
+                                // overload note where currentProcId is updated the same way below.
                                 long id;
-                                if (currentFileSymbols.TryGetValue(matchName, out id))
+                                if (currentFileSymbolsByLine.TryGetValue(p + 1, out id))
+                                {
                                     parentProcId = id;
+                                    parentProcName = matchName;
+                                }
                             }
                             continue;
                         }
@@ -813,6 +845,7 @@ namespace ClarionCodeGraph.Graph
                     if (parentProcId < 0) continue;
 
                     long currentProcId = parentProcId;
+                    string currentProcName = parentProcName;
                     bool seenFirstCode = false;
 
                     for (int i = target.StartLine; i < lines.Length; i++)
@@ -902,7 +935,7 @@ namespace ClarionCodeGraph.Graph
                             string matchedName = procMatch.Groups[1].Value;
                             // Update currentProcId for both top-level procedures AND class method
                             // implementations (ClassName.Method). Dotted method names resolve through
-                            // currentFileSymbols (the same lookup SELF.Method uses), so calls made
+                            // currentFileSymbolsByLine (the same lookup SELF.Method uses), so calls made
                             // inside a class method are attributed to that method — not to whatever
                             // procedure was recognized before it (issue #54, Bug 2). The old
                             // `!matchedName.Contains(".")` guard skipped every class-method
@@ -924,16 +957,28 @@ namespace ClarionCodeGraph.Graph
                             if (localMapNames.Contains(matchedName))
                             {
                                 currentProcId = parentProcId;
+                                currentProcName = parentProcName;
                                 continue;
                             }
-                            // Use ONLY file-specific lookup to avoid cross-file name collisions.
-                            // If the symbol isn't in this file's symbols, reset to parentProcId
-                            // rather than risking a match to a same-named symbol in another file.
+                            // Resolve by (file, exact definition line) rather than name alone --
+                            // Clarion allows multiple procedures/methods to share the same name via
+                            // parameter-type overloading (e.g. several same-named overloads
+                            // differing only by parameter type), which a name-keyed lookup can't
+                            // distinguish: it silently collapses onto whichever overload happened
+                            // to load last (see symbolLineByFile's comment above). procDefRegex only
+                            // ever matches a procedure's own definition line, so (file, line) is
+                            // unambiguous here.
                             long id;
-                            if (currentFileSymbols.TryGetValue(matchedName, out id))
+                            if (currentFileSymbolsByLine.TryGetValue(i + 1, out id))
+                            {
                                 currentProcId = id;
+                                currentProcName = matchedName;
+                            }
                             else
+                            {
                                 currentProcId = parentProcId;
+                                currentProcName = parentProcName;
+                            }
                             continue;
                         }
 
@@ -992,17 +1037,14 @@ namespace ClarionCodeGraph.Graph
                             // procedure symbol, so this can't manufacture a false "calls" edge -- it only
                             // stops erasing real ones.
 
-                            // Try to resolve as ClassName.MethodName using the current procedure's class
-                            string callerName = null;
-                            // Look up current proc name to find its class prefix
-                            foreach (var kvp2 in symbolNameToId)
-                            {
-                                if (kvp2.Value == currentProcId && kvp2.Key.Contains("."))
-                                {
-                                    callerName = kvp2.Key;
-                                    break;
-                                }
-                            }
+                            // Try to resolve as ClassName.MethodName using the current procedure's
+                            // class. currentProcName is tracked directly alongside currentProcId
+                            // (overload-safe -- see the update above) rather than reverse-scanned
+                            // from symbolNameToId: a reverse scan can't tell which of several
+                            // same-named overloads currentProcId actually refers to.
+                            string callerName = (currentProcName != null && currentProcName.Contains("."))
+                                ? currentProcName
+                                : null;
                             if (callerName != null)
                             {
                                 string className = callerName.Substring(0, callerName.LastIndexOf('.'));
@@ -1054,8 +1096,6 @@ namespace ClarionCodeGraph.Graph
                             bool foundLocalVar = false;
                             if (currentFileVars != null)
                             {
-                                string currentProcNameForParamScope = null;
-                                bool triedCurrentProcNameForParamScope = false;
                                 foreach (var varInfo in currentFileVars)
                                 {
                                     if (!string.Equals(varInfo.Name, objName, StringComparison.OrdinalIgnoreCase))
@@ -1065,18 +1105,12 @@ namespace ClarionCodeGraph.Graph
                                     // same parameter name can carry a different type in a different
                                     // procedure in the same file, so the file-wide-by-name matching
                                     // that's safe for DATA locals (see Bug 1/#54) is not safe here.
+                                    // currentProcName is tracked directly alongside currentProcId
+                                    // (overload-safe -- see the update above), not reverse-scanned.
                                     if (string.Equals(varInfo.Scope, "parameter", StringComparison.OrdinalIgnoreCase))
                                     {
-                                        if (!triedCurrentProcNameForParamScope)
-                                        {
-                                            triedCurrentProcNameForParamScope = true;
-                                            foreach (var kvp4 in currentFileSymbols)
-                                            {
-                                                if (kvp4.Value == currentProcId) { currentProcNameForParamScope = kvp4.Key; break; }
-                                            }
-                                        }
-                                        if (currentProcNameForParamScope == null ||
-                                            !string.Equals(varInfo.ParentName, currentProcNameForParamScope, StringComparison.OrdinalIgnoreCase))
+                                        if (currentProcName == null ||
+                                            !string.Equals(varInfo.ParentName, currentProcName, StringComparison.OrdinalIgnoreCase))
                                             continue; // wrong procedure's parameter of the same name -- skip
                                     }
 
@@ -1096,15 +1130,12 @@ namespace ClarionCodeGraph.Graph
                             // class-name derivation already used for SELF.Method resolution above.
                             if (!foundLocalVar)
                             {
-                                string ownerClassName = null;
-                                foreach (var kvp3 in symbolNameToId)
-                                {
-                                    if (kvp3.Value == currentProcId && kvp3.Key.Contains("."))
-                                    {
-                                        ownerClassName = kvp3.Key.Substring(0, kvp3.Key.LastIndexOf('.'));
-                                        break;
-                                    }
-                                }
+                                // currentProcName is tracked directly alongside currentProcId
+                                // (overload-safe -- see the update above), not reverse-scanned
+                                // from symbolNameToId.
+                                string ownerClassName = (currentProcName != null && currentProcName.Contains("."))
+                                    ? currentProcName.Substring(0, currentProcName.LastIndexOf('.'))
+                                    : null;
                                 if (ownerClassName != null)
                                 {
                                     // Walk the inheritance chain: try the current class first, then
@@ -1189,17 +1220,10 @@ namespace ClarionCodeGraph.Graph
                                 // - local vars and parameters are only visible to their owning procedure
                                 if ((varInfo.Scope == "local" || varInfo.Scope == "parameter") && varInfo.ParentName != null)
                                 {
-                                    // Check if this var belongs to the current procedure
-                                    // currentProcId must match the procedure that owns this variable
-                                    string currentProcName = null;
-                                    foreach (var kvp2 in currentFileSymbols)
-                                    {
-                                        if (kvp2.Value == currentProcId)
-                                        {
-                                            currentProcName = kvp2.Key;
-                                            break;
-                                        }
-                                    }
+                                    // Check if this var belongs to the current procedure.
+                                    // currentProcName is tracked directly alongside currentProcId
+                                    // (overload-safe -- see the update above), not reverse-scanned
+                                    // from a name-keyed symbol lookup.
                                     if (currentProcName == null ||
                                         !string.Equals(varInfo.ParentName, currentProcName, StringComparison.OrdinalIgnoreCase))
                                         continue;

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -2,9 +2,10 @@
 
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
 the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92), the GROUP-typed CLASS-member fix
-(PR #93), the inherited-CLASS-member dotted-call resolution fix (PR #112), and the
-built-in-name-collision fix (PR #118) — a single compiling Clarion solution whose procedures each
-exercise one historical parser/indexer bug. This is currently the only regression coverage the
+(PR #93), the inherited-CLASS-member dotted-call resolution fix (PR #112), the
+built-in-name-collision fix (PR #118), issue #97's attrs+same-line-terminator fix, and the
+overload-attribution fix (Bug P, this PR) — a single compiling Clarion solution whose procedures
+each exercise one historical parser/indexer bug. This is currently the only regression coverage the
 CodeGraph parser has; run it after ANY change to `Parsing/ClarionParser.cs` or
 `Graph/CodeGraphIndexer.cs` (either synced copy).
 
@@ -21,10 +22,10 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 ```
 
 ## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, #112, and
-#118, then re-verified with #97; line numbers below reflect the fixture AFTER #97's
-`AttrTermLocalGroupTest` addition)
+#118, then re-verified with #97 and with Bug P (this PR); line numbers below reflect the fixture
+AFTER Bug P's `OverloadBugClass.Dispatch` addition)
 
-### Callers of `WorkerClass.Sign` — exactly 21 `calls` rows
+### Callers of `WorkerClass.Sign` — exactly 22 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
@@ -49,8 +50,9 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 | LikeMemberBugClass.CallViaPlainInstanceMember | 309 | #92 (call through a reference CLASS member, unaffected control) |
 | MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 327 | #93 (member after multi-line GROUP with its own extra field) |
 | DerivedWorkerClass.CallViaInheritedMember | 338 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
+| OverloadBugClass.Dispatch (LONG overload) | 349 | Bug P (own overload's call, correctly self-attributed — not misattributed to the CSTRING overload) |
 
-### Callers of `WorkerClass.Ask` — exactly 2 `calls` rows (Bug N, **fixed in #118**)
+### Callers of `WorkerClass.Ask` — exactly 3 `calls` rows (Bug N fixed in #118, +1 from Bug P)
 
 `Ask` is identical in shape to `Sign` (same class, same signature) — the only difference is its
 name, which happens to collide with the Clarion built-in `ASK()` window/UI statement. Both call
@@ -61,6 +63,7 @@ SAME call site, so the two can be compared line-for-line:
 |---|---|---|---|
 | TestSignatureFlow | 30 | line 25 (`worker.Sign( 1 )`) | DATA-section local variable (baseline path) |
 | OwnerClass.CallViaMember | 69 | line 63 (`SELF.MyWorker.Sign( 10 )`) | cross-file CLASS member (#84/#86, and #112's inheritance walk when applicable) |
+| OverloadBugClass.Dispatch (CSTRING overload) | 368 | line 349 (`worker.Sign( pValue )`, LONG overload) | Bug P — sibling overload's call, correctly self-attributed to the CSTRING overload's own line (363), not the LONG overload's (346) |
 
 **Root cause (fixed by #118)**: `"ASK"` is in `ClarionBuiltins.cs`'s `_builtins` set (window/UI
 statement). Before #118 both the `SELF.Method` and the dotted `ObjectName.Method` call-detection
@@ -78,6 +81,41 @@ built-in/keyword collision was confirmed against a production Clarion solution a
 `Empty`, `Reset`, `Get`, `Put`, `Update`, `Destroy` — all real Clarion built-in keywords also used
 as ordinary ABC-style class method names), suggesting a substantial number of currently-invisible
 calls solution-wide, not a narrow edge case.
+
+### Bug P: overloaded procedure/method names collapsed onto one arbitrary overload
+
+`OverloadBugClass.Dispatch` is declared twice with the exact same name, differing only by
+parameter type (`LONG` vs `*CSTRING`) — a real, legal Clarion overload. `ResolveRelationships`
+tracked "which procedure is this source line inside" (`currentProcId`) via dictionaries keyed by
+name only (`symbolByFile`/`symbolNameToId`), which can hold just one id per name. Before this fix,
+every line inside **both** `Dispatch` bodies — every call, every variable reference — collapsed
+onto whichever overload happened to be inserted last, regardless of which overload's body the
+scanner was actually inside.
+
+The CSTRING overload delegates to the LONG overload via `SELF.Dispatch(...)`, the same general
+shape as the real-world case that motivated this fix (an overload calling a sibling overload of
+the same name via `SELF.Method(...)`). Each overload calls a different, distinguishable target
+(`WorkerClass.Sign` from the LONG overload, `WorkerClass.Ask` from the CSTRING overload) so the two
+bodies' own calls can be told apart in the results:
+
+- **Before the fix**: both `worker.Sign(pValue)` (inside the LONG overload) and `worker.Ask(result)`
+  (inside the CSTRING overload) would be attributed as coming from the SAME one overload symbol —
+  whichever loaded last — never from their own respective overloads.
+- **After the fix**: `WorkerClass.Sign` gains exactly one caller row from `OverloadBugClass.Dispatch`
+  at line 349, correctly attributed to the LONG overload's own definition line (346). `WorkerClass.Ask`
+  gains exactly one caller row from `OverloadBugClass.Dispatch` at line 368, correctly attributed to
+  the CSTRING overload's own definition line (363) — a different id than the Sign caller above, even
+  though both share the literal name `OverloadBugClass.Dispatch`.
+
+**Deliberately NOT fixed by this change, and not a regression if still true**: the
+`SELF.Dispatch(99)` call at line 367 (inside the CSTRING overload, intending to call the LONG
+overload) still resolves its call *target* to the CSTRING overload itself (i.e. `to_id`'s
+definition line is 363, not 346) — call-target resolution for an overloaded name still isn't
+type-aware; it still picks whichever overload loaded last, same as before this fix. This fix only
+corrects the *caller* side (`currentProcId`/`currentProcName` — "which procedure is this line
+inside"), not the *callee* side (which overload a given call site actually invokes). Per-overload
+caller *counts* (grouping by `to_id` for an overloaded name) remain unreliable; "what does this
+specific overload call" (grouping by `from_id`) is now correct.
 
 ### Symbols
 
@@ -130,6 +168,11 @@ calls solution-wide, not a narrow edge case.
   as correctly as `WorkerClass.Sign` right next to it (proving the symbol/parsing side was always
   unaffected) — the bug was entirely in call-site resolution, not symbol capture. Compare against
   the "Callers of `WorkerClass.Ask`" table above.
+- `OverloadBugClass.Dispatch` (Bug P, this PR): two `procedure` symbols sharing the identical
+  name, at lines 346 (`( LONG pValue )`) and 363 (`( *CSTRING pValue )`) — both were ALWAYS
+  correctly stored as two distinct symbols (proving, like Bug N, that the bug was entirely in
+  relationship resolution, not symbol capture). Compare against the "Bug P" writeup and the
+  `WorkerClass.Sign`/`WorkerClass.Ask` caller tables above.
 
 ### Program symbol (#81)
 
@@ -144,13 +187,23 @@ SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
--- Bug N (fixed in #118): expect 2 rows (TestSignatureFlow line 30, OwnerClass.CallViaMember
--- line 69). If this drops back to 0, Bug N has regressed — the built-in-named method is being
--- erased at the dotted/SELF. call sites again.
+-- Bug N (fixed in #118): expect 3 rows (TestSignatureFlow line 30, OwnerClass.CallViaMember
+-- line 69, OverloadBugClass.Dispatch line 368 -- the last one is Bug P's addition, not Bug N's).
+-- If this drops back to 0, Bug N has regressed — the built-in-named method is being erased at
+-- the dotted/SELF. call sites again.
 SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Ask' AND r.type='calls' ORDER BY r.line_number;
 
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
 OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','GenCertData','SomeHandle','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember','AttrTermGroup','AttrTermGroupPeriod','BaseWorker');
+
+-- Bug P: expect the LONG overload (line 346) as the sole caller of WorkerClass.Sign here, and
+-- the CSTRING overload (line 363) as the sole caller of WorkerClass.Ask -- never the same
+-- overload's line for both.
+SELECT s_to.name AS callee, r.line_number, s_from.line_number AS from_overload_def_line
+FROM relationships r
+JOIN symbols s_to ON r.to_id = s_to.id
+JOIN symbols s_from ON r.from_id = s_from.id
+WHERE s_to.name IN ('WorkerClass.Sign','WorkerClass.Ask') AND s_from.name = 'OverloadBugClass.Dispatch';
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -339,3 +339,32 @@ result   LONG
   DISPOSE( SELF.BaseWorker )
   RETURN result
 
+! Bug P repro: the LONG overload -- the "real work" implementation. Calls WorkerClass.Sign,
+! a distinct, identifiable target from the CSTRING overload below (which calls
+! WorkerClass.Ask instead), so the two overload bodies' OWN calls can be told apart in the
+! results. See WorkerLib.inc for the declaration and README.md for the full writeup.
+OverloadBugClass.Dispatch PROCEDURE( LONG pValue )
+worker WorkerClass
+  CODE
+  RETURN worker.Sign( pValue )
+
+! Bug P repro: the CSTRING overload -- delegates to the LONG overload above via
+! SELF.Dispatch(...), the same general shape as the real production case that motivated this
+! fix (an overload calling a sibling overload of the same name via SELF.Method(...)). Before
+! this fix, every line inside this body -- including this SELF.Dispatch(...) call and the
+! worker.Ask(...) call below -- was misattributed as coming from the LONG overload above
+! instead of from here (both overloads share the exact same declared name, and the old
+! name-keyed currentProcId lookup can only ever resolve to one of them). Expected AFTER the
+! fix: WorkerClass.Sign gains exactly one more caller (this overload's OWN symbol, from the
+! LONG overload above) and WorkerClass.Ask gains exactly one more caller (this overload's OWN
+! symbol) -- not both attributed to the same one. Note: the SELF.Dispatch(99) call's TARGET
+! resolution (which overload it calls) is a SEPARATE, still-open limitation (call-target
+! overload resolution isn't type-aware yet) -- this repro only asserts the CALLER side.
+OverloadBugClass.Dispatch PROCEDURE( *CSTRING pValue )
+result LONG
+worker WorkerClass
+  CODE
+  result = SELF.Dispatch( 99 )
+  result = worker.Ask( result )
+  RETURN result
+

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -124,3 +124,16 @@ DerivedWorkerClass CLASS(BaseWorkerClass),TYPE, MODULE('WorkerLib.CLW'), LINK('W
 
 CallViaInheritedMember PROCEDURE( ), LONG
             END
+
+! Bug P repro: Dispatch is declared TWICE with the exact same name, differing only by
+! parameter type (LONG vs *CSTRING) -- a real, legal Clarion overload. CodeGraphIndexer.cs's
+! ResolveRelationships tracked "which procedure is this line inside" (currentProcId) via a
+! name-keyed dictionary (symbolByFile/symbolNameToId) that can only hold ONE id per name -- so
+! every line inside BOTH bodies collapsed onto whichever overload happened to load last,
+! regardless of which one the scanner was actually inside. See WorkerLib.clw for the two
+! implementations and README.md for the full writeup + expected before/after counts.
+OverloadBugClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
+
+Dispatch      PROCEDURE( LONG pValue ), LONG
+Dispatch      PROCEDURE( *CSTRING pValue ), LONG
+            END


### PR DESCRIPTION
## Summary

CodeGraph's "what does this procedure/method call" resolution silently collapses every overloaded
Clarion procedure or class method (several declarations sharing the exact same name, differing only
by parameter type — a legal, common Clarion pattern) onto a single arbitrary overload. Every call
and variable reference made from *any* of the overloads' bodies gets attributed to whichever overload
happened to be loaded last, regardless of which overload's body the scanner was actually inside.

Confirmed against a real production Clarion solution: **65 distinct overloaded names** (2 to 6 overloads each,
145 overload symbols total), with **4,372 `calls`/`references` relationship rows** collapsed onto
one overload per name. Only 66 of those 145 overload symbols ever appeared as a caller of anything
in any query — the other 79 were completely invisible; asking "what does this specific overload
call?" for any of them silently returned nothing, or someone else's calls. After the fix: 139 of 145
now correctly appear as callers (the remaining 6 have genuinely empty bodies).

## Root cause

`ResolveRelationships` in `CodeGraphIndexer.cs` tracks "which procedure is the current source line
inside" (`currentProcId`) via dictionaries keyed by **name only**:

- `symbolByFile` / the per-file `currentFileSymbols` lookup (`filePath → name → id`)
- `symbolNameToId` (global `name → id`, explicitly documented as "last wins — implementation in
  member file overwrites MAP declaration")

Both can hold exactly one id per name. That's fine for the one case the "last wins" comment was
written for (a MAP forward-declaration and its later real implementation, both surfacing under the
same name). It silently breaks for genuine overloading: several *simultaneously real* procedures
sharing one name each get their own row in the `symbols` table (correct — the symbol/parsing side was
never the problem), but the relationship-resolution pass's `currentProcId = currentFileSymbols[matchedName]`
lookup can only ever return one of them — the one every OTHER overload's calls/references also get
attributed to, incorrectly.

Four other places in the same method **reverse-scan** one of these name-keyed dictionaries looking
for "the entry whose value equals `currentProcId`" (to recover the current procedure's *name*, e.g.
to derive its owning class for `SELF.Method` resolution, or to scope a parameter lookup to the right
procedure). These are independently broken by the same root cause: even fixing the id-side lookup
above doesn't fix these, since a reverse scan over a name-keyed dict still can't distinguish which of
several overloads sharing one dictionary entry a given id actually belongs to.

## Fix

Added a new per-file `(definition line → id)` lookup (`symbolLineByFile` / `currentFileSymbolsByLine`),
populated from the `symbols` table's existing `line_number` column (only the `SELECT` needed
widening). `procDefRegex` only ever matches a line that *is* a procedure's own definition line, so
resolving `currentProcId` by `(file, exact line)` instead of `(file, name)` is unambiguous regardless
of how many overloads share a name — no heuristics, no signature parsing needed for this half of the
problem.

Introduced a `currentProcName` string, updated in lockstep with `currentProcId` at every one of its
three assignment sites (initialization from `parentProcId`, the local-MAP reset case, and the main
per-line resolution case), and used it to replace all four reverse-scan loops directly — since the
matched procedure's name text is already in hand at the exact moment `currentProcId` is resolved,
no scan is needed at all.

Applied identically to both synced copies (`CodeGraph/Graph/CodeGraphIndexer.cs`, the in-process
copy, and `indexer/Graph/CodeGraphIndexer.cs`, the standalone CLI copy).

**Independent code-reviewer agent verification done before applying** (per this project's standard
practice): walked every `currentProcId` assignment site to confirm `currentProcName` is correctly
paired at all of them (one initially-suspected gap was checked directly against the code and
retracted — no missing pairing found), confirmed no 5th reverse-scan site was missed, confirmed the
two synced copies are substantively identical, confirmed the 1-based `line_number` column vs.
0-based loop-index (`i`/`p`) convention is applied consistently at both write and read time, and
confirmed no regression risk for the common non-overloaded case (a real implementation's definition
line always has a `symbolLineByFile` entry, since the same regex/line convention feeds both the
symbol table and this resolver).

## Deliberately out of scope

This fix only corrects the **caller** side — "what does this specific overload call" — not the
**callee** side: which overload a given *call site* actually targets is still resolved by the old
name-keyed `symbolNameToId` lookup, so it still picks whichever overload loaded last, same as
before. Real disambiguation there needs type-aware overload resolution (matching call-site argument
types against each candidate's declared parameter types) — a materially bigger feature, not
attempted here. Per-overload *caller counts* (grouping by call-target id) remain unreliable for an
overloaded name; "what does this overload call" (grouping by caller id) is now correct. See the
fixture's Bug P writeup for the exact before/after boundary, including a documented case
(`SELF.Dispatch(...)`) where the call still resolves to the wrong sibling overload on purpose, to
make clear that's not a regression.

A related, pre-existing, NOT-fixed-by-this-PR gap noticed during verification: local-variable
*references* can still cross-contaminate between overloads that happen to share a variable name,
since `VariableInfo.ParentName` is stored as plain procedure-name text (identical across all
overloads of that name), not tied to a specific overload's symbol/line. Unaffected by this fix
either way — not introduced, not worsened, not fixed.

## Minimal reproduction

Extended the shared `test-fixtures/codegraph-repro/` fixture: `OverloadBugClass.Dispatch` is
declared twice, differing only by parameter type (`LONG` vs `*CSTRING`). The `*CSTRING` overload
delegates to the `LONG` overload via `SELF.Dispatch(...)` — the same general shape as the
motivating case (an overload calling a sibling overload of the same name). Each overload calls a
different, already-existing target (`WorkerClass.Sign` from the `LONG` overload, `WorkerClass.Ask`
from the `*CSTRING` overload) so the two bodies' own calls can be told apart in the results:

```clarion
OverloadBugClass.Dispatch PROCEDURE( LONG pValue )
worker WorkerClass
  CODE
  RETURN worker.Sign( pValue )

OverloadBugClass.Dispatch PROCEDURE( *CSTRING pValue )
result LONG
worker WorkerClass
  CODE
  result = SELF.Dispatch( 99 )
  result = worker.Ask( result )
  RETURN result
```

**Before this fix**: both `worker.Sign(pValue)` (inside the `LONG` overload) and
`worker.Ask(result)` (inside the `*CSTRING` overload) would be attributed as coming from the same
one overload symbol — whichever loaded last — never from their own respective overloads.

**After this fix** (verified via the standalone `clarion-indexer.exe`): `WorkerClass.Sign` gains
exactly one caller (21 → 22), correctly attributed to the `LONG` overload's own definition line.
`WorkerClass.Ask` gains exactly one caller (2 → 3), correctly attributed to the `*CSTRING`
overload's own definition line — a different id than the `Sign` caller above, despite both sharing
the literal name `OverloadBugClass.Dispatch`. Zero regressions on any prior fixture case.

**Also verified against the real production solution**: reindexing confirmed the from-side of every
one of the 65 overloaded names now correctly distributes its relationships across its own overloads
instead of collapsing onto one (see Summary for the aggregate numbers).

## Scope note

Branches cleanly from `upstream/master` (built and verified in an isolated worktree, no dependency
on any other unmerged branch).
