### PR TITLE
fix/diagnostics: decode Clarion source with cp1252 fallback before pushing to LSP

### DIFF
--- a/ClarionAssistant/Services/LspClient.cs
+++ b/ClarionAssistant/Services/LspClient.cs
@@ -887,7 +887,7 @@ namespace ClarionAssistant.Services
                 if (!File.Exists(filePath)) return;
 
                 string uri = FilePathToUri(filePath);
-                string content = File.ReadAllText(filePath);
+                string content = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath));
 
                 string ext = Path.GetExtension(filePath).ToLower();
                 string languageId = ext == ".inc" || ext == ".clw" || ext == ".equ" ? "clarion" : "plaintext";
@@ -998,7 +998,7 @@ namespace ClarionAssistant.Services
                 }
 
                 string uri = FilePathToUri(filePath);
-                string content = File.ReadAllText(filePath);
+                string content = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath));
                 int nextVersion = currentVersion + 1;
 
                 // LSP TextDocumentContentChangeEvent without `range` = full document replacement.

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -806,7 +806,7 @@ namespace ClarionAssistant.Services
             // SharedGetDiagnostics and the bundled LspClient.EnsureDocumentOpen. (Bob, ticket 3d9a6ec9)
             if (string.IsNullOrEmpty(bufferText) && !string.IsNullOrEmpty(filePath) && File.Exists(filePath))
             {
-                try { bufferText = File.ReadAllText(filePath); } catch { }
+                try { bufferText = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath)); } catch { }
             }
             try
             {
@@ -846,7 +846,7 @@ namespace ClarionAssistant.Services
         {
             string buffer = null;
             if (liveBuffer) { lock (_sharedBufLock) { _sharedBuffers.TryGetValue(filePath, out buffer); } }
-            if (buffer == null && File.Exists(filePath)) { try { buffer = File.ReadAllText(filePath); } catch { } }
+            if (buffer == null && File.Exists(filePath)) { try { buffer = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath)); } catch { } }
 
             var result = new LspClient.DiagnosticWaitResult { Entries = new List<LspClient.DiagnosticEntry>(), Pending = true };
             try


### PR DESCRIPTION
## Summary

Diagnostics were reporting a large number of "this character will corrupt the file" warnings on source files that were completely fine on disk. The problem wasn't in the Clarion source — this addin was reading the file assuming UTF-8 encoding, instead of the file's actual encoding (Windows-1252/ANSI), before handing the text to the language server. That wrong assumption is what produced the garbled characters the diagnostics then (correctly, but misleadingly) flagged.

- `LspClient.EnsureDocumentOpen`/its didChange re-trigger path, and `SharedLspBridge.SharedGetCompletion`/`SharedGetDiagnostics`, all read Clarion source with `File.ReadAllText(filePath)` and no encoding argument. `.NET` only auto-detects encoding via BOM; Clarion source is saved as Windows-1252/ANSI with no BOM, so this silently decoded as UTF-8 and replaced any single-byte high-bit character (e.g. the copyright symbol, `0xA9`) with `U+FFFD` before the text was ever sent to the LSP server via `textDocument/didOpen`/`didChange`.
- The server's `UnicodeDiagnostics` validator then correctly flagged the `U+FFFD` it was handed, producing a wave of "can't be represented in any Windows ANSI code page" false positives on files that are, on disk, perfectly valid ANSI — sometimes dozens per file.
- Fix: read through the existing `EncodingHelper.DetectFileEncoding(path)` helper (strict-UTF-8-decode-or-fall-back-to-ANSI) at all four call sites, instead of a bare `File.ReadAllText`. This is the same helper — and the same underlying bug class — as #94 (`DiffService`'s encoding fix), just a different, previously-unfixed code path that feeds the LSP rather than the diff viewer.

## Root cause

Verified directly: read the raw bytes at one flagged position in a real `.clw` file and confirmed a single valid `0xA9` byte (`©`) — not real corruption. Traced the diagnostic backward through `UnicodeDiagnostics.ts` (operates purely on `TextDocument.getText()`, so the corruption had to already be in the text) to the four `File.ReadAllText(filePath)` call sites on the C# side that populate that document via LSP text sync.

## Fix

All four sites changed to:
```csharp
File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath))
```
- `Services/LspClient.cs` — `EnsureDocumentOpen` (initial `didOpen`)
- `Services/LspClient.cs` — didChange re-trigger path
- `Services/SharedLspBridge.cs` — `SharedGetCompletion`'s file-mode fallback
- `Services/SharedLspBridge.cs` — `SharedGetDiagnostics`'s file-mode path (the one actually behind the MCP diagnostics tool for files not open in the editor)

## Test plan

- [x] Builds clean (`ClarionAssistant.csproj`, Debug/C11)
- [x] Deployed and live-retested against a real solution: files that previously showed dozens of `U+FFFD` warnings (61, 98, 119, 60, 21 on five different files) now show zero
- [x] Confirmed unrelated, still-open diagnostics on the same files (a reserved-keyword-as-label false positive, and some `BREAK`/`CYCLE`-outside-loop warnings) are byte-for-byte unchanged before/after — this fix only affects the encoding-detection class of false positive
