### PR TITLE
docs(diagnostics): point DiagnosticsCacheKey's comment at ComputeAsync

### DIFF
--- a/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
+++ b/ClarionAssistant/Terminal/ModernEmbeditorViewContent.cs
@@ -1295,7 +1295,7 @@ namespace ClarionAssistant.Terminal
         /// surface raw. FILE MODE ONLY, deliberately: there _lspFileName is the real file and the
         /// squiggle pass runs with embedSlotChecks=false, so the cache is exactly what Monaco marked
         /// up. In embed mode the same cache holds WHOLE-generated-buffer diagnostics that
-        /// ModernEmbeditorDiagnostics.Compute clamps to the editable slots before rendering —
+        /// ModernEmbeditorDiagnostics.ComputeAsync clamps to the editable slots before rendering —
         /// reporting those unclamped would count generated-line noise the editor never squiggled.
         /// </summary>
         public string DiagnosticsCacheKey { get { return _fileMode ? _lspFileName : null; } }


### PR DESCRIPTION
PR #170 renamed ModernEmbeditorDiagnostics.Compute to ComputeAsync when the settle loop made it async. PR #169 landed 6 seconds later and added a doc comment on DiagnosticsCacheKey that names the old method. Different files, so no merge conflict flagged it — just a name in a comment that no longer exists.

Verified this is the only stale reference left on master: every call site (MonacoClarionSourceEditor.cs, ModernEmbeditorViewContent.cs) and the declaration itself already read ComputeAsync. Comment text only, no behaviour.