### PR TITLE
fix(completion): bare-prefix CodeGraph merge leaks procedure-local variables solution-wide

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -1899,6 +1899,13 @@ namespace ClarionAssistant.Services
                     foreach (var s in syms)
                     {
                         if (s == null || string.IsNullOrEmpty(s.Name)) continue;
+                        // A "local" symbol is procedure-private (CodeGraph's own scoping, set by
+                        // ClarionParser) — never a valid completion candidate outside the procedure
+                        // that declared it, let alone from a different file across the whole
+                        // solution. FindSymbols() has no scope awareness (plain name LIKE match), so
+                        // this merge must filter it out itself instead of surfacing every same-prefix
+                        // local from every procedure in every file as if it were global.
+                        if (string.Equals(s.Scope, "local", StringComparison.OrdinalIgnoreCase)) continue;
                         if (!s.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue; // true prefix only
                         if (bareNamesOnly && s.Name.IndexOf('.') >= 0) continue; // ClassName.Method → member-access only
                         if (!seen.Add(s.Name)) continue;


### PR DESCRIPTION
## Summary

Follow-up to the `?Ctrl` field-equate bare-prefix merge guard (PR #159 — see
[pr-description-field-equate-bare-prefix-merge-guard.md](pr-description-field-equate-bare-prefix-merge-guard.md)).
That PR guarded `MergeBarePrefixCompletions()`'s own qualified-context check, but a *different*
merge step inside the same function — `MergeDbBarePrefix()`, which backfills bare-word completion
from the solution-wide CodeGraph database — had no equivalent guard against surfacing
procedure-private symbols.

Found while investigating a Clarion-Extension bug report (missing `INCLUDE` keyword completion;
see companion Clarion-Extension PRs #393/#394): even after both upstream LSP fixes deployed,
completion at the top of a PROGRAM file still surfaced variables like `IncludeAddress` — a real
variable, but declared as a procedure-local inside an entirely unrelated procedure, in an entirely
different file.

## Root cause

`MergeDbBarePrefix()` calls `CodeGraphProvider.FindSymbols()`, which does a plain substring `LIKE`
match across the whole solution's indexed `.codegraph.db` — no file or scope awareness at all.
`ClarionParser` already tags every indexed symbol with a `Scope`: `"local"` (procedure-private),
`"module"` (file-scope), `"global"`, `"class"`, `"virtual"` — but `MergeDbBarePrefix()` never reads
that field. Every `"local"` symbol matching the typed prefix gets merged into completion exactly
like a genuine global, regardless of which procedure or file the cursor is actually in.

## Fix

One-line guard added to the merge loop, `Services/SharedLspBridge.cs` (`MergeDbBarePrefix`):

```csharp
if (string.Equals(s.Scope, "local", StringComparison.OrdinalIgnoreCase)) continue;
```

Placed before the existing prefix/dedup checks. The sibling call for the ClarionGraph static
library DB (`bareNamesOnly: true`) is unaffected — those symbols are never scoped `"local"` in the
first place, so the guard is a no-op there.

## Testing

Clean `Debug-C` build (MSBuild, `ClarionRoot=D:\_dev\C111`), only `Services/SharedLspBridge.cs`
touched. No automated test harness exists for this addin (same as PR #159) — verification is
build-clean + live-verify in the IDE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
