### PR TITLE
 fix(create-class): highlight keywords before strings to avoid HTML attribute collision

### DIFF
--- a/ClarionAssistant/Terminal/create-class.html
+++ b/ClarionAssistant/Terminal/create-class.html
@@ -359,13 +359,13 @@
       var codePart = commentIdx >= 0 ? line.substring(0, commentIdx) : line;
       var commentPart = commentIdx >= 0 ? '<span class="hl-comment">' + line.substring(commentIdx) + '</span>' : '';
 
-      // Highlight strings
-      codePart = codePart.replace(/'([^']*)'/g, '<span class="hl-string">\'$1\'</span>');
-
       // Highlight keywords
       codePart = codePart.replace(keywords, function(match) {
         return '<span class="hl-keyword">' + match + '</span>';
       });
+
+      // Highlight strings
+      codePart = codePart.replace(/'([^']*)'/g, '<span class="hl-string">\'$1\'</span>');
 
       result.push(codePart + commentPart);
     }


### PR DESCRIPTION
## Summary

`Create New Class` → class-model code preview (`Terminal/create-class.html`) rendered visibly broken HTML for any model whose declaration contains both a Clarion keyword and a quoted string on the same line — e.g. a standard `CLASS,TYPE,MODULE('X.CLW'),LINK('X.CLW')` declaration showed the literal text `class="hl-string">'X.CLW'` instead of a colored string.

## Root cause

`highlightClarion()` ran two sequential regex passes over the same string:

1. Wrap quoted strings in `<span class="hl-string">'...'</span>`
2. Wrap keywords in `<span class="hl-keyword">...</span>`

The keyword regex is case-insensitive (`/gi`) and its word list includes `CLASS` and `STRING`. Since pass 2 runs on the HTML already produced by pass 1, it also matches the literal `class` and `string` substrings inside the `class="hl-string"` attribute pass 1 just injected, wrapping them in a nested `<span>` and corrupting the tag — a `<span>` can't validly contain another tag inside its own attribute list, so the browser renders the mangled markup as literal text instead of colored HTML.

## Fix

Swap the order: highlight keywords first, on raw (pre-HTML) text, then highlight strings second. With this order there is no HTML for the keyword pass to collide with, and the string pass's single-quote regex doesn't match anything inside the keyword pass's double-quoted `class="hl-keyword"` attributes either.

This also preemptively fixes a second, not-yet-reported instance of the identical bug: `STRING` is also a keyword, and would have corrupted the `hl-string` attribute the same way in a template line combining a `STRING` field declaration with a quoted default value.

## Verification

- Live-tested in the running Clarion IDE: opened Create New Class, selected the `StandardLegacy` model — the `MODULE('StandardLegacy.CLW')`/`LINK('StandardLegacy.CLW')` line now renders with correctly colored keywords and string literals, no literal `class="hl-string">` text.
- Change is a 2-statement reorder with no other logic touched; diff is minimal and isolated to `Terminal/create-class.html`.
