### PR TITLE
fix(embeditor): WebView2 post-after-dispose race on closing a CA Embeditor tab

### DIFF
--- a/ClarionAssistant/Terminal/MonacoEditorControl.cs
+++ b/ClarionAssistant/Terminal/MonacoEditorControl.cs
@@ -355,24 +355,40 @@ namespace ClarionAssistant.Terminal
 
         /// <summary>Send a JSON message host-&gt;page (PostWebMessageAsJson), marshalled to the UI
         /// thread. Note: WebView2 delivers it to JS as a parsed OBJECT, not a string — page handlers
-        /// must not JSON.parse it. Used by the host for the state-assembled messages (SendSource etc.).</summary>
+        /// must not JSON.parse it. Used by the host for the state-assembled messages (SendSource etc.).
+        ///
+        /// GPF-on-close guard: a background continuation (e.g. the diagnostics settle-loop in
+        /// ModernEmbeditorDiagnostics.ComputeAsync, which can now run for several seconds) can still be
+        /// in flight when the embed is closed and DetachOverlay()/Dispose() tears this control down.
+        /// `_webView != null` alone does NOT detect that — Dispose() never nulls the field, only IsDisposed
+        /// flips. Worse, `InvokeRequired` on a control whose handle was just destroyed (mid-teardown, or
+        /// its parent chain was just severed by Controls.Remove) returns FALSE — not because we're on the
+        /// UI thread, but because it has no handle left to compare against — which used to fall through to
+        /// calling the WebView2/CoreWebView2 COM object (STA) directly from a thread-pool thread instead of
+        /// marshalling. That's undefined behaviour for an STA COM object mid-teardown and can produce a
+        /// native access violation no C# try/catch can intercept. IsDisposed is checked before trusting
+        /// InvokeRequired at all, and again inside the marshalled action (the two checks can't be merged
+        /// into one atomic test, but this closes the window down to the marshalling call itself).</summary>
         public void PostJson(string json)
         {
+            if (IsDisposed || _webView == null || _webView.IsDisposed) return;
             Action post = () =>
             {
-                try { if (_webView != null && _webView.CoreWebView2 != null) _webView.CoreWebView2.PostWebMessageAsJson(json); }
+                try { if (_webView != null && !_webView.IsDisposed && _webView.CoreWebView2 != null) _webView.CoreWebView2.PostWebMessageAsJson(json); }
                 catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[MonacoEditorControl] PostJson error: " + ex.Message); }
             };
             try { if (InvokeRequired) BeginInvoke(post); else post(); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[MonacoEditorControl] PostJson marshal error: " + ex.Message); }
         }
 
-        /// <summary>Send a raw string message host-&gt;page (PostWebMessageAsString), UI-thread marshalled.</summary>
+        /// <summary>Send a raw string message host-&gt;page (PostWebMessageAsString), UI-thread marshalled.
+        /// Same GPF-on-close guard as <see cref="PostJson"/> — see its remarks.</summary>
         public void PostString(string message)
         {
+            if (IsDisposed || _webView == null || _webView.IsDisposed) return;
             Action post = () =>
             {
-                try { if (_webView != null && _webView.CoreWebView2 != null) _webView.CoreWebView2.PostWebMessageAsString(message); }
+                try { if (_webView != null && !_webView.IsDisposed && _webView.CoreWebView2 != null) _webView.CoreWebView2.PostWebMessageAsString(message); }
                 catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[MonacoEditorControl] PostString error: " + ex.Message); }
             };
             try { if (InvokeRequired) BeginInvoke(post); else post(); }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ Ask it to write Clarion code, explain procedures, refactor classes, build COM co
 
 ---
 
+## What's New (Unreleased)
+
+### Fix a WebView2 post-after-dispose race on closing a CA Embeditor tab
+
+A background continuation (e.g. the diagnostics settle-loop from v5.6's #170, which can now stay in flight for several seconds instead of a single bounded 1.5s wait) could still be posting a response after `DetachOverlay()`/`Dispose()` had already started tearing the WebView2 control down.
+
+Two bugs compounded: `_webView != null` doesn't detect disposal (`Dispose()` never nulls the field), and `InvokeRequired` on a control whose window handle was just destroyed returns `false` &mdash; not because the call was already on the UI thread, but because it had no handle left to compare against &mdash; so the post fell through to calling the WebView2/CoreWebView2 COM object (an STA object) directly from a thread-pool thread instead of marshalling. That's undefined behavior for an STA COM object mid-teardown.
+
+`MonacoEditorControl.PostJson`/`PostString` &mdash; the single chokepoint every host&rarr;page message (diagnostics, hover, completion, save results, designer messages, ...) already funnelled through &mdash; now check `IsDisposed` before trusting `InvokeRequired` at all, closing the fallthrough at its source.
+
+This closes a real, distinct race, but it is **not** a full fix for every embed-close crash: a separate, native Access Violation inside Clarion's own Generator ("Internal error: Restore Procedure") reproduced after this fix was deployed &mdash; tracked as #179, likely the same underlying step behind the stale window-designer error icons in #142.
+
+---
+
 ## What's New in v5.6
 
 Documentation search is the headline: PDF text extraction now works on every machine instead of only ones that happened to have a third-party tool installed, the extracted text is more accurate, and it is indexed so that a question is answered by the first result rather than the fifth query. Alongside that, a cycle of fixes across the diagnostics path, completion scoping, and the CA Editor's Monaco overlay &mdash; plus a build fix that restores Clarion 10 to the shipped set.


### PR DESCRIPTION
## Summary

- Fixes a real, distinct race in `MonacoEditorControl.PostJson`/`PostString` (the single chokepoint every host→page message — diagnostics, hover, completion, save results, designer messages, ... — already funnels through): a background continuation can still be posting a response after `DetachOverlay()`/`Dispose()` has started tearing the WebView2 control down.
  - `_webView != null` doesn't detect disposal — `Dispose()` never nulls the field, only `IsDisposed` flips.
  - `InvokeRequired` on a control whose window handle was just destroyed returns `false` — not because the call is already on the UI thread, but because it has no handle left to compare against — so the post fell through to calling the WebView2/CoreWebView2 COM object (STA) directly from a thread-pool thread instead of marshalling.
  - Fix: check `IsDisposed` before trusting `InvokeRequired` at all, both at the outer guard and again inside the marshalled action.
- v5.6's diagnostics settle-loop (#170) widened the window for this considerably — a diagnostics round-trip that used to resolve within a bounded 1.5s wait can now take several seconds across multiple thread-pool hops, so it's far more likely to still be in flight when a tab closes.

## Scope — please read before assuming this closes out embed-close crashes

This is **not** a full fix for embed-close instability. While chasing a recurring crash-on-close report, this fix stopped one clean reproduction, but the same symptom reproduced again afterward — this time caught as Clarion's own internal exception dialog, a **native Access Violation inside the Generator** ("Internal error: Restore Procedure"), not a .NET/WebView2 issue at all. Filed separately as #179, with the full crash detail and a working theory connecting it to the stale window-designer error icons in #142.

Shipping this fix anyway because it's a real, well-understood bug on its own terms (a documented WinForms/COM gotcha, verifiable independent of the native crash), and closing the race is worth doing regardless of whether #179 turns out to be the dominant cause of what users are seeing.

## Test plan

- [x] Reproduced pre-fix: closing an embed tab immediately after typing (diagnostics request in flight) crashed reliably.
- [x] Post-fix: repeated close cycles in the same pattern, no crash from this specific path.
- [ ] Not fully conclusive on its own — see #179, which reproduced independently after this fix was live.