### PR TITLE
fix(diagnostics): stop the squiggle overlay going blank on slow or premature LSP results

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -984,10 +984,14 @@ namespace ClarionAssistant
         {
             int reqId; string buffer; List<int[]> ranges;
             if (!ParseDiagRequest(rawJson, out reqId, out buffer, out ranges)) return;
-            System.Threading.Tasks.Task.Run(() =>
+            System.Threading.Tasks.Task.Run(async () =>
             {
                 var markers = new List<Dictionary<string, object>>();
-                try { markers = ModernEmbeditorDiagnostics.Compute(_filePath, buffer ?? "", ranges, null, embedSlotChecks: true); }
+                try
+                {
+                    markers = await ModernEmbeditorDiagnostics.ComputeAsync(
+                        _filePath, buffer ?? "", ranges, null, embedSlotChecks: true).ConfigureAwait(false);
+                }
                 catch (Exception ex) { MonacoSpikeLog.Write("overlay diagnostics error: " + ex.Message); }
                 editor.PostResponse(reqId, new Dictionary<string, object> { { "markers", markers } });
             });

--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -162,11 +162,7 @@ namespace ClarionAssistant.Services
                     int off = (lspContext != null) ? lspContext.LineOffset : 0;
                     SharedLspBridge.EnsureBufferSynced(lspFileName,
                         (lspContext != null) ? lspContext.WrapBuffer(buffer) : buffer);
-                    var wait = SharedLspBridge.WaitForDiagnostics(lspFileName, 1500, true);
-                    List<LspClient.DiagnosticEntry> entries =
-                        (wait != null && !wait.Pending && wait.Entries != null)
-                            ? wait.Entries
-                            : (SharedLspBridge.GetCachedDiagnostics(lspFileName) ?? new List<LspClient.DiagnosticEntry>());
+                    List<LspClient.DiagnosticEntry> entries = WaitForSettledDiagnostics(lspFileName);
 
                     foreach (var d in entries)
                     {
@@ -327,6 +323,45 @@ namespace ClarionAssistant.Services
             }
 
             return markers;
+        }
+
+        // The Clarion LSP publishes diagnostics progressively for a file that just changed: an early
+        // batch (sometimes empty) arrives first, with slower checks — e.g. the cross-file scope
+        // resolution behind an undeclared-variable warning — landing in a later republish. A single
+        // bounded WaitForDiagnostics can catch that early batch and mistake it for final: confirmed
+        // live (lsp_diagnostics raced an authoritative-looking "0 entries" twice in a row before the
+        // real, complete set — including the undeclared-variable warning — arrived on the 3rd query).
+        // That empty-but-premature result is indistinguishable from a genuinely clean file using
+        // WasPublished alone (both are "published, zero entries") — the same ambiguity PR #169
+        // (bb77f85) fixed for the diagnostics pill via a null-vs-empty check, which doesn't help here
+        // since this isn't null.
+        //
+        // Only an EMPTY result gets the extra scrutiny — a non-empty result already found something
+        // real and returns immediately, so files with existing diagnostics see no added latency.
+        // For an empty result, keep re-checking the (passive, non-blocking) diagnostics cache for a
+        // short settle window and take whatever lands, so a slow-to-resolve identifier gets the extra
+        // time its diagnostic needs instead of losing the race to the file's first, still-catching-up
+        // publish.
+        private const int SettleIntervalMs = 400;
+        private const int SettleMaxChecks = 5; // ~2s extra ceiling, on top of the initial 1500ms wait
+
+        private static List<LspClient.DiagnosticEntry> WaitForSettledDiagnostics(string lspFileName)
+        {
+            var wait = SharedLspBridge.WaitForDiagnostics(lspFileName, 1500, true);
+            List<LspClient.DiagnosticEntry> last =
+                (wait != null && !wait.Pending && wait.Entries != null)
+                    ? wait.Entries
+                    : (SharedLspBridge.GetCachedDiagnostics(lspFileName) ?? new List<LspClient.DiagnosticEntry>());
+
+            for (int i = 0; last.Count == 0 && i < SettleMaxChecks; i++)
+            {
+                System.Threading.Thread.Sleep(SettleIntervalMs);
+                var next = SharedLspBridge.GetCachedDiagnostics(lspFileName);
+                if (next == null) continue; // no fresher publish yet — keep waiting out the settle window
+                last = next;
+                if (last.Count > 0) break; // a fuller batch landed — done, no need to keep waiting
+            }
+            return last;
         }
 
         private static bool InAnyRange(int line1, List<int[]> ranges)

--- a/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorDiagnostics.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace ClarionAssistant.Services
 {
@@ -142,7 +143,7 @@ namespace ClarionAssistant.Services
         /// or labels as if a structure opened, producing bogus "FILE is not terminated with END" errors.
         /// The LSP/compiler does real whole-file structure validation, so the heuristic adds only noise.
         /// </summary>
-        public static List<Dictionary<string, object>> Compute(
+        public static async Task<List<Dictionary<string, object>>> ComputeAsync(
             string lspFileName, string buffer, List<int[]> ranges, string procedureName,
             bool embedSlotChecks = true, EmbedLspContext lspContext = null)
         {
@@ -162,7 +163,8 @@ namespace ClarionAssistant.Services
                     int off = (lspContext != null) ? lspContext.LineOffset : 0;
                     SharedLspBridge.EnsureBufferSynced(lspFileName,
                         (lspContext != null) ? lspContext.WrapBuffer(buffer) : buffer);
-                    List<LspClient.DiagnosticEntry> entries = WaitForSettledDiagnostics(lspFileName);
+                    List<LspClient.DiagnosticEntry> entries =
+                        await WaitForSettledDiagnosticsAsync(lspFileName).ConfigureAwait(false);
 
                     foreach (var d in entries)
                     {
@@ -345,7 +347,13 @@ namespace ClarionAssistant.Services
         private const int SettleIntervalMs = 400;
         private const int SettleMaxChecks = 5; // ~2s extra ceiling, on top of the initial 1500ms wait
 
-        private static List<LspClient.DiagnosticEntry> WaitForSettledDiagnostics(string lspFileName)
+        // await Task.Delay, NOT Thread.Sleep: this runs on a thread-pool thread (both call sites
+        // dispatch through Task.Run), and slow typing — keystrokes further apart than the page's 600ms
+        // debounce — puts several of these requests in flight at once. Sleeping would park one pool
+        // thread per request for the whole settle window; past the pool's core-count baseline .NET only
+        // injects replacements at roughly 1-2/sec, so queuing delay compounds exactly when requests
+        // overlap, which is the same slow-machine case this settle window exists to serve.
+        private static async Task<List<LspClient.DiagnosticEntry>> WaitForSettledDiagnosticsAsync(string lspFileName)
         {
             var wait = SharedLspBridge.WaitForDiagnostics(lspFileName, 1500, true);
             List<LspClient.DiagnosticEntry> last =
@@ -355,7 +363,7 @@ namespace ClarionAssistant.Services
 
             for (int i = 0; last.Count == 0 && i < SettleMaxChecks; i++)
             {
-                System.Threading.Thread.Sleep(SettleIntervalMs);
+                await Task.Delay(SettleIntervalMs).ConfigureAwait(false);
                 var next = SharedLspBridge.GetCachedDiagnostics(lspFileName);
                 if (next == null) continue; // no fresher publish yet — keep waiting out the settle window
                 last = next;

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -2951,18 +2951,19 @@ namespace ClarionAssistant.Terminal
         {
             int reqId; string buffer; List<int[]> ranges;
             if (!ParseDiagnosticsRequest(json, out reqId, out buffer, out ranges)) return;
-            Task.Run(() =>
+            Task.Run(async () =>
             {
                 var markers = new List<Dictionary<string, object>>();
                 try
                 {
-                    markers = ModernEmbeditorDiagnostics.Compute(
+                    markers = await ModernEmbeditorDiagnostics.ComputeAsync(
                         _lspFileName,
                         buffer ?? _sourceText,
                         (ranges != null && ranges.Count > 0) ? ranges : _editableRanges,
                         _procedureName,
                         embedSlotChecks: !_fileMode,    // file mode: LSP only, skip embed-slot heuristics
-                        lspContext: _lspContext);       // #56: wrap the LSP pass with the MEMBER header
+                        lspContext: _lspContext)        // #56: wrap the LSP pass with the MEMBER header
+                        .ConfigureAwait(false);
                 }
                 catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[ModernEmbeditor] diagnostics: " + ex.Message); }
                 PostResponse(reqId, new Dictionary<string, object> { { "markers", markers } });

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -1450,7 +1450,10 @@
     }
 
     // ----- Async request/response to the C# host (for LSP completion + hover) -----
-    function requestFromHost(action, payload) {
+    // timeoutMs is per-call and defaults to 4000: completion/hover are interactive and should give up
+    // fast, but the diagnostics round-trip has a legitimately longer worst case (see DIAG_TIMEOUT_MS)
+    // and must not be judged by the interactive budget.
+    function requestFromHost(action, payload, timeoutMs) {
         return new Promise(function (resolve) {
             var reqId = ++reqSeq;
             pendingRequests[reqId] = resolve;
@@ -1460,7 +1463,7 @@
             // Don't hang a Monaco provider forever if the host never replies.
             setTimeout(function () {
                 if (pendingRequests[reqId]) { delete pendingRequests[reqId]; resolve(null); }
-            }, 4000);
+            }, timeoutMs || 4000);
         });
     }
 
@@ -3450,12 +3453,30 @@
         return embedRanges.map(function (r) { return [r[0], r[1]]; });
     }
 
+    // Must exceed the host's own worst-case diagnostics latency, or a slow-but-successful analysis is
+    // discarded by the client that asked for it. That worst case is the LSP settle window in
+    // ModernEmbeditorDiagnostics (an initial bounded wait plus a bounded poll for a late republish),
+    // plus the buffer sync and marshalling a whole-file buffer across the WebView2 boundary each way —
+    // several seconds on a slow machine or a large file. Deliberately generous: with the timeout no
+    // longer clearing markers (below), overshooting costs nothing but a late no-op.
+    var DIAG_TIMEOUT_MS = 10000;
+
     function refreshDiagnostics() {
         if (!editor) return;
         var model = editor.getModel();
-        requestFromHost('diagnostics', { buffer: model.getValue(), ranges: liveEditableRanges() })
+        requestFromHost('diagnostics', { buffer: model.getValue(), ranges: liveEditableRanges() }, DIAG_TIMEOUT_MS)
             .then(function (resp) {
-                var markers = (resp && resp.markers) || [];
+                // null = the host never replied in time: NO INFORMATION, which is not the same claim as
+                // "this file has zero diagnostics". setModelMarkers REPLACES the whole set, so treating a
+                // timeout as an empty list actively wipes every squiggle AND its gutter/overview-ruler
+                // mark, with no retry until the next edit — the worst possible reading of "don't know".
+                // Keep what's already rendered instead; Monaco tracks those markers across subsequent
+                // edits, and the next successful round-trip replaces them wholesale.
+                // A reply that IS present but carries an empty list still clears, as it should — that
+                // is the host telling us the file really is clean. Same null-vs-empty distinction the
+                // diagnostics pill draws in PollLspUi.
+                if (!resp) return;
+                var markers = resp.markers || [];
                 monaco.editor.setModelMarkers(model, 'clarion', markers.map(function (m) {
                     return {
                         severity: m.severity,

--- a/ClarionAssistant/docs/ModernEmbeditor-PathA.md
+++ b/ClarionAssistant/docs/ModernEmbeditor-PathA.md
@@ -612,7 +612,7 @@ validators run over the WHOLE generated buffer, so a user's unterminated IF in a
 balanced/masked by surrounding generated ENDs (reports 0, or flags the wrong line near EOF) and markers on
 read-only generated lines are noise. ⇒ pure-LSP is near-useless for embed-slot editing.
 
-**Implemented hybrid** (`Services/ModernEmbeditorDiagnostics.Compute`):
+**Implemented hybrid** (`Services/ModernEmbeditorDiagnostics.ComputeAsync`):
   - Pass 1 — LSP structural diagnostics, **clamped** to live editable slots (drops generated-line
     noise/mislocations); LSP severity → Monaco MarkerSeverity.
   - Pass 2 — **per-slot structure balance** (open/close stack; opener w/o END or '.' in the slot → Error;


### PR DESCRIPTION


## Summary

The squiggle overlay — and with it every gutter/overview-ruler mark — could render **nothing at all** for a file, even when the diagnostics pill correctly reported an error or warning for that same file moments later.

Four defects on the squiggle diagnostics path, all producing that one symptom. They share a root theme: **the path conflates "no information yet" with "authoritatively zero diagnostics"**, in two separate places, and then compounds it with two latency problems. That's the same conflation #169 fixed for the diagnostics pill (`GetCachedDiagnostics` returning `null` — never published — versus an empty list — published and genuinely clean); the pill survives it anyway because it re-polls every 2 seconds forever, whereas the squiggle path fires once per edit and never looks again.

## 1. A premature empty LSP republish was trusted as final

The Clarion LSP publishes diagnostics progressively after a buffer change: an early batch — sometimes empty — can land before a slower check finishes and republishes the fuller set. The single bounded `SharedLspBridge.WaitForDiagnostics(lspFileName, 1500, true)` call in `ModernEmbeditorDiagnostics` could catch that early batch and treat it as the final answer.

Reproduced directly against a running LSP session: a diagnostics request raced an authoritative-looking `{"pending":false,"count":0}` result **twice in a row** before the real, complete set — including a warning that needs cross-file scope resolution to compute — arrived on a third query. Same file, same content, no edit in between.

`WasPublished` cannot distinguish this case, because a premature batch *is* published (`WasPublished=true`, `Entries=[]`) — identical to a genuinely clean file by that signal alone.

**Fix:** only an *empty* result gets extra scrutiny — a non-empty one already found something real and returns immediately, so files with existing diagnostics see no added latency. For an empty result, re-read the diagnostics cache over a short settle window and take whatever lands. The re-read is passive: it inspects the cache the publish handler populates, and never issues another request.

## 2. A timed-out round-trip actively wiped the marker set

`requestFromHost` resolves `null` when the host doesn't reply in time, and `refreshDiagnostics` folded that straight into an empty marker list:

```js
var markers = (resp && resp.markers) || [];
```

Since `setModelMarkers` **replaces** the entire set, a slow round-trip didn't merely fail to add a squiggle — it erased every existing one, plus its gutter and overview-ruler marks, with no retry until the next edit. That is the worst available reading of "don't know."

**Fix:** a `null` response now leaves the rendered markers alone; Monaco already tracks them across subsequent edits, and the next successful round-trip replaces them wholesale. An authoritative empty list still clears, as it should.

## 3. The client's timeout sat below the host's worst case

That timeout was a fixed 4000ms, shared with the interactive completion and hover callers — but below the diagnostics path's own worst case (the settle window described above, plus the buffer sync and marshalling a whole-file buffer across the WebView2 boundary in each direction). So the client could discard a slow but **successful** analysis.

**Fix:** `requestFromHost` takes a per-call timeout, defaulting to the previous 4000ms so completion and hover keep their short interactive budget. Only the diagnostics call opts into a longer one. Raising the shared constant instead would have made an unresponsive LSP hang hover and completion too — a regression in the opposite direction.

## 4. The settle loop blocked thread-pool threads

That same settle window used `Thread.Sleep`, and both call sites dispatch `Compute` through `Task.Run`. Keystrokes spaced further apart than the page's own 600ms debounce each dispatch their own request, so several run concurrently — each parking a pool thread for the whole settle window. Past the pool's core-count baseline .NET injects replacements at only ~1–2/sec, so queuing delay compounds precisely when requests overlap, which is the same slow-machine case the settle window exists to serve.

**Fix:** `Compute` becomes `ComputeAsync` and awaits `Task.Delay`. Both call sites already ran off the UI thread, so nothing moves on or off it; `ConfigureAwait(false)` keeps the continuation off the captured context exactly as before.

## Verification

- Clean build, no new warnings (`ClarionAssistant.csproj`, VS2022 MSBuild toolset), with the branch built standalone off `master`.
- Live-tested for the premature-republish case: an identifier declared elsewhere in the workspace but out of scope at the point of use — so ruling it out requires the slower cross-file check — previously never squiggled, while a similar identifier appearing nowhere in the workspace always did. After the fix both squiggle correctly, gutter marks included, and the previously-slow transition is immediate. No added latency observed on files that already carry diagnostics.
- The remaining three only manifest under timing conditions. Exercised live by typing at roughly one character per second — slower than the editor's own 600ms debounce, so every keystroke dispatches its own request and several overlap: markers appeared consistently, the gutter stayed stable, and there was no flashing or marker loss. The specific worst-case triggers (a round-trip exceeding the client timeout; thread-pool starvation under sustained overlap) are not reproducible on demand and were verified by code reading.

## Known remaining gap, deliberately not in this PR

`refreshDiagnostics` has no request sequencing: each debounce cycle dispatches its own request, and whichever *response* arrives last wins, regardless of dispatch order. Because the diagnostics cache is keyed per file with no version, an older request can return *newer* LSP data than the buffer it was computed against, so markers can land a few lines off until the next edit corrects them.

That is a distinct bug — different root cause, different symptom, and independent of everything above — so it belongs in its own change. Worth noting for whoever picks it up: `Terminal/monaco-embeditor.html` already implements exactly the needed guard for saves (`if (msg.savedSeq == null || msg.savedSeq === editSeq) doCancel();`), so the pattern is established there rather than novel.

