### PR TITLE
fix(hover): don't resolve CodeGraph fallback symbols inside strings/ccomments 

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -1185,6 +1185,41 @@ namespace ClarionAssistant.Services
         // Clarion identifier under the cursor — mirrors server.ts getWordAtPosition.
         private static readonly Regex CgWordPattern = new Regex(@"[A-Za-z_][A-Za-z0-9_:.]*");
 
+        /// <summary>True when `character` (0-based) on `lineText` sits inside a single-quoted Clarion
+        /// string literal — '' is an escaped quote, not a terminator, and both delimiting quote chars
+        /// count as "inside" (matches the LSP's own TokenHelper.isPositionInString convention) — or on
+        /// or after an unquoted `!` comment marker. CgWordPattern has no tokenizer and matches
+        /// identifier-shaped text inside either just as readily as real code; callers that fall back to
+        /// a bare-word symbol lookup must check this first so a string/comment never resolves as if it
+        /// were a reference.</summary>
+        private static bool CgIsInsideStringOrComment(string lineText, int character)
+        {
+            if (string.IsNullOrEmpty(lineText)) return false;
+            bool inString = false;
+            int stringStart = -1;
+            for (int i = 0; i < lineText.Length; i++)
+            {
+                char ch = lineText[i];
+                if (!inString && ch == '!') return character >= i;
+                if (ch == '\'')
+                {
+                    if (inString && i + 1 < lineText.Length && lineText[i + 1] == '\'') { i++; continue; } // '' escape
+                    if (inString)
+                    {
+                        if (character >= stringStart && character <= i) return true;
+                        inString = false;
+                    }
+                    else
+                    {
+                        inString = true;
+                        stringStart = i;
+                    }
+                }
+            }
+            // Unterminated string running to end of line — still "inside" from the opening quote onward.
+            return inString && character >= stringStart;
+        }
+
         /// <summary>True when a dispatcher result carries no usable payload (null, an error, or an
         /// empty result collection) — i.e. the LSP had no answer and we should try CodeGraph.</summary>
         private static bool IsEmptyResult(Dictionary<string, object> r)
@@ -1444,6 +1479,21 @@ namespace ClarionAssistant.Services
         {
             try
             {
+                // The LSP already bails on hover for a position inside a string literal or comment
+                // (TokenHelper.isPositionInString/isPositionInComment) — that's WHY it returned nothing
+                // and this fallback fired. CgWordPattern has no tokenizer, so without this guard it
+                // happily matches identifier-shaped text inside either and looks it up as if it were
+                // real code: hovering the 'Total' argument in SomeClass.SetValue('Total', ...) resolved
+                // an unrelated local variable named Total instead of showing nothing (string-literal
+                // text coincidentally matching a variable name elsewhere in scope). Bail the same way
+                // the LSP did.
+                string[] lines = CgGetLines(bufferText, filePath);
+                if (lines != null && line >= 0 && line < lines.Length &&
+                    CgIsInsideStringOrComment(lines[line], character))
+                {
+                    return null;
+                }
+
                 // Member access first ("oInstance.Member" → that member's signature), resolved via the buffer.
                 string mDb, mLabel;
                 var mSym = ResolveMemberAccessSymbol(bufferText, filePath, line, character, out mDb, out mLabel);
@@ -1463,7 +1513,6 @@ namespace ClarionAssistant.Services
                 // indexed solution or library. CgHoverFromDb below is a global, UNSCOPED exact-name lookup —
                 // without this, an in-scope local (e.g. "PRO") or a brand-new, not-yet-indexed procedure
                 // (e.g. "Test") can resolve to an unrelated class member elsewhere that merely shares the name.
-                string[] lines = CgGetLines(bufferText, filePath);
                 var localHover = BufferLocalHover(lines, line, word, filePath);
                 if (localHover != null) return localHover;
 


### PR DESCRIPTION
## Summary

Hovering a word *inside a string literal or comment* shows an unrelated symbol's info instead of nothing, whenever that word happens to match the name of a real local variable/procedure/class elsewhere in scope or in the CodeGraph/ClarionGraph index.

Repro:
```clarion
SomeClass.SetValue( 'Total', 2, 'Description' )
```
Hovering anywhere inside `'Total'` (including on either delimiting quote) shows:
```
Total  LONG(0)
local · SomeClass.clw
```
— the info for an unrelated local variable `Total`, which happens to be declared elsewhere in the same procedure/class. The string literal has nothing to do with that variable.

---

## Root cause

This is **not** a bug in the vendored Clarion-Extension LSP. `HoverContextBuilder.build()` already correctly detects the cursor is inside a string (`TokenHelper.isPositionInString`) and returns `null` — verified directly against the real tokenizer output for this exact repro, and by invoking `HoverProvider.provideHover()` in isolation with a fresh document (returns `null` for every character position inside `'Total'`, including both delimiting quotes).

The bug is in `SharedLspBridge.cs`'s **CodeGraph hover fallback**, added (ticket 6e8f2439) so ABC/library symbols the LSP itself can't resolve still show something on hover:

```csharp
// GetHover(...)
Dictionary<string, object> primary = ...;         // real LSP hover — correctly null here
if (!IsHoverEmpty(primary)) return primary;
return CodeGraphHover(filePath, line, character, bufferText) ?? primary;   // <-- fires because primary is empty
```

`CodeGraphHover` treats *any* empty LSP result as "the LSP couldn't resolve this, let me try", without distinguishing "couldn't resolve" from "this position isn't code at all." It calls `CgWordAt`, which extracts the identifier under the cursor with a plain regex (`CgWordPattern = [A-Za-z_][A-Za-z0-9_:.]*`) run directly against the raw line text — no tokenizer, no idea that the match sits inside `'...'` or after `!`. For the repro line, `CgWordAt` happily returns `"Total"` from inside the quotes, and `CgHoverFromDb`/`BufferLocalHover` then do an exact-name lookup that finds the real (unrelated) local variable `Total`.

Any string literal or comment whose text happens to match a real symbol name anywhere in scope or in the CodeGraph/ClarionGraph DB triggers this — not specific to any particular file or method.

---

## Fix

Add a small, tokenizer-free guard, `CgIsInsideStringOrComment(lineText, character)`, next to `CgWordPattern`/`CgWordAt`: a single-quote scan (`''` treated as an escaped quote, not a terminator — same convention as `TokenHelper.isPositionInString` on the LSP side, inclusive of both delimiting quote characters) plus a check for an unquoted `!` comment marker. `CodeGraphHover` calls this first and bails immediately (returns `null`, same as the LSP already did) when the cursor is inside either — before member-access resolution, bare-word lookup, or buffer-local search ever run.

```csharp
private static bool CgIsInsideStringOrComment(string lineText, int character)
{
    if (string.IsNullOrEmpty(lineText)) return false;
    bool inString = false;
    int stringStart = -1;
    for (int i = 0; i < lineText.Length; i++)
    {
        char ch = lineText[i];
        if (!inString && ch == '!') return character >= i;
        if (ch == '\'')
        {
            if (inString && i + 1 < lineText.Length && lineText[i + 1] == '\'') { i++; continue; } // '' escape
            if (inString)
            {
                if (character >= stringStart && character <= i) return true;
                inString = false;
            }
            else { inString = true; stringStart = i; }
        }
    }
    return inString && character >= stringStart; // unterminated string to EOL
}
```

`CodeGraphHover` (top of the `try`):
```csharp
string[] lines = CgGetLines(bufferText, filePath);
if (lines != null && line >= 0 && line < lines.Length &&
    CgIsInsideStringOrComment(lines[line], character))
{
    return null;
}
```
(The pre-existing `string[] lines = CgGetLines(...)` further down in the function was removed as a duplicate — the guard now computes it once and the rest of the function reuses it.)

Scoped deliberately to the **hover** fallback only (`CodeGraphHover`). `CgWordAt` is also used by the analogous CodeGraph fallbacks for go-to-definition and workspace-symbol resolution (`CodeGraphDefinition` and one more call site) — those likely have the same latent issue, but weren't reported and are left for a separate fix rather than folded in here unverified.

---

## Verification

Since this is plain C# with no existing unit-test project in this repo, verified via reflection against the built `ClarionAssistant.dll`, calling `CgIsInsideStringOrComment` directly:

- `SomeClass.SetValue( 'Total', 2, 'Description' )` — chars spanning both quotes inclusive (matching `TokenHelper.isPositionInString`'s convention) → `true`; the `(`/space immediately before, and the `,`/space onward, → `false`.
- `Msg('it''s ok')` — the `''` escape does **not** terminate the string; every char from the opening `'` through the closing `'` → `true`; the char right after → `false`.
- `x = 1 ! Total is a comment word here` — every char at/after `!` → `true`.
- A normal code line with no string/comment → `false` everywhere (fallback proceeds as before — unaffected).

Also re-confirmed via a live runtime trace (temporarily added to the deployed `TokenHelper.js`, reverted after) that the real LSP already computes the correct tokens and returns `null` for the string-literal position — the fallback was the only thing producing the wrong answer. Also live-tested the comment (`!`) branch directly in the IDE — confirmed hover correctly shows nothing there too, not just for strings.

---

## Scope note

This fix addresses the **hover** CodeGraph fallback only. It does not address:
- The analogous `CgWordAt` call sites for go-to-definition / workspace-symbol CodeGraph fallbacks, which likely share the same gap (not reported/verified here).
- Any deeper LSP-side hover behavior — that side was verified correct and is unchanged.

