### PR TITLE
perf(encoding): read and decode a file once instead of twice

### DIFF
--- a/ClarionAssistant/MonacoClarionSourceEditor.cs
+++ b/ClarionAssistant/MonacoClarionSourceEditor.cs
@@ -1189,8 +1189,7 @@ namespace ClarionAssistant
                     return;
                 }
 
-                Encoding enc = EncodingHelper.DetectFileEncoding(_filePath);
-                string text = File.ReadAllText(_filePath, enc);
+                string text = EncodingHelper.ReadAllText(_filePath, out _);
                 _overlayLiveText = text;
                 _overlayDirty = false;
                 RefreshDiskWatchBaseline();   // we just resynced with disk — any pending watcher event is now stale
@@ -1789,8 +1788,7 @@ namespace ClarionAssistant
                 if (string.IsNullOrEmpty(_filePath) || !File.Exists(_filePath)) return;
                 var data = new JavaScriptSerializer { MaxJsonLength = int.MaxValue }.DeserializeObject(rawJson) as Dictionary<string, object>;
                 string liveText = (data != null && data.ContainsKey("text")) ? (data["text"] as string ?? "") : (_overlayLiveText ?? "");
-                Encoding enc = EncodingHelper.DetectFileEncoding(_filePath);
-                string diskText = File.ReadAllText(_filePath, enc);
+                string diskText = EncodingHelper.ReadAllText(_filePath, out _);
                 var diff = new MonacoDiffViewContent(
                     "External change: " + Path.GetFileName(_filePath), diskText, liveText, "clarion", false, Services.CaEditorSettings.MonacoThemeDark);
                 // This is a read-only comparison, not a code-review workflow — there's nothing to "apply"

--- a/ClarionAssistant/Services/DiffService.cs
+++ b/ClarionAssistant/Services/DiffService.cs
@@ -212,7 +212,7 @@ namespace ClarionAssistant.Services
                 string originalText;
                 try
                 {
-                    originalText = ReadOriginalText(originalFile, startLine, endLine, EncodingHelper.DetectFileEncoding(originalFile));
+                    originalText = ReadOriginalText(originalFile, startLine, endLine, out _);
                 }
                 catch (ArgumentException ex)
                 {
@@ -248,13 +248,11 @@ namespace ClarionAssistant.Services
                 if (!File.Exists(modifiedFile))
                     return "Error: Modified file not found: " + modifiedFile;
 
-                // Detected ONCE here and carried on the context — a save must round-trip the encoding the text
-                // was read with, and re-detecting later would mean reading a file we're about to overwrite.
-                Encoding originalEncoding = EncodingHelper.DetectFileEncoding(originalFile);
-                Encoding modifiedEncoding = EncodingHelper.DetectFileEncoding(modifiedFile);
-
-                string originalText = ReadOriginalText(originalFile, origStartLine, origEndLine, originalEncoding);
-                string modifiedText = ReadOriginalText(modifiedFile, modStartLine, modEndLine, modifiedEncoding);
+                // Captured from the READ itself and carried on the context — a save must round-trip the
+                // encoding the text was read with, and re-detecting later would mean reading a file we're
+                // about to overwrite.
+                string originalText = ReadOriginalText(originalFile, origStartLine, origEndLine, out Encoding originalEncoding);
+                string modifiedText = ReadOriginalText(modifiedFile, modStartLine, modEndLine, out Encoding modifiedEncoding);
 
                 // Same "whole file" test ReadOriginalText itself uses, so the editable/read-only decision can
                 // never disagree with whether the panes actually hold the complete file.
@@ -285,11 +283,16 @@ namespace ClarionAssistant.Services
         /// spurious "extra blank line" diff that was never a real edit. A genuine sub-range still
         /// goes through line splitting, since some reconstruction is unavoidable there anyway.
         /// </summary>
-        private static string ReadOriginalText(string filePath, int startLine, int endLine, Encoding encoding)
+        private static string ReadOriginalText(string filePath, int startLine, int endLine, out Encoding encoding)
         {
+            // Whole file: one read gets the text AND the encoding. The sub-range branch still detects
+            // separately because it needs the file in line-split form, which ReadAllLines only gives
+            // for a second read — a rarer path, and not worth re-implementing ReadLine's terminator
+            // and trailing-newline rules by hand just to save it.
             if (startLine <= 1 && endLine == -1)
-                return File.ReadAllText(filePath, encoding);
+                return EncodingHelper.ReadAllText(filePath, out encoding);
 
+            encoding = EncodingHelper.DetectFileEncoding(filePath);
             string[] allLines = File.ReadAllLines(filePath, encoding);
             if (startLine < 1) startLine = 1;
             if (endLine < 1 || endLine > allLines.Length) endLine = allLines.Length;

--- a/ClarionAssistant/Services/EncodingHelper.cs
+++ b/ClarionAssistant/Services/EncodingHelper.cs
@@ -10,42 +10,132 @@ namespace ClarionAssistant.Services
     /// typically real UTF-8 WITHOUT a BOM, so a no-BOM file can't be assumed ANSI outright —
     /// a strict UTF-8 decode attempt disambiguates the two (invalid UTF-8 byte sequences,
     /// e.g. a lone cp1252 high-bit byte, throw and fall back to ANSI).
+    ///
+    /// Prefer <see cref="ReadAllText(string, out Encoding)"/> over
+    /// <see cref="DetectFileEncoding"/> + <c>File.ReadAllText</c>: detection has to read the
+    /// whole file to attempt the strict decode, so the pair opens, reads and decodes the file
+    /// TWICE and throws the first decode away. On the LSP text-sync path that repeats per
+    /// didChange, and on a generated .clw both the byte[] and the discarded string are large
+    /// enough to land on the Large Object Heap.
     /// </summary>
     public static class EncodingHelper
     {
+        /// <summary>
+        /// Read a file and report the encoding it was decoded with, opening and decoding it ONCE.
+        /// Observationally identical to <c>File.ReadAllText(path, DetectFileEncoding(path))</c> —
+        /// same text, same reported encoding, same exceptions, same FileShare — but without the
+        /// second read. Callers that already tolerate an unreadable file keep their try/catch.
+        /// </summary>
+        public static string ReadAllText(string path, out Encoding encoding)
+        {
+            // FileShare.Read, matching File.ReadAllText. Detection uses ReadWrite, but the pair's
+            // NET behaviour was the stricter of the two: detection would succeed on a file held
+            // open for writing and the follow-up read would then throw. Widening the share mode
+            // here would silently hand callers a half-written file instead of that exception —
+            // a real change in failure semantics, and not one a read-once change should make.
+            byte[] bytes = ReadAllBytes(path, FileShare.Read);
+
+            // Anything BOM-shaped is decoded by a StreamReader over the buffer we already hold,
+            // which inherits File.ReadAllText's exact semantics for free: preamble stripping, a
+            // dropped trailing partial code unit, and UTF-32 sniffing. Decoding a BOM'd buffer by
+            // hand gets all three subtly wrong — GetString keeps the U+FEFF, and flushes a partial
+            // trailing unit through the fallback as U+FFFD, which is precisely the character the
+            // server's UnicodeDiagnostics flags. No extra IO: same bytes, just wrapped.
+            if (StartsWithBom(bytes))
+            {
+                using (var ms = new MemoryStream(bytes, false))
+                using (var reader = new StreamReader(ms, DetectFromBytes(bytes), true))
+                {
+                    string bomText = reader.ReadToEnd();
+                    encoding = reader.CurrentEncoding;   // post-read: reflects what StreamReader sniffed
+                    return bomText;
+                }
+            }
+
+            // No BOM — the common Clarion case, and the one worth the fast path. A strict decode
+            // both TESTS the UTF-8 hypothesis and PRODUCES the text, so a UTF-8 file is decoded
+            // exactly once; DetectFileEncoding has to throw this same string away. When it isn't
+            // UTF-8 the attempt aborts at the first invalid byte rather than decoding the whole
+            // buffer, so the cp1252 path costs one full decode, not two.
+            try
+            {
+                string text = new UTF8Encoding(false, true).GetString(bytes);
+                encoding = new UTF8Encoding(false);
+                return text;
+            }
+            catch (DecoderFallbackException)
+            {
+                encoding = Encoding.Default;
+                return encoding.GetString(bytes);
+            }
+        }
+
+        /// <summary>
+        /// Detect a file's encoding without keeping the text. Use only where the text is genuinely
+        /// not wanted, or is read in a different shape (e.g. <c>File.ReadAllLines</c> for a
+        /// sub-range) — otherwise <see cref="ReadAllText(string, out Encoding)"/> gets both for the
+        /// price of one read. Returns <c>Encoding.Default</c> if the file can't be read.
+        /// </summary>
         public static Encoding DetectFileEncoding(string path)
         {
             try
             {
-                byte[] bytes;
-                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                {
-                    bytes = new byte[fs.Length];
-                    int offset = 0;
-                    while (offset < bytes.Length)
-                    {
-                        int read = fs.Read(bytes, offset, bytes.Length - offset);
-                        if (read == 0) break;
-                        offset += read;
-                    }
-                }
-
-                if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) return new UTF8Encoding(true);
-                if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) return Encoding.Unicode;
-                if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) return Encoding.BigEndianUnicode;
-
-                try
-                {
-                    new UTF8Encoding(false, true).GetString(bytes);
-                    return new UTF8Encoding(false);
-                }
-                catch (DecoderFallbackException)
-                {
-                    return Encoding.Default;
-                }
+                return DetectFromBytes(ReadAllBytes(path, FileShare.ReadWrite));
             }
             catch { }
             return Encoding.Default;
+        }
+
+        /// <summary>
+        /// True if the buffer opens with a byte pattern <c>StreamReader</c> would treat as a BOM.
+        /// UTF-32LE (FF FE 00 00) is deliberately covered by the UTF-16LE prefix, matching what
+        /// <see cref="DetectFromBytes"/> reports and therefore what the previous code did.
+        /// </summary>
+        private static bool StartsWithBom(byte[] bytes)
+        {
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) return true;
+            if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) return true;
+            if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) return true;
+            if (bytes.Length >= 4 && bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF) return true;
+            return false;
+        }
+
+        private static Encoding DetectFromBytes(byte[] bytes)
+        {
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF) return new UTF8Encoding(true);
+            if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE) return Encoding.Unicode;
+            if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF) return Encoding.BigEndianUnicode;
+
+            try
+            {
+                new UTF8Encoding(false, true).GetString(bytes);
+                return new UTF8Encoding(false);
+            }
+            catch (DecoderFallbackException)
+            {
+                return Encoding.Default;
+            }
+        }
+
+        private static byte[] ReadAllBytes(string path, FileShare share)
+        {
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, share))
+            {
+                var bytes = new byte[fs.Length];
+                int offset = 0;
+                while (offset < bytes.Length)
+                {
+                    int read = fs.Read(bytes, offset, bytes.Length - offset);
+                    if (read == 0) break;
+                    offset += read;
+                }
+
+                // The buffer is sized from fs.Length, but a short read leaves the tail zero-filled.
+                // Harmless while this only fed a throwaway validity test; now the buffer IS the
+                // text, so those pad bytes would decode to U+0000 and be handed to the server.
+                if (offset != bytes.Length) System.Array.Resize(ref bytes, offset);
+                return bytes;
+            }
         }
     }
 }

--- a/ClarionAssistant/Services/LspClient.cs
+++ b/ClarionAssistant/Services/LspClient.cs
@@ -887,7 +887,7 @@ namespace ClarionAssistant.Services
                 if (!File.Exists(filePath)) return;
 
                 string uri = FilePathToUri(filePath);
-                string content = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath));
+                string content = EncodingHelper.ReadAllText(filePath, out _);
 
                 string ext = Path.GetExtension(filePath).ToLower();
                 string languageId = ext == ".inc" || ext == ".clw" || ext == ".equ" ? "clarion" : "plaintext";
@@ -998,7 +998,7 @@ namespace ClarionAssistant.Services
                 }
 
                 string uri = FilePathToUri(filePath);
-                string content = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath));
+                string content = EncodingHelper.ReadAllText(filePath, out _);
                 int nextVersion = currentVersion + 1;
 
                 // LSP TextDocumentContentChangeEvent without `range` = full document replacement.

--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -806,7 +806,7 @@ namespace ClarionAssistant.Services
             // SharedGetDiagnostics and the bundled LspClient.EnsureDocumentOpen. (Bob, ticket 3d9a6ec9)
             if (string.IsNullOrEmpty(bufferText) && !string.IsNullOrEmpty(filePath) && File.Exists(filePath))
             {
-                try { bufferText = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath)); } catch { }
+                try { bufferText = EncodingHelper.ReadAllText(filePath, out _); } catch { }
             }
             try
             {
@@ -846,7 +846,7 @@ namespace ClarionAssistant.Services
         {
             string buffer = null;
             if (liveBuffer) { lock (_sharedBufLock) { _sharedBuffers.TryGetValue(filePath, out buffer); } }
-            if (buffer == null && File.Exists(filePath)) { try { buffer = File.ReadAllText(filePath, EncodingHelper.DetectFileEncoding(filePath)); } catch { } }
+            if (buffer == null && File.Exists(filePath)) { try { buffer = EncodingHelper.ReadAllText(filePath, out _); } catch { } }
 
             var result = new LspClient.DiagnosticWaitResult { Entries = new List<LspClient.DiagnosticEntry>(), Pending = true };
             try

--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1264,8 +1264,7 @@ namespace ClarionAssistant.Terminal
             _fileMode = true;
             _title = Path.GetFileName(_filePath);
             _fileIdentity = CanonicalFileId(_filePath);   // stable identity for dedup/state, survives path aliasing (item 3)
-            _fileEncoding = EncodingHelper.DetectFileEncoding(_filePath);
-            _sourceText = File.ReadAllText(_filePath, _fileEncoding);
+            _sourceText = EncodingHelper.ReadAllText(_filePath, out _fileEncoding);
             _fileEol = DetectEol(_sourceText);
             _fileDiskSig = ReadFileSignature(_filePath);
             _fileLiveText = _sourceText;
@@ -1890,8 +1889,7 @@ namespace ClarionAssistant.Terminal
                 // Re-detect encoding + EOL: the file may have been externally rewritten in a different encoding
                 // since open. Reusing the stale open-time encoding would misdecode and a later save would write the
                 // corrupted text back. (pipeline item 4 — adversary)
-                _fileEncoding = EncodingHelper.DetectFileEncoding(_filePath);
-                _sourceText = File.ReadAllText(_filePath, _fileEncoding);
+                _sourceText = EncodingHelper.ReadAllText(_filePath, out _fileEncoding);
                 _fileEol = DetectEol(_sourceText);
                 _fileDiskSig = ReadFileSignature(_filePath);
                 _fileOverwriteArmedSig = null;


### PR DESCRIPTION
# perf(encoding): read and decode a file once instead of twice

## Summary

Follow-up to the review note on #168. Every call site paired `EncodingHelper.DetectFileEncoding(path)` with `File.ReadAllText(path, enc)` — and detection isn't a cheap sniff. It reads the **whole** file and runs a strict-UTF-8 `GetString` purely to test whether the decode succeeds, then throws that string away. So each read opened the file twice, decoded it twice, and discarded a complete `byte[]` plus a complete `string`.

The note said "doubles the IO"; the actual cost was 2× read **and** 2× decode. On a generated `.clw` both discards are large enough to land on the Large Object Heap, and `SendDidChangeFromDisk` repeats it per change.

Adds `EncodingHelper.ReadAllText(path, out Encoding)` — one open, one decode, keeping the string the UTF-8 test already produced. For a cp1252 file the strict attempt aborts at the first high-bit byte rather than decoding the whole buffer, so that path costs one full decode, not two.

## Call sites converted (9)

| Site | Encoding kept? |
|---|---|
| `LspClient.EnsureDocumentOpen` — initial `didOpen` | no |
| `LspClient` didChange re-trigger | no |
| `SharedLspBridge.SharedGetCompletion` — file-mode fallback | no |
| `SharedLspBridge.SharedGetDiagnostics` — file-mode path | no |
| `MonacoClarionSourceEditor` — overlay disk-reload | no |
| `MonacoClarionSourceEditor` — external-change diff | no |
| `ModernEmbeditorViewContent` — file-mode ctor | yes, for later save |
| `ModernEmbeditorViewContent` — reload | yes, for later save |
| `DiffService.ReadOriginalText` — whole-file branch | yes, onto `DiffFileContext` |

`DiffService`'s sub-range branch still detects separately — it needs the file in `ReadAllLines` form, and hand-rolling `ReadLine`'s terminator and trailing-newline rules to save one read on a rare path is a bad trade.

## Why the BOM path delegates to StreamReader

Decoding a BOM'd buffer with `Encoding.GetString` gets three things wrong, so anything BOM-shaped is decoded by a `StreamReader` over the bytes already in hand — no extra IO, and it inherits `File.ReadAllText`'s exact semantics:

1. The preamble is **stripped** rather than surfacing as a leading `U+FEFF` (which would read as a phantom first-line diff, and a stray character in the editor buffer).
2. A trailing partial code unit in an odd-length UTF-16 file is **dropped** rather than flushed through the fallback as `U+FFFD` — the very character `UnicodeDiagnostics` flags. Getting this wrong would have reintroduced #168's false-positive class.
3. UTF-32 is sniffed. This also closes a latent hole: a UTF-32BE file previously decoded as UTF-32BE but was *reported* as `Windows-1252`, so saving it back would have destroyed it. It now reports `utf-32BE` and round-trips.

Also resizes the buffer to the byte count actually read. It's sized from `fs.Length`, and a short read left the tail zero-filled — harmless while that buffer only fed a throwaway validity test, but it's now the text itself, so the padding would have decoded to `U+0000` and gone to the server.

## No change in failure semantics

`ReadAllText` opens `FileShare.Read`, matching `File.ReadAllText`. Detection keeps `FileShare.ReadWrite`, but the pair's **net** behaviour was the stricter of the two — detection succeeded on a file held open for writing and the follow-up read then threw. Widening it here would have silently handed callers a half-written file instead of that exception, so it's deliberately left alone.

## Correction to #168's description

#168 said its four sites "are the only unguarded `File.ReadAllText` on the LSP text-sync path." That isn't right. `EmbedLspContext.RevertShadow()` still does:

```csharp
SharedLspBridge.EnsureBufferSynced(RealPath, File.ReadAllText(RealPath));
```

No encoding argument, pushing on-disk Clarion source into the LSP buffer on embeditor tab teardown — so #168's false positives return after closing an embed tab. That's a behaviour fix rather than a perf change, so it's coming as its own PR, not folded in here.

## Test plan

- [x] Builds clean (`ClarionAssistant.csproj`, Debug), zero warnings
- [x] Equivalence harness against the built assembly, old pair vs new call across **26 fixtures**: utf8 with/without BOM, cp1252, utf16 LE/BE, utf32 LE/BE, empty, 1-byte, BOM-only, odd-length and truncated utf16, truncated and overlong utf8, non-BMP surrogate pairs, mid-content `U+FEFF`, LF/CR/CRLF, embedded NUL. Identical text and identical reported encoding in all 26, and no round-trip that worked before stops working
- [x] Second harness confirms `FileShare` parity — old and new both throw `IOException` while another process holds the file open for writing
