### PR TITLE
Fix/diagnostics window follow theme + visual improvements + correctness fixes

### DIFF
--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -958,7 +958,7 @@ namespace ClarionAssistant
                 // Live-follow the Monaco/CA Editor's own theme toggle (independent of this chat
                 // pane's theme) — the page pushes it to CaEditorSettings on every toolbar toggle,
                 // but nothing notifies this control directly, so pick up a change on the next tick.
-                bool monacoDark = CaEditorSettings.MonacoThemeDark;
+                bool monacoDark = ResolveEditorThemeDark();
                 if (_lastMonacoThemeDark != monacoDark)
                 {
                     _lastMonacoThemeDark = monacoDark;
@@ -1076,6 +1076,30 @@ namespace ClarionAssistant
         }
 
         /// <summary>
+        /// Which theme the pill and the diagnostics window should wear: the ACTIVE editor's, not the
+        /// process-wide CaEditorSettings.MonacoThemeDark mirror. That mirror records whichever Monaco
+        /// page most recently booted or toggled — switching tabs posts nothing and moves nothing — so
+        /// polling it alone left the diagnostics window wearing the theme of whatever surface last
+        /// spoke rather than the editor being looked at. Same shape as ResolveDiagnosticsTarget below:
+        /// ask the active editor, fall back to the global. The mirror stays the fallback (and stays a
+        /// mirror), so nothing else that reads it changes behaviour.
+        /// </summary>
+        private bool ResolveEditorThemeDark()
+        {
+            try
+            {
+                bool? overlay = MonacoClarionEditor.ActiveEditorIsDark();
+                if (overlay.HasValue) return overlay.Value;
+
+                bool? modern = ModernEmbeditorViewContent.ActiveViewIsDark();
+                if (modern.HasValue) return modern.Value;
+            }
+            catch { /* fall through to the global mirror */ }
+
+            return CaEditorSettings.MonacoThemeDark;
+        }
+
+        /// <summary>
         /// Which file the pill and the diagnostics window are about. There are TWO independent
         /// Monaco-backed editing surfaces in this addin, and either can be the one the developer is
         /// actually looking at:
@@ -1123,7 +1147,7 @@ namespace ClarionAssistant
                     line => _editorService.GoToLine(line),
                     () => _lastDiagEntries,
                     () => _lastDiagFile);
-                _diagForm.ApplyTheme(CaEditorSettings.MonacoThemeDark);
+                _diagForm.ApplyTheme(ResolveEditorThemeDark());
             }
             _diagForm.UpdateDiagnostics(_lastDiagFile, _lastDiagEntries);
             if (!_diagForm.Visible)
@@ -2059,9 +2083,10 @@ namespace ClarionAssistant
             if (_contentArea != null) _contentArea.BackColor = _isDarkTheme ? Color.FromArgb(12, 12, 12) : Color.White;
 
             // LSP status bar + diagnostics window show diagnostics for the CODE editor, so they
-            // follow the Monaco/CA Editor's own theme (CaEditorSettings.MonacoThemeDark) rather
-            // than this chat pane's own _isDarkTheme — the two are independent settings and can differ.
-            bool monacoDark = CaEditorSettings.MonacoThemeDark;
+            // follow the ACTIVE editor's own theme rather than this chat pane's own _isDarkTheme —
+            // the two are independent settings and can differ. See ResolveEditorThemeDark for why
+            // this asks the active surface instead of reading CaEditorSettings.MonacoThemeDark.
+            bool monacoDark = ResolveEditorThemeDark();
             _lastMonacoThemeDark = monacoDark;
             if (_lspStatusBar != null) _lspStatusBar.ApplyTheme(monacoDark);
             if (_diagForm != null) _diagForm.ApplyTheme(monacoDark);

--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -971,14 +971,20 @@ namespace ClarionAssistant
                     lsp.OnLspRequest += OnLspRequest;
                 }
 
-                if (lsp == null || !lsp.IsRunning)
+                // Ask the BRIDGE whether an LSP is up, not the bundled LspClient. When the IDE's own
+                // ClarionLsp is the active client the bundled one is never started at all, so
+                // lsp.IsRunning is false and this hid the pill on every tick — even with the CA
+                // Editor showing live squiggles, because the squiggle pass (and every other
+                // consumer) already routes through SharedLspBridge. The two clients also keep
+                // SEPARATE diagnostics caches, so the read below has to go through the bridge too
+                // or it looks in an empty dictionary.
+                if (!SharedLspBridge.IsRunning)
                 {
                     _lspStatusBar.SetDiagnostics(0, 0, hidden: true);
                     return;
                 }
 
-                // Read diagnostics for the last file the LSP operated on
-                string filePath = lsp.LastActiveFilePath;
+                string filePath = ResolveDiagnosticsTarget(lsp);
                 if (string.IsNullOrEmpty(filePath))
                 {
                     _lspStatusBar.SetDiagnostics(0, 0, hidden: true);
@@ -987,7 +993,7 @@ namespace ClarionAssistant
 
                 // Deduplicate diagnostics by (line, message) — the Clarion LSP server
                 // can emit the same diagnostic dozens of times per analysis cycle.
-                var raw = lsp.GetCachedDiagnostics(filePath);
+                var raw = SharedLspBridge.GetCachedDiagnostics(filePath);
                 List<Services.LspClient.DiagnosticEntry> entries = null;
                 int errors = 0, warnings = 0;
                 if (raw != null && raw.Count > 0)
@@ -1053,6 +1059,46 @@ namespace ClarionAssistant
                 }
             }
             catch { }
+        }
+
+        /// <summary>
+        /// Which file the pill and the diagnostics window are about. There are TWO independent
+        /// Monaco-backed editing surfaces in this addin, and either can be the one the developer is
+        /// actually looking at:
+        ///   1. MonacoClarionEditor — a Monaco squiggle OVERLAY on the native Clarion source editor
+        ///      (ClarionEditor). This is what a plain "open a .clw and edit it" session uses, and its
+        ///      _filePath is exactly what EditorService.GetActiveDocumentPath() resolves (confirmed
+        ///      live via inspect_ide: all currently-open windows report as this type; get_active_file,
+        ///      which calls GetActiveDocumentPath(), correctly returned the real path for one).
+        ///   2. ModernEmbeditorViewContent — the separate CA Editor / embeditor tab surface. It does
+        ///      NOT expose FileName/PrimaryFileName (GetActiveDocumentPath's reflection probes miss it
+        ///      entirely), so it needs its own DiagnosticsCacheKey lookup as a distinct path, not a
+        ///      fallback that GetActiveDocumentPath will ever satisfy for it.
+        /// Try (1) first since it's the common case, then (2). LastActiveFilePath is the last resort —
+        /// it follows the last file ANY LSP tool touched, which chat-driven hover/definition lookups
+        /// and full-solution sweeps retarget to files nobody is editing.
+        /// </summary>
+        private string ResolveDiagnosticsTarget(LspClient lsp)
+        {
+            try
+            {
+                string active = _editorService?.GetActiveDocumentPath();
+                // Reject a bare filename with no directory — GetActiveDocumentPath's last-resort
+                // Title fallback returns that shape, and it can't key the diagnostics cache.
+                if (!string.IsNullOrEmpty(active) && active.IndexOf('\\') >= 0)
+                    return active;
+            }
+            catch { /* fall through */ }
+
+            try
+            {
+                var view = ModernEmbeditorViewContent.ActiveModernView();
+                string key = (view != null) ? view.DiagnosticsCacheKey : null;
+                if (!string.IsNullOrEmpty(key)) return key;
+            }
+            catch { /* fall through to the last-LSP-activity path */ }
+
+            return (lsp != null) ? lsp.LastActiveFilePath : null;
         }
 
         private void OnDiagnosticsBarClicked(object sender, EventArgs e)

--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -1062,7 +1062,7 @@ namespace ClarionAssistant
                 _diagForm = new Dialogs.DiagnosticsForm(
                     line => _editorService.GoToLine(line),
                     () => _lastDiagEntries);
-                _diagForm.ApplyTheme(_isDarkTheme);
+                _diagForm.ApplyTheme(CaEditorSettings.MonacoThemeDark);
             }
             _diagForm.UpdateDiagnostics(_lastDiagFile, _lastDiagEntries);
             if (!_diagForm.Visible)

--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -72,6 +72,9 @@ namespace ClarionAssistant
         private string _lastDiagFile;
         private int _lastDiagErrors = -1;
         private int _lastDiagWarnings = -1;
+        // Tri-state guard: unknown and clean are BOTH 0/0, so the counts alone can't tell the
+        // change detector that a file just resolved from "not analyzed" to "analyzed, clean".
+        private bool _lastDiagKnown = true;
         private List<Services.LspClient.DiagnosticEntry> _lastDiagEntries;
         private bool? _lastMonacoThemeDark; // tracks CaEditorSettings.MonacoThemeDark for live-follow in PollLspUi
 
@@ -994,6 +997,13 @@ namespace ClarionAssistant
                 // Deduplicate diagnostics by (line, message) — the Clarion LSP server
                 // can emit the same diagnostic dozens of times per analysis cycle.
                 var raw = SharedLspBridge.GetCachedDiagnostics(filePath);
+                // null = the server has NEVER published for this file (bundled path reports it via
+                // DiagnosticSet.WasPublished, shared path by the key being absent) — genuinely
+                // unknown, NOT clean. An authoritatively clean file caches an EMPTY list instead,
+                // so null-vs-empty already carries the distinction; it was being thrown away by
+                // flattening both to 0/0, which painted a confident green "OK" over a file nothing
+                // had been heard about yet.
+                bool known = raw != null;
                 List<Services.LspClient.DiagnosticEntry> entries = null;
                 int errors = 0, warnings = 0;
                 if (raw != null && raw.Count > 0)
@@ -1012,14 +1022,18 @@ namespace ClarionAssistant
                     }
                 }
 
-                // Only update if the file or counts changed (avoid flicker)
-                if (filePath != _lastDiagFile || errors != _lastDiagErrors || warnings != _lastDiagWarnings)
+                // Only update if the file, the counts, or known-ness changed (avoid flicker).
+                // `known` has to be in this test: unknown and clean are both 0/0, so without it the
+                // pill would stay stuck on "○ …" once a file resolved to genuinely clean.
+                if (filePath != _lastDiagFile || errors != _lastDiagErrors || warnings != _lastDiagWarnings
+                    || known != _lastDiagKnown)
                 {
                     _lastDiagFile = filePath;
                     _lastDiagErrors = errors;
                     _lastDiagWarnings = warnings;
+                    _lastDiagKnown = known;
                     _lastDiagEntries = entries;
-                    _lspStatusBar.SetDiagnostics(errors, warnings, hidden: false);
+                    _lspStatusBar.SetDiagnostics(errors, warnings, hidden: false, known: known);
 
                     // Update the diagnostics form if it's visible
                     if (_diagForm != null && _diagForm.Visible)

--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -73,6 +73,7 @@ namespace ClarionAssistant
         private int _lastDiagErrors = -1;
         private int _lastDiagWarnings = -1;
         private List<Services.LspClient.DiagnosticEntry> _lastDiagEntries;
+        private bool? _lastMonacoThemeDark; // tracks CaEditorSettings.MonacoThemeDark for live-follow in PollLspUi
 
         public string CurrentSolutionPath { get { return _currentSlnPath; } }
         public SettingsService Settings { get { return _settings; } }
@@ -950,6 +951,17 @@ namespace ClarionAssistant
             try
             {
                 if (_lspStatusBar == null) return;
+
+                // Live-follow the Monaco/CA Editor's own theme toggle (independent of this chat
+                // pane's theme) — the page pushes it to CaEditorSettings on every toolbar toggle,
+                // but nothing notifies this control directly, so pick up a change on the next tick.
+                bool monacoDark = CaEditorSettings.MonacoThemeDark;
+                if (_lastMonacoThemeDark != monacoDark)
+                {
+                    _lastMonacoThemeDark = monacoDark;
+                    _lspStatusBar.ApplyTheme(monacoDark);
+                    if (_diagForm != null) _diagForm.ApplyTheme(monacoDark);
+                }
 
                 // Wire up the OnLspRequest event once the LspClient is available
                 var lsp = _toolRegistry?.LspClientInstance;
@@ -1984,8 +1996,14 @@ namespace ClarionAssistant
             _splitter.BackColor = _isDarkTheme ? Color.FromArgb(49, 50, 68) : Color.FromArgb(204, 208, 218);
             if (_tabStrip != null) _tabManager?.ApplyTheme(_isDarkTheme);
             if (_contentArea != null) _contentArea.BackColor = _isDarkTheme ? Color.FromArgb(12, 12, 12) : Color.White;
-            if (_lspStatusBar != null) _lspStatusBar.ApplyTheme(_isDarkTheme);
-            if (_diagForm != null) _diagForm.ApplyTheme(_isDarkTheme);
+
+            // LSP status bar + diagnostics window show diagnostics for the CODE editor, so they
+            // follow the Monaco/CA Editor's own theme (CaEditorSettings.MonacoThemeDark) rather
+            // than this chat pane's own _isDarkTheme — the two are independent settings and can differ.
+            bool monacoDark = CaEditorSettings.MonacoThemeDark;
+            _lastMonacoThemeDark = monacoDark;
+            if (_lspStatusBar != null) _lspStatusBar.ApplyTheme(monacoDark);
+            if (_diagForm != null) _diagForm.ApplyTheme(monacoDark);
         }
 
         private float GetFontSize()

--- a/ClarionAssistant/AssistantChatControl.cs
+++ b/ClarionAssistant/AssistantChatControl.cs
@@ -1061,7 +1061,8 @@ namespace ClarionAssistant
             {
                 _diagForm = new Dialogs.DiagnosticsForm(
                     line => _editorService.GoToLine(line),
-                    () => _lastDiagEntries);
+                    () => _lastDiagEntries,
+                    () => _lastDiagFile);
                 _diagForm.ApplyTheme(CaEditorSettings.MonacoThemeDark);
             }
             _diagForm.UpdateDiagnostics(_lastDiagFile, _lastDiagEntries);

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using ClarionAssistant.Services;
 
@@ -13,9 +14,16 @@ namespace ClarionAssistant.Dialogs
     /// </summary>
     public class DiagnosticsForm : Form
     {
+        // Win32 common-control ListView headers don't follow BackColor/ForeColor — without this,
+        // the column header band stays light even in dark mode. "DarkMode_Explorer" is the standard
+        // uxtheme.dll trick for making a ListView's native header (and scrollbar) follow dark mode.
+        [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
+        private static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
+
         private ListView _listView;
         private Button _refreshButton;
-        private Label _fileLabel;
+        private ToolTip _toolTip;
+        private string _currentFileName = "";
         private readonly Action<int> _goToLine;
         private readonly Func<List<LspClient.DiagnosticEntry>> _refreshData;
         private bool _isDark = true;
@@ -37,31 +45,22 @@ namespace ClarionAssistant.Dialogs
             ShowInTaskbar = false;
             FormBorderStyle = FormBorderStyle.SizableToolWindow;
 
-            _fileLabel = new Label
-            {
-                Dock = DockStyle.Top,
-                Height = 22,
-                Padding = new Padding(6, 4, 0, 0),
-                Font = new Font("Segoe UI", 8.5f),
-                Text = ""
-            };
-
-            var toolbar = new FlowLayoutPanel
-            {
-                Dock = DockStyle.Top,
-                Height = 28,
-                FlowDirection = FlowDirection.LeftToRight,
-                Padding = new Padding(4, 2, 0, 0)
-            };
+            // Slim single strip: just the icon-only refresh button, right-aligned. The filename
+            // used to live in its own row here — it's now folded into the window title instead
+            // (see UpdateDiagnostics), so this row only needs to hold the refresh action.
+            var toolbar = new Panel { Dock = DockStyle.Top, Height = 24 };
             _refreshButton = new Button
             {
-                Text = "Refresh",
-                AutoSize = true,
+                Text = "⟳",
+                Dock = DockStyle.Right,
+                Width = 28,
                 FlatStyle = FlatStyle.Flat,
-                Font = new Font("Segoe UI", 8f)
+                Font = new Font("Segoe UI", 10f)
             };
             _refreshButton.Click += (s, e) => RefreshFromSource();
             toolbar.Controls.Add(_refreshButton);
+            _toolTip = new ToolTip();
+            _toolTip.SetToolTip(_refreshButton, "Refresh");
 
             _listView = new ListView
             {
@@ -81,7 +80,6 @@ namespace ClarionAssistant.Dialogs
 
             Controls.Add(_listView);
             Controls.Add(toolbar);
-            Controls.Add(_fileLabel);
 
             ApplyTheme(_isDark);
         }
@@ -95,7 +93,6 @@ namespace ClarionAssistant.Dialogs
                 ForeColor = Color.FromArgb(205, 214, 244);
                 _listView.BackColor = Color.FromArgb(24, 24, 37);
                 _listView.ForeColor = Color.FromArgb(205, 214, 244);
-                _fileLabel.ForeColor = Color.FromArgb(127, 132, 156);
                 _refreshButton.ForeColor = Color.FromArgb(205, 214, 244);
                 _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(69, 71, 90);
             }
@@ -105,15 +102,18 @@ namespace ClarionAssistant.Dialogs
                 ForeColor = Color.FromArgb(76, 79, 105);
                 _listView.BackColor = Color.FromArgb(230, 233, 239);
                 _listView.ForeColor = Color.FromArgb(76, 79, 105);
-                _fileLabel.ForeColor = Color.FromArgb(108, 111, 133);
                 _refreshButton.ForeColor = Color.FromArgb(76, 79, 105);
                 _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(188, 192, 204);
             }
+
+            try { SetWindowTheme(_listView.Handle, isDark ? "DarkMode_Explorer" : "Explorer", null); }
+            catch { /* best-effort — header just stays whatever the OS default is */ }
         }
 
         public void UpdateDiagnostics(string filePath, List<LspClient.DiagnosticEntry> entries)
         {
-            _fileLabel.Text = string.IsNullOrEmpty(filePath) ? "" : System.IO.Path.GetFileName(filePath);
+            _currentFileName = string.IsNullOrEmpty(filePath) ? "" : System.IO.Path.GetFileName(filePath);
+            Text = string.IsNullOrEmpty(_currentFileName) ? "Diagnostics" : "Diagnostics — " + _currentFileName;
 
             _listView.BeginUpdate();
             _listView.Items.Clear();
@@ -159,7 +159,7 @@ namespace ClarionAssistant.Dialogs
             if (_refreshData != null)
             {
                 var entries = _refreshData();
-                UpdateDiagnostics(_fileLabel.Text, entries);
+                UpdateDiagnostics(_currentFileName, entries);
             }
         }
 

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -174,12 +174,29 @@ namespace ClarionAssistant.Dialogs
             catch { /* best-effort — caption just stays whatever the OS default is */ }
         }
 
+        // GDI+ paints exactly the requested color with normal alpha blending against whatever's
+        // already on the surface. GDI's TextRenderer.DrawText, even given the correct background
+        // color, still renders ClearType-composited text visibly paler than the literal RGB value
+        // for these saturated severity colors — DrawString avoids that ambiguity entirely.
+        private static readonly StringFormat CellTextFormat = new StringFormat
+        {
+            Alignment = StringAlignment.Near,
+            LineAlignment = StringAlignment.Center,
+            Trimming = StringTrimming.EllipsisCharacter,
+            FormatFlags = StringFormatFlags.NoWrap
+        };
+
+        // TextRenderer.DrawText added a couple pixels of left padding automatically; DrawString
+        // doesn't, so without this the text would sit flush against the cell's left edge.
+        private static RectangleF Inset(Rectangle bounds) =>
+            new RectangleF(bounds.X + 2, bounds.Y, Math.Max(0, bounds.Width - 2), bounds.Height);
+
         private void OnDrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
         {
             using (var brush = new SolidBrush(_headerBackColor))
                 e.Graphics.FillRectangle(brush, e.Bounds);
-            TextRenderer.DrawText(e.Graphics, e.Header.Text, _listView.Font, e.Bounds, _headerForeColor, _headerBackColor,
-                TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
+            using (var foreBrush = new SolidBrush(_headerForeColor))
+                e.Graphics.DrawString(e.Header.Text, _listView.Font, foreBrush, Inset(e.Bounds), CellTextFormat);
         }
 
         private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
@@ -196,11 +213,8 @@ namespace ClarionAssistant.Dialogs
 
             using (var backBrush = new SolidBrush(back))
                 e.Graphics.FillRectangle(backBrush, e.Bounds);
-            // Passing the real background color (not the 5-arg "transparent" overload) matters:
-            // without it, GDI doesn't know what it's compositing ClearType antialiasing against
-            // and the severity colors render visibly washed out/pastel instead of their true value.
-            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, _listView.Font, e.Bounds, fore, back,
-                TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
+            using (var foreBrush = new SolidBrush(fore))
+                e.Graphics.DrawString(e.SubItem.Text, _listView.Font, foreBrush, Inset(e.Bounds), CellTextFormat);
 
             using (var pen = new Pen(_gridLineColor))
             {

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -28,6 +28,13 @@ namespace ClarionAssistant.Dialogs
         private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
         private const int DWMWA_USE_IMMERSIVE_DARK_MODE_OLD = 19;
+        // Windows 11 22H2+: force the exact caption background/text color instead of relying on
+        // the OS's generic dark-mode default, which renders caption text in a duller gray than
+        // our own client-area text.
+        private const int DWMWA_CAPTION_COLOR = 35;
+        private const int DWMWA_TEXT_COLOR = 36;
+
+        private static int ToColorRef(Color c) => c.R | (c.G << 8) | (c.B << 16);
 
         private ListView _listView;
         private Button _refreshButton;
@@ -38,6 +45,7 @@ namespace ClarionAssistant.Dialogs
         private bool _isDark = true;
         private Color _headerBackColor = Color.White;
         private Color _headerForeColor = Color.Black;
+        private Color _gridLineColor = Color.FromArgb(220, 220, 220);
 
         public DiagnosticsForm(Action<int> goToLine, Func<List<LspClient.DiagnosticEntry>> refreshData)
         {
@@ -78,7 +86,9 @@ namespace ClarionAssistant.Dialogs
                 Dock = DockStyle.Fill,
                 View = View.Details,
                 FullRowSelect = true,
-                GridLines = true,
+                // Native gridlines always use a fixed system color (bright, non-theme-aware) —
+                // drawn manually in OnDrawSubItem instead so they can match the theme.
+                GridLines = false,
                 HeaderStyle = ColumnHeaderStyle.Nonclickable,
                 OwnerDraw = true,
                 Font = new Font("Cascadia Code", 9f, FontStyle.Regular,
@@ -90,8 +100,11 @@ namespace ClarionAssistant.Dialogs
             _listView.DoubleClick += OnListDoubleClick;
             _listView.KeyDown += OnListKeyDown;
             _listView.DrawColumnHeader += OnDrawColumnHeader;
-            _listView.DrawItem += (s, e) => e.DrawDefault = true;
-            _listView.DrawSubItem += (s, e) => e.DrawDefault = true;
+            // Details view: draw everything (background, text, and the custom grid lines) in
+            // DrawSubItem — DrawDefault=true there would paint AFTER any custom drawing here,
+            // overwriting it, so DrawItem must fully defer instead of drawing its own default.
+            _listView.DrawItem += (s, e) => e.DrawDefault = false;
+            _listView.DrawSubItem += OnDrawSubItem;
 
             Controls.Add(_listView);
             Controls.Add(toolbar);
@@ -106,12 +119,15 @@ namespace ClarionAssistant.Dialogs
             {
                 // Plain near-black, deliberately NOT the same blue-tinted black as the Monaco
                 // editor chrome, so the list reads as a distinct panel rather than blending in.
+                // Kept the same shade as the window/caption background per feedback, rather than
+                // a darker shade of its own.
                 BackColor = Color.FromArgb(32, 32, 32);
                 ForeColor = Color.FromArgb(235, 235, 235);
-                _listView.BackColor = Color.FromArgb(18, 18, 18);
+                _listView.BackColor = Color.FromArgb(32, 32, 32);
                 _listView.ForeColor = Color.FromArgb(235, 235, 235);
                 _refreshButton.ForeColor = Color.FromArgb(235, 235, 235);
                 _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(90, 90, 90);
+                _gridLineColor = Color.FromArgb(70, 70, 70);
                 // Header matches the list body exactly, same as it does natively in light mode.
                 _headerBackColor = _listView.BackColor;
                 _headerForeColor = _listView.ForeColor;
@@ -124,6 +140,7 @@ namespace ClarionAssistant.Dialogs
                 _listView.ForeColor = Color.FromArgb(32, 32, 32);
                 _refreshButton.ForeColor = Color.FromArgb(32, 32, 32);
                 _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(180, 180, 180);
+                _gridLineColor = Color.FromArgb(220, 220, 220);
                 _headerBackColor = _listView.BackColor;
                 _headerForeColor = _listView.ForeColor;
             }
@@ -139,6 +156,11 @@ namespace ClarionAssistant.Dialogs
                 int useDark = isDark ? 1 : 0;
                 if (DwmSetWindowAttribute(Handle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref useDark, sizeof(int)) != 0)
                     DwmSetWindowAttribute(Handle, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD, ref useDark, sizeof(int));
+
+                int captionColor = ToColorRef(BackColor);
+                int textColor = ToColorRef(ForeColor);
+                DwmSetWindowAttribute(Handle, DWMWA_CAPTION_COLOR, ref captionColor, sizeof(int));
+                DwmSetWindowAttribute(Handle, DWMWA_TEXT_COLOR, ref textColor, sizeof(int));
             }
             catch { /* best-effort — caption just stays whatever the OS default is */ }
         }
@@ -149,6 +171,24 @@ namespace ClarionAssistant.Dialogs
                 e.Graphics.FillRectangle(brush, e.Bounds);
             TextRenderer.DrawText(e.Graphics, e.Header.Text, _listView.Font, e.Bounds, _headerForeColor,
                 TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
+        }
+
+        private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
+        {
+            bool selected = e.Item.Selected;
+            Color back = selected ? SystemColors.Highlight : _listView.BackColor;
+            Color fore = selected ? SystemColors.HighlightText : e.Item.ForeColor;
+
+            using (var backBrush = new SolidBrush(back))
+                e.Graphics.FillRectangle(backBrush, e.Bounds);
+            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, _listView.Font, e.Bounds, fore,
+                TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
+
+            using (var pen = new Pen(_gridLineColor))
+            {
+                e.Graphics.DrawLine(pen, e.Bounds.Left, e.Bounds.Bottom - 1, e.Bounds.Right, e.Bounds.Bottom - 1);
+                e.Graphics.DrawLine(pen, e.Bounds.Right - 1, e.Bounds.Top, e.Bounds.Right - 1, e.Bounds.Bottom);
+            }
         }
 
         public void UpdateDiagnostics(string filePath, List<LspClient.DiagnosticEntry> entries)

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -178,7 +178,7 @@ namespace ClarionAssistant.Dialogs
         {
             using (var brush = new SolidBrush(_headerBackColor))
                 e.Graphics.FillRectangle(brush, e.Bounds);
-            TextRenderer.DrawText(e.Graphics, e.Header.Text, _listView.Font, e.Bounds, _headerForeColor,
+            TextRenderer.DrawText(e.Graphics, e.Header.Text, _listView.Font, e.Bounds, _headerForeColor, _headerBackColor,
                 TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
         }
 
@@ -196,7 +196,10 @@ namespace ClarionAssistant.Dialogs
 
             using (var backBrush = new SolidBrush(back))
                 e.Graphics.FillRectangle(backBrush, e.Bounds);
-            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, _listView.Font, e.Bounds, fore,
+            // Passing the real background color (not the 5-arg "transparent" overload) matters:
+            // without it, GDI doesn't know what it's compositing ClearType antialiasing against
+            // and the severity colors render visibly washed out/pastel instead of their true value.
+            TextRenderer.DrawText(e.Graphics, e.SubItem.Text, _listView.Font, e.Bounds, fore, back,
                 TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
 
             using (var pen = new Pen(_gridLineColor))

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -159,6 +159,19 @@ namespace ClarionAssistant.Dialogs
                 _headerBackColor = _listView.BackColor;
                 _headerForeColor = _listView.ForeColor;
             }
+            // Rows keep whatever ForeColor they were given when they were ADDED, so a theme flip
+            // left an already-populated list painted in the other theme's palette — the dark
+            // palette's pastel red/amber against the light background reads as washed out, and it
+            // persisted until the next UpdateDiagnostics happened to rebuild the rows. Re-derive
+            // each row's color from the severity stashed in its RowInfo. (Latent since this form
+            // was written; only reachable now that the window follows a theme that changes at
+            // runtime instead of one fixed at construction.)
+            foreach (ListViewItem item in _listView.Items)
+            {
+                var info = item.Tag as RowInfo;
+                if (info != null) item.ForeColor = SeverityColor(info.Severity);
+            }
+
             _listView.Invalidate();
 
             try { SetWindowTheme(_listView.Handle, isDark ? "DarkMode_Explorer" : "Explorer", null); }
@@ -229,6 +242,32 @@ namespace ClarionAssistant.Dialogs
             }
         }
 
+        /// <summary>
+        /// Per-row state the form still needs after the row is built: the line to navigate to, and
+        /// the severity to RE-derive the text color from if the theme changes under an already
+        /// populated list. ApplyTheme can't recompute a color whose input it never kept.
+        /// </summary>
+        private class RowInfo
+        {
+            public int Line;       // 0-based, as the LSP reports it
+            public int Severity;   // LSP severity: 1=error, 2=warning, 3=info, 4=hint
+        }
+
+        /// <summary>Severity text color for the CURRENT theme. Single source of truth so a row
+        /// built by UpdateDiagnostics and a row recolored by ApplyTheme can never disagree.</summary>
+        private Color SeverityColor(int severity)
+        {
+            if (_isDark)
+            {
+                return severity == 1 ? Color.FromArgb(243, 139, 168) :  // red
+                       severity == 2 ? Color.FromArgb(250, 179, 135) :  // amber
+                       Color.FromArgb(137, 180, 250);                    // blue
+            }
+            return severity == 1 ? Color.FromArgb(210, 15, 57) :
+                   severity == 2 ? Color.FromArgb(254, 100, 11) :
+                   Color.FromArgb(30, 102, 245);
+        }
+
         public void UpdateDiagnostics(string filePath, List<LspClient.DiagnosticEntry> entries)
         {
             _currentFileName = string.IsNullOrEmpty(filePath) ? "" : System.IO.Path.GetFileName(filePath);
@@ -248,20 +287,8 @@ namespace ClarionAssistant.Dialogs
                     var item = new ListViewItem(icon);
                     item.SubItems.Add((e.Line + 1).ToString());   // LSP 0-based → display 1-based
                     item.SubItems.Add(e.Message ?? "");
-                    item.Tag = e.Line;                             // store 0-based for GoToLine
-
-                    if (_isDark)
-                    {
-                        item.ForeColor = e.Severity == 1 ? Color.FromArgb(243, 139, 168) :  // red
-                                         e.Severity == 2 ? Color.FromArgb(250, 179, 135) :  // amber
-                                         Color.FromArgb(137, 180, 250);                      // blue
-                    }
-                    else
-                    {
-                        item.ForeColor = e.Severity == 1 ? Color.FromArgb(210, 15, 57) :
-                                         e.Severity == 2 ? Color.FromArgb(254, 100, 11) :
-                                         Color.FromArgb(30, 102, 245);
-                    }
+                    item.Tag = new RowInfo { Line = e.Line, Severity = e.Severity };
+                    item.ForeColor = SeverityColor(e.Severity);
 
                     _listView.Items.Add(item);
                 }
@@ -306,9 +333,10 @@ namespace ClarionAssistant.Dialogs
         {
             if (_listView.SelectedItems.Count == 0) return;
             var item = _listView.SelectedItems[0];
-            if (item.Tag is int line)
+            var info = item.Tag as RowInfo;
+            if (info != null)
             {
-                try { _goToLine(line + 1); } // LSP 0-based → IDE 1-based
+                try { _goToLine(info.Line + 1); } // LSP 0-based → IDE 1-based
                 catch { }
             }
         }

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -78,7 +78,10 @@ namespace ClarionAssistant.Dialogs
             };
             _refreshButton.Click += (s, e) => RefreshFromSource();
             toolbar.Controls.Add(_refreshButton);
-            _toolTip = new ToolTip();
+            // ShowAlways is required here: a ToolTip only shows by default when its parent form
+            // is the active foreground window, and this non-modal tool window (shown via
+            // Show(this) from the docked chat pane) apparently never becomes active.
+            _toolTip = new ToolTip { ShowAlways = true };
             _toolTip.SetToolTip(_refreshButton, "Reload");
 
             _listView = new ListView

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -82,7 +82,7 @@ namespace ClarionAssistant.Dialogs
             // is the active foreground window, and this non-modal tool window (shown via
             // Show(this) from the docked chat pane) apparently never becomes active.
             _toolTip = new ToolTip { ShowAlways = true };
-            _toolTip.SetToolTip(_refreshButton, "Reload");
+            _toolTip.SetToolTip(_refreshButton, "Refresh");
 
             _listView = new ListView
             {

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -106,6 +106,12 @@ namespace ClarionAssistant.Dialogs
             _listView.DrawItem += (s, e) => e.DrawDefault = false;
             _listView.DrawSubItem += OnDrawSubItem;
 
+            // ListView doesn't expose DoubleBuffered publicly. Without it, every owner-drawn
+            // repaint (including the ones Windows triggers just from mouse-move hover tracking,
+            // even with no hover-selection behavior configured) flashes visibly before painting.
+            typeof(Control).GetProperty("DoubleBuffered", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                ?.SetValue(_listView, true, null);
+
             Controls.Add(_listView);
             Controls.Add(toolbar);
 
@@ -173,16 +179,16 @@ namespace ClarionAssistant.Dialogs
                 TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
         }
 
-        // One fixed middle gray for selection, used in BOTH themes (rather than per-theme accent
-        // colors) — legible against both the near-black dark background and white light background.
-        // Selected text keeps its normal severity color (red/amber/blue) instead of a forced
-        // white/black override, so a selected row still reads the same as an unselected one.
-        private static readonly Color SelectionBackColor = Color.FromArgb(128, 128, 128);
-
         private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
         {
             bool selected = e.Item.Selected;
-            Color back = selected ? SelectionBackColor : _listView.BackColor;
+            // A flat middle gray sits in the worst contrast zone for the pastel/saturated
+            // severity colors (red/amber/blue) used for the text — it's roughly as bright as
+            // the amber text itself. A subtle per-theme tint close to the row's own background
+            // keeps the same contrast the text already had while still reading as "selected".
+            Color back = selected
+                ? (_isDark ? Color.FromArgb(60, 60, 68) : Color.FromArgb(210, 210, 218))
+                : _listView.BackColor;
             Color fore = e.Item.ForeColor;
 
             using (var backBrush = new SolidBrush(back))

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -79,7 +79,7 @@ namespace ClarionAssistant.Dialogs
             _refreshButton.Click += (s, e) => RefreshFromSource();
             toolbar.Controls.Add(_refreshButton);
             _toolTip = new ToolTip();
-            _toolTip.SetToolTip(_refreshButton, "Refresh");
+            _toolTip.SetToolTip(_refreshButton, "Reload");
 
             _listView = new ListView
             {

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -17,8 +17,17 @@ namespace ClarionAssistant.Dialogs
         // Win32 common-control ListView headers don't follow BackColor/ForeColor — without this,
         // the column header band stays light even in dark mode. "DarkMode_Explorer" is the standard
         // uxtheme.dll trick for making a ListView's native header (and scrollbar) follow dark mode.
+        // SetWindowTheme on the ListView handle alone only covers the item area/scrollbar — the
+        // column header is a separate child HWND (Header32) that needs its own SetWindowTheme call,
+        // plus a WM_THEMECHANGED nudge to make it actually repaint with the new palette.
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
         private static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        private const int LVM_GETHEADER = 0x1000 + 31;
+        private const int WM_THEMECHANGED = 0x031A;
 
         private ListView _listView;
         private Button _refreshButton;
@@ -89,24 +98,37 @@ namespace ClarionAssistant.Dialogs
             _isDark = isDark;
             if (isDark)
             {
-                BackColor = Color.FromArgb(30, 30, 46);
-                ForeColor = Color.FromArgb(205, 214, 244);
-                _listView.BackColor = Color.FromArgb(24, 24, 37);
-                _listView.ForeColor = Color.FromArgb(205, 214, 244);
-                _refreshButton.ForeColor = Color.FromArgb(205, 214, 244);
-                _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(69, 71, 90);
+                // Plain near-black, deliberately NOT the same blue-tinted black as the Monaco
+                // editor chrome, so the list reads as a distinct panel rather than blending in.
+                BackColor = Color.FromArgb(32, 32, 32);
+                ForeColor = Color.FromArgb(235, 235, 235);
+                _listView.BackColor = Color.FromArgb(18, 18, 18);
+                _listView.ForeColor = Color.FromArgb(235, 235, 235);
+                _refreshButton.ForeColor = Color.FromArgb(235, 235, 235);
+                _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(90, 90, 90);
             }
             else
             {
-                BackColor = Color.FromArgb(239, 241, 245);
-                ForeColor = Color.FromArgb(76, 79, 105);
-                _listView.BackColor = Color.FromArgb(230, 233, 239);
-                _listView.ForeColor = Color.FromArgb(76, 79, 105);
-                _refreshButton.ForeColor = Color.FromArgb(76, 79, 105);
-                _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(188, 192, 204);
+                // Plain light grey, not the pale lavender-tinted panel used before — that tint
+                // plus the soft grey text was too low-contrast to read comfortably.
+                BackColor = Color.FromArgb(240, 240, 240);
+                ForeColor = Color.FromArgb(32, 32, 32);
+                _listView.BackColor = Color.FromArgb(225, 225, 225);
+                _listView.ForeColor = Color.FromArgb(32, 32, 32);
+                _refreshButton.ForeColor = Color.FromArgb(32, 32, 32);
+                _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(180, 180, 180);
             }
 
-            try { SetWindowTheme(_listView.Handle, isDark ? "DarkMode_Explorer" : "Explorer", null); }
+            try
+            {
+                SetWindowTheme(_listView.Handle, isDark ? "DarkMode_Explorer" : "Explorer", null);
+                IntPtr header = SendMessage(_listView.Handle, LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero);
+                if (header != IntPtr.Zero)
+                {
+                    SetWindowTheme(header, isDark ? "DarkMode_ItemsView" : "Explorer", null);
+                    SendMessage(header, WM_THEMECHANGED, IntPtr.Zero, IntPtr.Zero);
+                }
+            }
             catch { /* best-effort — header just stays whatever the OS default is */ }
         }
 

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -14,20 +14,20 @@ namespace ClarionAssistant.Dialogs
     /// </summary>
     public class DiagnosticsForm : Form
     {
-        // Win32 common-control ListView headers don't follow BackColor/ForeColor — without this,
-        // the column header band stays light even in dark mode. "DarkMode_Explorer" is the standard
-        // uxtheme.dll trick for making a ListView's native header (and scrollbar) follow dark mode.
-        // SetWindowTheme on the ListView handle alone only covers the item area/scrollbar — the
-        // column header is a separate child HWND (Header32) that needs its own SetWindowTheme call,
-        // plus a WM_THEMECHANGED nudge to make it actually repaint with the new palette.
+        // Win32 common-control ListView headers don't follow BackColor/ForeColor, and the
+        // "DarkMode_Explorer"/"DarkMode_ItemsView" SetWindowTheme trick only reliably recolors the
+        // header BACKGROUND, not its text — leaving black-on-near-black in dark mode. Owner-drawing
+        // the header (see OnDrawColumnHeader) gives full control over both, so use that instead.
         [DllImport("uxtheme.dll", CharSet = CharSet.Unicode)]
         private static extern int SetWindowTheme(IntPtr hWnd, string pszSubAppName, string pszSubIdList);
 
-        [DllImport("user32.dll")]
-        private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-
-        private const int LVM_GETHEADER = 0x1000 + 31;
-        private const int WM_THEMECHANGED = 0x031A;
+        // Makes the native title bar itself follow dark/light mode (Windows 10 20H1+ / Windows 11),
+        // so the caption looks like a normal OS window caption in either theme instead of always
+        // rendering in the OS default (light) regardless of the client area's theme.
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE = 20;
+        private const int DWMWA_USE_IMMERSIVE_DARK_MODE_OLD = 19;
 
         private ListView _listView;
         private Button _refreshButton;
@@ -36,6 +36,8 @@ namespace ClarionAssistant.Dialogs
         private readonly Action<int> _goToLine;
         private readonly Func<List<LspClient.DiagnosticEntry>> _refreshData;
         private bool _isDark = true;
+        private Color _headerBackColor = Color.White;
+        private Color _headerForeColor = Color.Black;
 
         public DiagnosticsForm(Action<int> goToLine, Func<List<LspClient.DiagnosticEntry>> refreshData)
         {
@@ -78,6 +80,7 @@ namespace ClarionAssistant.Dialogs
                 FullRowSelect = true,
                 GridLines = true,
                 HeaderStyle = ColumnHeaderStyle.Nonclickable,
+                OwnerDraw = true,
                 Font = new Font("Cascadia Code", 9f, FontStyle.Regular,
                     GraphicsUnit.Point, 0, false)
             };
@@ -86,6 +89,9 @@ namespace ClarionAssistant.Dialogs
             _listView.Columns.Add("Message", 400);
             _listView.DoubleClick += OnListDoubleClick;
             _listView.KeyDown += OnListKeyDown;
+            _listView.DrawColumnHeader += OnDrawColumnHeader;
+            _listView.DrawItem += (s, e) => e.DrawDefault = true;
+            _listView.DrawSubItem += (s, e) => e.DrawDefault = true;
 
             Controls.Add(_listView);
             Controls.Add(toolbar);
@@ -106,30 +112,43 @@ namespace ClarionAssistant.Dialogs
                 _listView.ForeColor = Color.FromArgb(235, 235, 235);
                 _refreshButton.ForeColor = Color.FromArgb(235, 235, 235);
                 _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(90, 90, 90);
+                // Header matches the list body exactly, same as it does natively in light mode.
+                _headerBackColor = _listView.BackColor;
+                _headerForeColor = _listView.ForeColor;
             }
             else
             {
-                // Plain light grey, not the pale lavender-tinted panel used before — that tint
-                // plus the soft grey text was too low-contrast to read comfortably.
                 BackColor = Color.FromArgb(240, 240, 240);
                 ForeColor = Color.FromArgb(32, 32, 32);
-                _listView.BackColor = Color.FromArgb(225, 225, 225);
+                _listView.BackColor = Color.White;
                 _listView.ForeColor = Color.FromArgb(32, 32, 32);
                 _refreshButton.ForeColor = Color.FromArgb(32, 32, 32);
                 _refreshButton.FlatAppearance.BorderColor = Color.FromArgb(180, 180, 180);
+                _headerBackColor = _listView.BackColor;
+                _headerForeColor = _listView.ForeColor;
             }
+            _listView.Invalidate();
+
+            try { SetWindowTheme(_listView.Handle, isDark ? "DarkMode_Explorer" : "Explorer", null); }
+            catch { /* best-effort — scrollbar just stays whatever the OS default is */ }
 
             try
             {
-                SetWindowTheme(_listView.Handle, isDark ? "DarkMode_Explorer" : "Explorer", null);
-                IntPtr header = SendMessage(_listView.Handle, LVM_GETHEADER, IntPtr.Zero, IntPtr.Zero);
-                if (header != IntPtr.Zero)
-                {
-                    SetWindowTheme(header, isDark ? "DarkMode_ItemsView" : "Explorer", null);
-                    SendMessage(header, WM_THEMECHANGED, IntPtr.Zero, IntPtr.Zero);
-                }
+                // Accessing Handle forces early creation if needed — safe pre-Show, and required
+                // so the caption is already themed correctly on first display (no dark→light flash).
+                int useDark = isDark ? 1 : 0;
+                if (DwmSetWindowAttribute(Handle, DWMWA_USE_IMMERSIVE_DARK_MODE, ref useDark, sizeof(int)) != 0)
+                    DwmSetWindowAttribute(Handle, DWMWA_USE_IMMERSIVE_DARK_MODE_OLD, ref useDark, sizeof(int));
             }
-            catch { /* best-effort — header just stays whatever the OS default is */ }
+            catch { /* best-effort — caption just stays whatever the OS default is */ }
+        }
+
+        private void OnDrawColumnHeader(object sender, DrawListViewColumnHeaderEventArgs e)
+        {
+            using (var brush = new SolidBrush(_headerBackColor))
+                e.Graphics.FillRectangle(brush, e.Bounds);
+            TextRenderer.DrawText(e.Graphics, e.Header.Text, _listView.Font, e.Bounds, _headerForeColor,
+                TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
         }
 
         public void UpdateDiagnostics(string filePath, List<LspClient.DiagnosticEntry> entries)

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -173,11 +173,17 @@ namespace ClarionAssistant.Dialogs
                 TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix);
         }
 
+        // One fixed middle gray for selection, used in BOTH themes (rather than per-theme accent
+        // colors) — legible against both the near-black dark background and white light background.
+        // Selected text keeps its normal severity color (red/amber/blue) instead of a forced
+        // white/black override, so a selected row still reads the same as an unselected one.
+        private static readonly Color SelectionBackColor = Color.FromArgb(128, 128, 128);
+
         private void OnDrawSubItem(object sender, DrawListViewSubItemEventArgs e)
         {
             bool selected = e.Item.Selected;
-            Color back = selected ? SystemColors.Highlight : _listView.BackColor;
-            Color fore = selected ? SystemColors.HighlightText : e.Item.ForeColor;
+            Color back = selected ? SelectionBackColor : _listView.BackColor;
+            Color fore = e.Item.ForeColor;
 
             using (var backBrush = new SolidBrush(back))
                 e.Graphics.FillRectangle(backBrush, e.Bounds);

--- a/ClarionAssistant/Dialogs/DiagnosticsForm.cs
+++ b/ClarionAssistant/Dialogs/DiagnosticsForm.cs
@@ -42,15 +42,21 @@ namespace ClarionAssistant.Dialogs
         private string _currentFileName = "";
         private readonly Action<int> _goToLine;
         private readonly Func<List<LspClient.DiagnosticEntry>> _refreshData;
+        // Refresh must re-read the file identity from the same source as the entries, not
+        // reuse the cached _currentFileName — see RefreshFromSource.
+        private readonly Func<string> _refreshFile;
         private bool _isDark = true;
         private Color _headerBackColor = Color.White;
         private Color _headerForeColor = Color.Black;
         private Color _gridLineColor = Color.FromArgb(220, 220, 220);
 
-        public DiagnosticsForm(Action<int> goToLine, Func<List<LspClient.DiagnosticEntry>> refreshData)
+        public DiagnosticsForm(Action<int> goToLine,
+                               Func<List<LspClient.DiagnosticEntry>> refreshData,
+                               Func<string> refreshFile)
         {
             _goToLine = goToLine;
             _refreshData = refreshData;
+            _refreshFile = refreshFile;
             InitializeUI();
         }
 
@@ -269,11 +275,17 @@ namespace ClarionAssistant.Dialogs
 
         private void RefreshFromSource()
         {
-            if (_refreshData != null)
-            {
-                var entries = _refreshData();
-                UpdateDiagnostics(_currentFileName, entries);
-            }
+            if (_refreshData == null) return;
+
+            // Both the file and the entries must come from the current source. Passing the
+            // cached _currentFileName here instead captioned the window with whatever file
+            // was showing when it last updated, while the rows below were the newly-fetched
+            // entries — which belong to whichever file the LSP has since moved on to. The
+            // two reads are safe as a pair: the source updates them together on the UI
+            // thread (AssistantChatControl.PollLspUi), and this runs on the UI thread too.
+            var entries = _refreshData();
+            string filePath = _refreshFile != null ? _refreshFile() : _currentFileName;
+            UpdateDiagnostics(filePath, entries);
         }
 
         private void OnListDoubleClick(object sender, EventArgs e)

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -1421,6 +1421,30 @@ namespace ClarionAssistant
             catch (Exception ex) { MonacoSpikeLog.Write("initial-open focus error: " + ex.Message); }
         }
 
+        /// <summary>
+        /// Dark/light state of the Monaco overlay on the ACTIVE document, or null when the active
+        /// document isn't one of these (or its surface isn't up yet). Mirrors
+        /// ModernEmbeditorViewContent.ActiveModernView()'s reflection walk — the workbench exposes
+        /// ActiveViewContent as an explicit-interface member, so it has to be reached via the window.
+        /// Callers want this in preference to CaEditorSettings.MonacoThemeDark, which records only
+        /// whichever page posted last and so drifts from the active editor as soon as two disagree.
+        /// </summary>
+        public static bool? ActiveEditorIsDark()
+        {
+            try
+            {
+                var wb = ICSharpCode.SharpDevelop.Gui.WorkbenchSingleton.Workbench;
+                if (wb == null) return null;
+                var aw = ReflectProp(wb, "ActiveWorkbenchWindow");
+                if (aw == null) return null;
+                var vc = ReflectProp(aw, "ActiveViewContent") ?? ReflectProp(aw, "ViewContent");
+                var me = vc as MonacoClarionEditor;
+                if (me == null || me._editor == null) return null;
+                return me._editor.IsDark;
+            }
+            catch { return null; }
+        }
+
         private static object ReflectProp(object obj, string name)
         {
             if (obj == null) return null;

--- a/ClarionAssistant/Terminal/LspStatusBar.cs
+++ b/ClarionAssistant/Terminal/LspStatusBar.cs
@@ -92,8 +92,10 @@ namespace ClarionAssistant.Terminal
 
         /// <summary>
         /// Update the diagnostics count display. Sets color based on severity.
+        /// <paramref name="known"/> false = the server has never published for this file, so the
+        /// counts mean "not told yet", not "none" — see the unknown branch below.
         /// </summary>
-        public void SetDiagnostics(int errors, int warnings, bool hidden)
+        public void SetDiagnostics(int errors, int warnings, bool hidden, bool known = true)
         {
             if (hidden)
             {
@@ -102,6 +104,25 @@ namespace ClarionAssistant.Terminal
             }
 
             Visible = true;
+
+            if (!known)
+            {
+                // Deliberately NOT the "OK" branch. Zero-errors and never-been-told are different
+                // claims, and the green check mark asserts the first while meaning the second —
+                // which is precisely the window where results are still arriving, so it read as
+                // "clean" right before flipping to errors. Muted color so it registers as absence
+                // of information rather than a result. Self-clears on the next poll tick.
+                // U+25CB (hollow) deliberately mirrors the U+25CF filled dot the real states use:
+                // same slot, no result yet — and it's the same Geometric Shapes block already
+                // proven to render in this Cascadia Code label.
+                // Escaped, not literal: this .cs has no BOM, so a non-ASCII literal is at the mercy
+                // of the compiler's encoding guess — same reason the three branches below escape.
+                _diagLabel.Text = "\u25CB \u2026";
+                _diagLabel.ForeColor = _isDark
+                    ? Color.FromArgb(108, 112, 134)   // Catppuccin overlay0
+                    : Color.FromArgb(140, 143, 161);
+                return;
+            }
 
             if (errors > 0)
             {

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1290,6 +1290,16 @@ namespace ClarionAssistant.Terminal
         /// <summary>The file this tab edits (file mode), else null.</summary>
         public string FilePath { get { return _filePath; } }
 
+        /// <summary>
+        /// The key this tab's diagnostics are cached under, or null when that cache isn't safe to
+        /// surface raw. FILE MODE ONLY, deliberately: there _lspFileName is the real file and the
+        /// squiggle pass runs with embedSlotChecks=false, so the cache is exactly what Monaco marked
+        /// up. In embed mode the same cache holds WHOLE-generated-buffer diagnostics that
+        /// ModernEmbeditorDiagnostics.Compute clamps to the editable slots before rendering —
+        /// reporting those unclamped would count generated-line noise the editor never squiggled.
+        /// </summary>
+        public string DiagnosticsCacheKey { get { return _fileMode ? _lspFileName : null; } }
+
         /// <summary>Find the open file-mode tab for a path, or null. Used by the open command to dedup so the same
         /// file doesn't open in two tabs (→ last-save-wins). Matches on the UNION of two identities:
         ///  • the canonical file ID (vol serial + file index) — collapses path aliases AND hard links;

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1300,6 +1300,22 @@ namespace ClarionAssistant.Terminal
         /// </summary>
         public string DiagnosticsCacheKey { get { return _fileMode ? _lspFileName : null; } }
 
+        /// <summary>
+        /// Dark/light state of the ACTIVE Modern tab's Monaco surface, or null when the active
+        /// document isn't one (or its panel isn't up yet). Preferred over
+        /// CaEditorSettings.MonacoThemeDark, which only records whichever page posted last and so
+        /// drifts from the active editor once two surfaces disagree.
+        /// </summary>
+        public static bool? ActiveViewIsDark()
+        {
+            try
+            {
+                var view = ActiveModernView();
+                return (view != null && view._panel != null) ? view._panel.IsDark : (bool?)null;
+            }
+            catch { return null; }
+        }
+
         /// <summary>Find the open file-mode tab for a path, or null. Used by the open command to dedup so the same
         /// file doesn't open in two tabs (→ last-save-wins). Matches on the UNION of two identities:
         ///  • the canonical file ID (vol serial + file index) — collapses path aliases AND hard links;

--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -165,6 +165,17 @@ namespace ClarionAssistant.Terminal
         /// "clarion-embeditor-data", matching monaco-embeditor.html).</summary>
         public string VirtualHost { get { return _virtualHost; } }
 
+        /// <summary>
+        /// THIS surface's current dark/light state, as opposed to the process-wide
+        /// CaEditorSettings.MonacoThemeDark mirror — which records whichever page most recently
+        /// booted or toggled, and so does NOT track the editor the user is currently looking at.
+        /// Seeded from the ctor and re-synced on every themeChanged this page posts (boot and each
+        /// toolbar toggle), which is the only way to know a given surface's theme: localStorage is
+        /// shared per-origin, but an already-open page never re-reads it, so its live theme exists
+        /// only in that page's memory until it tells us.
+        /// </summary>
+        public bool IsDark { get; private set; }
+
         public MonacoEditorControl(IMonacoEditorHost host, bool isDark = true,
                                    string htmlFileName = "monaco-embeditor.html",
                                    string virtualHost = "clarion-embeditor-data")
@@ -174,6 +185,7 @@ namespace ClarionAssistant.Terminal
             _virtualHost = string.IsNullOrEmpty(virtualHost) ? "clarion-embeditor-data" : virtualHost;
 
             Dock = DockStyle.Fill;
+            IsDark = isDark;
             BackColor = isDark ? Color.FromArgb(30, 30, 46) : Color.FromArgb(239, 241, 245);
 
             // Plain WebView2 — Monaco's native mouseWheelZoom owns Ctrl+wheel inside the renderer.
@@ -261,7 +273,12 @@ namespace ClarionAssistant.Terminal
                         // see CaEditorSettings.MonacoThemeDark). Handled here — not on IMonacoEditorHost — so
                         // every Monaco surface mirrors it without each host implementing anything. Payload is
                         // our own tiny fixed message, so a literal match beats a JSON round-trip.
-                        try { Services.CaEditorSettings.MonacoThemeDark = json.IndexOf("\"dark\":true", StringComparison.Ordinal) >= 0; }
+                        // Record it PER SURFACE as well as in the global mirror: the mirror only ever
+                        // says "whoever posted last", so it can't answer "what theme is the editor the
+                        // user is looking at right now" once two surfaces disagree. See IsDark.
+                        bool pageIsDark = json.IndexOf("\"dark\":true", StringComparison.Ordinal) >= 0;
+                        IsDark = pageIsDark;
+                        try { Services.CaEditorSettings.MonacoThemeDark = pageIsDark; }
                         catch { }
                         break;
                     case "openLocation":
@@ -563,6 +580,7 @@ namespace ClarionAssistant.Terminal
         /// {type:"applyTheme", isDark} once the surface is live.</summary>
         public void ApplyTheme(bool isDark)
         {
+            IsDark = isDark;
             BackColor = isDark ? Color.FromArgb(30, 30, 46) : Color.FromArgb(239, 241, 245);
             if (_isInitialized)
                 PostJson("{\"type\":\"applyTheme\",\"isDark\":" + (isDark ? "true" : "false") + "}");

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>851</VersionBuild>
-    <FullVersion>5.5.851</FullVersion>
-    <AssemblyFullVersion>5.5.851.0</AssemblyFullVersion>
+    <VersionBuild>853</VersionBuild>
+    <FullVersion>5.5.853</FullVersion>
+    <AssemblyFullVersion>5.5.853.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>870</VersionBuild>
-    <FullVersion>5.5.870</FullVersion>
-    <AssemblyFullVersion>5.5.870.0</AssemblyFullVersion>
+    <VersionBuild>872</VersionBuild>
+    <FullVersion>5.5.872</FullVersion>
+    <AssemblyFullVersion>5.5.872.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>880</VersionBuild>
-    <FullVersion>5.5.880</FullVersion>
-    <AssemblyFullVersion>5.5.880.0</AssemblyFullVersion>
+    <VersionBuild>882</VersionBuild>
+    <FullVersion>5.5.882</FullVersion>
+    <AssemblyFullVersion>5.5.882.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>862</VersionBuild>
-    <FullVersion>5.5.862</FullVersion>
-    <AssemblyFullVersion>5.5.862.0</AssemblyFullVersion>
+    <VersionBuild>864</VersionBuild>
+    <FullVersion>5.5.864</FullVersion>
+    <AssemblyFullVersion>5.5.864.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>857</VersionBuild>
-    <FullVersion>5.5.857</FullVersion>
-    <AssemblyFullVersion>5.5.857.0</AssemblyFullVersion>
+    <VersionBuild>860</VersionBuild>
+    <FullVersion>5.5.860</FullVersion>
+    <AssemblyFullVersion>5.5.860.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>872</VersionBuild>
-    <FullVersion>5.5.872</FullVersion>
-    <AssemblyFullVersion>5.5.872.0</AssemblyFullVersion>
+    <VersionBuild>876</VersionBuild>
+    <FullVersion>5.5.876</FullVersion>
+    <AssemblyFullVersion>5.5.876.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>866</VersionBuild>
-    <FullVersion>5.5.866</FullVersion>
-    <AssemblyFullVersion>5.5.866.0</AssemblyFullVersion>
+    <VersionBuild>868</VersionBuild>
+    <FullVersion>5.5.868</FullVersion>
+    <AssemblyFullVersion>5.5.868.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>876</VersionBuild>
-    <FullVersion>5.5.876</FullVersion>
-    <AssemblyFullVersion>5.5.876.0</AssemblyFullVersion>
+    <VersionBuild>880</VersionBuild>
+    <FullVersion>5.5.880</FullVersion>
+    <AssemblyFullVersion>5.5.880.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>855</VersionBuild>
-    <FullVersion>5.5.855</FullVersion>
-    <AssemblyFullVersion>5.5.855.0</AssemblyFullVersion>
+    <VersionBuild>857</VersionBuild>
+    <FullVersion>5.5.857</FullVersion>
+    <AssemblyFullVersion>5.5.857.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>882</VersionBuild>
-    <FullVersion>5.5.882</FullVersion>
-    <AssemblyFullVersion>5.5.882.0</AssemblyFullVersion>
+    <VersionBuild>884</VersionBuild>
+    <FullVersion>5.5.884</FullVersion>
+    <AssemblyFullVersion>5.5.884.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>853</VersionBuild>
-    <FullVersion>5.5.853</FullVersion>
-    <AssemblyFullVersion>5.5.853.0</AssemblyFullVersion>
+    <VersionBuild>855</VersionBuild>
+    <FullVersion>5.5.855</FullVersion>
+    <AssemblyFullVersion>5.5.855.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>860</VersionBuild>
-    <FullVersion>5.5.860</FullVersion>
-    <AssemblyFullVersion>5.5.860.0</AssemblyFullVersion>
+    <VersionBuild>862</VersionBuild>
+    <FullVersion>5.5.862</FullVersion>
+    <AssemblyFullVersion>5.5.862.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>868</VersionBuild>
-    <FullVersion>5.5.868</FullVersion>
-    <AssemblyFullVersion>5.5.868.0</AssemblyFullVersion>
+    <VersionBuild>869</VersionBuild>
+    <FullVersion>5.5.869</FullVersion>
+    <AssemblyFullVersion>5.5.869.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>869</VersionBuild>
-    <FullVersion>5.5.869</FullVersion>
-    <AssemblyFullVersion>5.5.869.0</AssemblyFullVersion>
+    <VersionBuild>870</VersionBuild>
+    <FullVersion>5.5.870</FullVersion>
+    <AssemblyFullVersion>5.5.870.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>

--- a/ClarionAssistant/Version.props
+++ b/ClarionAssistant/Version.props
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <VersionMajor>5</VersionMajor>
     <VersionMinor>5</VersionMinor>
-    <VersionBuild>864</VersionBuild>
-    <FullVersion>5.5.864</FullVersion>
-    <AssemblyFullVersion>5.5.864.0</AssemblyFullVersion>
+    <VersionBuild>866</VersionBuild>
+    <FullVersion>5.5.866</FullVersion>
+    <AssemblyFullVersion>5.5.866.0</AssemblyFullVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# fix: diagnostics window follows the CA Editor's theme, plus readability and correctness fixes

## Summary

The LSP status bar and the diagnostics popup window (opened by clicking the error/warning count in the status bar) always rendered in the chat pane's own dark/light setting, which is a separate preference from the CA Editor's own Monaco dark/light setting. If the two didn't match, the diagnostics window would look wrong compared to the editor. On top of that, once matched up, the window itself had a handful of rough edges — some of them plain bugs, some just low-contrast/low-legibility styling — that made it harder to read than it should be.

This PR makes the diagnostics window follow the CA Editor's own theme setting, and fixes those rough edges along the way.

**Scope note:** this started as a purely visual PR, and grew. Working on the window's appearance meant looking at it a lot, and that surfaced three correctness bugs in the same feature — including one where the status bar pill never appeared at all, which made the window unreachable in the most common configuration. Those are fixed here too rather than deferred, since they're the same window and the same code path. They're listed separately below.

## What changed — appearance

- **Theme source**: status bar and diagnostics window now read `CaEditorSettings.MonacoThemeDark` instead of the chat pane's theme. There's no change notification for that setting, so `AssistantChatControl.PollLspUi` (already ticking every 2s) also polls it and re-applies the theme on change — including on the diagnostics window's first-ever open, which had its own separate bug: it was reading the chat pane's theme on construction even after everything else was switched over.
- **Window layout**: filename folded into the window title (`Diagnostics — filename.clw`) instead of its own label row; the text "Refresh" button replaced with a compact icon-only button.

  The filename move is a deliberate space tradeoff, not an accident: the window is 340px tall by default with a 24px toolbar strip, and a separate label row spent roughly 10% of the client area on one short string the title bar shows for free. It costs no information — the window is strictly single-file, and the caption and the rows are populated from the same `filePath` in `PollLspUi`, so the caption can't disagree with the list. (It *could* disagree before this PR, via the refresh button — see the correctness section.)
- **Column header colors**: the header wasn't following the theme at all (plain OS default regardless of dark/light), and the standard `SetWindowTheme` trick for native ListView headers only reliably recolors the background, not the text — that left black-on-near-black in dark mode. Fixed by owner-drawing the header instead, for full control of both.
- **List background**: switched from a low-contrast, slightly-tinted palette to a plainer high-contrast one, and made the list/header background match the window's own background in both themes (previously they were different shades).
- **Grid lines**: native ListView grid lines use a fixed, non-theme-aware system color — shows up as stark white lines in dark mode. Now hand-drawn per-cell using a muted, per-theme color instead.
- **Selection highlight**: was hardcoded to the system blue-highlight/white-text pair, which didn't match the window's palette and overrode each row's severity color (red/amber/blue). Now uses a subtle per-theme background tint and keeps the row's own text color.
- **Hover flicker**: owner-drawing a ListView without enabling double buffering (not exposed publicly on `ListView`, set via reflection) visibly flashes on every repaint, including the ones Windows triggers from mouse-hover tracking alone.
- **Window caption**: added `DWMWA_USE_IMMERSIVE_DARK_MODE` so the native title bar follows dark/light at all, and (Windows 11 22H2+) `DWMWA_CAPTION_COLOR`/`DWMWA_TEXT_COLOR` so it matches the window's own palette exactly rather than the OS's generic dark-mode caption text.
- **Tooltip never showing**: the refresh button's tooltip silently never appeared. `ToolTip` only displays by default when its parent form is the active foreground window, and this non-modal tool window (opened via `Show(owner)` from the docked chat pane) apparently never becomes the active window. `ShowAlways = true` fixes it. (This is very likely also why keyboard input doesn't reach this window — not changed here, just noting it as a related, still-open observation.)
- **Washed-out severity text**: moving cell/header text drawing to manual owner-draw (needed for the header/gridlines/selection work above) introduced its own regression — drawing it with GDI's `TextRenderer.DrawText` rendered the red/amber severity colors visibly paler than their actual value, and passing the real background color through the 7-arg overload (to fix ClearType's background-compositing assumption) didn't fully resolve it either. Switched to GDI+'s `Graphics.DrawString` with a `SolidBrush` instead, which paints the exact requested color via normal alpha blending with no backdrop-composition ambiguity at all.

## What changed — correctness

- **The status bar pill never appeared, so the diagnostics window was unreachable.** `PollLspUi` gated the entire status bar on the *bundled* `LspClient` (`lsp == null || !lsp.IsRunning` → hide). When the IDE's own ClarionLsp addin is the active client, the bundled one is never started at all, so that test failed on every tick and the pill was hidden unconditionally — and clicking the pill is its only trigger. Meanwhile the editor showed squiggles perfectly well, because the squiggle pass and every other consumer already route through `SharedLspBridge`. The two clients also keep *separate* diagnostics caches (`LspClient._diagnostics` vs `SharedLspBridge._sharedDiagCache`), so reading the bundled cache would have come back empty even past the gate. Both the liveness check and the cache read now go through the bridge.

  The bridge has no equivalent of `LspClient.LastActiveFilePath`, so target resolution moved to the active editor. There are two independent Monaco-backed editing surfaces and either can be active: `MonacoClarionEditor` (a Monaco overlay on the native Clarion source editor — the common case, resolved by `EditorService.GetActiveDocumentPath()`), and `ModernEmbeditorViewContent` (the separate CA Editor tab, which exposes neither `FileName` nor `PrimaryFileName`, so `GetActiveDocumentPath()`'s probes always miss it and it needs its own lookup). `ResolveDiagnosticsTarget` tries both, then falls back to `LastActiveFilePath`.

  Preferring the active editor is also a behavioral improvement in its own right: `LastActiveFilePath` follows the last file *any* LSP tool touched, so a chat-driven hover or definition lookup — or a full-solution diagnostics sweep — would silently repoint the pill and the window at a file nobody is editing.
- **The refresh button captioned the window with a stale filename.** `RefreshFromSource` pulled fresh entries from its refresh delegate but reused the cached `_currentFileName` for the caption, so pressing refresh after the target had moved captioned one file over another file's rows. It now takes the file identity from the same source as the entries. (The two reads are safe as a pair: `PollLspUi` sets both together on the UI thread, and the click handler is UI-thread too.)
- **The pill claimed a green "OK" for files it had never heard about.** `SetDiagnostics` had no way to express "don't know yet", so an unanalyzed file was flattened to 0 errors / 0 warnings and rendered with the same green check mark as a genuinely clean file — an affirmative all-clear during exactly the window in which results are still arriving. The distinction was already available and simply being discarded: `GetCachedDiagnostics` returns `null` when nothing has ever been published for a file (the bundled client tracks this as `DiagnosticSet.WasPublished`, whose own comment calls out this exact case; the shared client, by the key being absent), while an authoritatively clean file caches an *empty* list. Added a third, muted pill state for it.

  Deliberately *not* a progress spinner: LSP has no "analysis complete" notification, so nothing can honestly report when a file is finished being analyzed, and a spinner that stopped early would assert a finality it can't know. This only claims what's actually knowable — nothing has been published yet — and self-clears on the next poll tick.
- **Severity text kept the previous theme's palette after a theme switch.** Rows were coloured once, when added, from the `_isDark` in effect at that moment; `ApplyTheme` updated backgrounds, header, gridlines and caption but never the rows already in the list. Switching dark → light therefore left the dark palette's pastel red and amber sitting on the light background, where they read as washed out, and it persisted until the next `UpdateDiagnostics` happened to rebuild the rows.

  This one is **not introduced by this PR** — the per-item colouring has looked like this since the form was written. It was unreachable, because the window's theme used to be fixed at construction, so there was never a live switch to expose it. Making the window follow a theme that changes at runtime is what turns it into a visible defect, so it's fixed here rather than left behind as a parting gift. The colour was recomputable all along; only its input was being discarded. Rows now carry the severity alongside the line number, and both the build path and the recolour path go through one `SeverityColor(severity)` helper so they can't drift apart.
- **The window followed whichever Monaco surface last spoke, not the one being looked at.** `CaEditorSettings.MonacoThemeDark` is a mirror, written whenever any Monaco page posts `themeChanged` — at boot and on each toolbar toggle. Switching tabs posts nothing, so the mirror doesn't move: with two editors open in different themes, the diagnostics window stayed on whichever one was last toggled or last opened, not the active one. Nothing tracked theme per surface to fix this with, so `MonacoEditorControl` gained an `IsDark` property (seeded from its constructor, kept in sync on every `themeChanged` and in `ApplyTheme`), and each editor surface exposes an active-instance accessor for it (`MonacoClarionEditor.ActiveEditorIsDark()`, `ModernEmbeditorViewContent.ActiveViewIsDark()`). `ResolveEditorThemeDark()` tries both, then falls back to the mirror — deliberately the same shape as `ResolveDiagnosticsTarget` above, active surface first, global as fallback.

  The mirror keeps its existing meaning and stays the fallback, so the pre-paint covers/backdrops it was originally built for (dark-mode no-white-flash on embeditor open) are unaffected — this doesn't make theme *shared* across surfaces, only resolves it correctly per consumer. Making it genuinely shared would reverse that original page-authoritative design and change every Monaco window's behaviour, which belongs in its own issue, not here.

## Test plan

- [x] Builds clean
- [x] Deployed and live-tested after each change, in both dark and light mode, including toggling the CA Editor's theme setting while the diagnostics window was open
- [x] Verified the window opens in the correct theme on its very first open, not just after a subsequent toggle
- [x] Confirmed diagnostics content itself (errors/warnings, line numbers, click-to-navigate) unaffected — spot-checked against a file with a real compile error
- [x] Full end-to-end pass on the correctness fixes: open IDE → load solution → pill shows `17W` → click pill → window opens with the 17 warnings → switch to another source file with the window still open → caption follows the new file and the list updates to `1E 7W`, contents correct → close solution → pill disappears → reload the same solution → correct again
- [x] Severity colours stay correct across a live dark ⇄ light switch with the window already populated
- [x] With two editors open in different themes, switching the active tab repaints the pill and window to match within one poll tick (~2s, the existing polling cadence — noticeable but not incorrect; not changed in this PR)

## Related, still open — not addressed here

- The diagnostics window doesn't receive keyboard input (Enter-to-navigate, arrow-key list navigation) even though the handling exists in code. Almost certainly the same root cause as the tooltip bug above — the window never becomes the active foreground window.
- The window is single-file by design. A full-solution sweep reports per-file in chat and doesn't populate this window. Aggregating multiple files into it would be a real feature (File column, per-entry paths, navigate-to-file via the existing `EditorService.NavigateToFileAndLine`) rather than a tweak — nothing is blocked on missing data, since `DiagnosticEntry` has no file field but the cache is keyed by file URI one level up. Deliberately left out of scope.

