### PR TITLE
Fix/ca editor CTRL-X did not copy to clipboard 

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -993,8 +993,23 @@ namespace ClarionAssistant
             });
         }
 
-        // The rest stay inert for now (Step 6 wires Ctrl+D through the embeditor's openDesigner path).
-        void IMonacoEditorHost.OnClipboard(MonacoEditorControl editor, string rawJson) { }
+        /// <summary>{action:"clipboard"} — Clarion-style Ctrl+X (doClarionCut in monaco-embeditor.html) posts the
+        /// cut/removed text here before deleting it from the buffer. This host used to leave the message unhandled,
+        /// so Ctrl+X in the CA Editor silently deleted the line without ever reaching the Windows clipboard —
+        /// unlike the embeditor's own OnClipboard (ModernEmbeditorViewContent.HandleClipboard), which does the
+        /// same Clipboard.SetText call. Clipboard.SetText throws on an empty string, hence the " " fallback,
+        /// matching the embeditor's handling exactly.</summary>
+        void IMonacoEditorHost.OnClipboard(MonacoEditorControl editor, string rawJson)
+        {
+            try
+            {
+                var ser = new JavaScriptSerializer { MaxJsonLength = int.MaxValue };
+                var data = ser.DeserializeObject(rawJson) as Dictionary<string, object>;
+                string text = (data != null && data.ContainsKey("text")) ? (data["text"]?.ToString() ?? "") : null;
+                if (text != null) Clipboard.SetText(text.Length == 0 ? " " : text);
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("OnClipboard error: " + ex.Message); }
+        }
 
         // CA Find pad protocol (GitHub #66) — the broker routes to/from the dockable pad.
         void IMonacoEditorHost.OnCaFind(MonacoEditorControl editor, string action, string rawJson)
@@ -1115,7 +1130,23 @@ namespace ClarionAssistant
             filePath = _filePath; line = _lastCursorLine; column = _lastCursorCol;
             return line >= 1 && !string.IsNullOrEmpty(_filePath);
         }
-        void IMonacoEditorHost.OnFocusEditor(MonacoEditorControl editor) { }
+        /// <summary>{action:"focusEditor"} — installDropInsert's native OS drop handler (monaco-embeditor.html)
+        /// posts this after a Data-pad field drag-drop lands directly on the WebView2 surface, since OS keyboard
+        /// focus stays on the Data pad (a separate WebView2) after the drop. This host used to leave the message
+        /// unhandled, so the CA Editor's own workbench tab never reclaimed activation after such a drop — same
+        /// gap as OnClipboard above, just for a different message. Reuses the SelectWindow reflection idiom
+        /// already used elsewhere in this file (e.g. OnWorkbenchWindowSelected, CloseWorkbenchTab).</summary>
+        void IMonacoEditorHost.OnFocusEditor(MonacoEditorControl editor)
+        {
+            try
+            {
+                object wbw = _wbWindow;
+                if (wbw == null) { try { wbw = GetType().GetProperty("WorkbenchWindow")?.GetValue(this, null); } catch { } }
+                if (wbw == null) { MonacoSpikeLog.Write("focusEditor: WorkbenchWindow not available"); return; }
+                wbw.GetType().GetMethod("SelectWindow", Type.EmptyTypes)?.Invoke(wbw, null);
+            }
+            catch (Exception ex) { MonacoSpikeLog.Write("OnFocusEditor error: " + ex.Message); }
+        }
 
         // Reload button (fileMode page, two-click confirm): discards the overlay's in-buffer edits and
         // re-reads the file fresh from disk, then resends it as a new setSource — same message shape

--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -1006,7 +1006,9 @@ namespace ClarionAssistant
                 var ser = new JavaScriptSerializer { MaxJsonLength = int.MaxValue };
                 var data = ser.DeserializeObject(rawJson) as Dictionary<string, object>;
                 string text = (data != null && data.ContainsKey("text")) ? (data["text"]?.ToString() ?? "") : null;
-                if (text != null) Clipboard.SetText(text.Length == 0 ? " " : text);
+                if (text == null) { MonacoSpikeLog.Write("OnClipboard: no 'text' field in payload (" + (rawJson ?? "").Length + " raw chars)"); return; }
+                Clipboard.SetText(text.Length == 0 ? " " : text);
+                MonacoSpikeLog.Write("OnClipboard: wrote " + text.Length + " chars to clipboard");
             }
             catch (Exception ex) { MonacoSpikeLog.Write("OnClipboard error: " + ex.Message); }
         }


### PR DESCRIPTION
## Summary

`MonacoClarionEditor` (the CA Editor's Monaco/WebView2 overlay, `MonacoClarionSourceEditor.cs`) implements `IMonacoEditorHost` with two callbacks that were left as empty stubs from the original overlay-convergence spike and never wired up:

- **`OnClipboard`** — `doClarionCut`'s Ctrl+X (`monaco-embeditor.html`) always posts `{action:"clipboard"}` with the cut/removed text before deleting it from the buffer, for both a selection cut and a no-selection whole-line cut. The CA Editor never forwarded that message to `Clipboard.SetText`, so **Ctrl+X deleted the text without ever putting anything on the Windows clipboard.**
- **`OnFocusEditor`** — `installDropInsert`'s native OS drop handler posts `{action:"focusEditor"}` after a Data-pad field drag-drop lands directly on the WebView2 surface, since OS keyboard focus stays on the Data pad (a separate WebView2) after the drop. Left unhandled, the CA Editor's own workbench tab never reclaimed activation after such a drop.

## Root cause

Both are the same bug class: the JS side of the shared `monaco-embeditor.html` protocol posts these messages unconditionally (not gated to embed mode), but this particular host (`MonacoClarionEditor`) never implemented its half of the contract. The CA Embeditor's own host (`ModernEmbeditorViewContent`) already implements both correctly — `HandleClipboard` calls `Clipboard.SetText`, and `OnFocusEditor` calls `BringToFront()`.

## Fix

- `OnClipboard`: ported `ModernEmbeditorViewContent.HandleClipboard`'s logic — deserialize the `text` field and call `Clipboard.SetText`, with the same empty-string guard (`Clipboard.SetText` throws on `""`, so an empty cut is written as `" "`). Also logs the written char count (and a distinct message if a payload ever arrives with no `text` field) — added while chasing a report that looked at first like a selection-specific clipboard bug, see Verification below.
- `OnFocusEditor`: activates this editor's own workbench tab via the same `SelectWindow` reflection idiom already used elsewhere in this file (`OnWorkbenchWindowSelected`, `CloseWorkbenchTab`) — `MonacoClarionEditor` doesn't have a `BringToFront()`-style helper like the embeditor's view content, since it's a `ClarionEditor` subclass rather than an `AbstractViewContent`, but it already caches `_wbWindow` for the same reflection call elsewhere.

## Two stubs deliberately left alone

The same interface implementation also has empty `OnCancel` and `OnOpenSource` stubs. Traced both in `monaco-embeditor.html`: the Cancel button and the clickable embed header are only ever shown/wired in embed-overlay mode (`has-embheader`) — file mode (which the CA Editor always runs in) explicitly keeps closing via the tab instead and never renders that header. Neither message is ever posted from the CA Editor, so these two are genuinely unreachable dead code, not a second instance of this bug — left untouched rather than "fixed" for something that can't happen.

## Verification

- Clean build via VS2022's MSBuild (`ClarionAssistant.csproj`, Debug, ClarionVersion=11).
- **Live-tested in the running Clarion 11.1 IDE** (deploy.ps1 rebuild+redeploy). Confirmed via `monaco-spike.log`:
  - Ctrl+X with no selection (whole-line remove): clipboard populated correctly.
  - Ctrl+X with an active selection: clipboard populated correctly (log shows `OnClipboard: wrote 47 chars to clipboard`, matching the selection cut, and a later `wrote 7 chars` for a follow-up line cut) — an initial round of this same test appeared to fail, but that was the git clone having been left checked out on an unrelated in-progress branch that never had this fix merged in, not a real code issue; redeploying from the actual fix branch resolved it.
