### PR TITLE
Fix/codegraph definition local var guard

### DIFF
--- a/ClarionAssistant/Services/SharedLspBridge.cs
+++ b/ClarionAssistant/Services/SharedLspBridge.cs
@@ -1409,8 +1409,15 @@ namespace ClarionAssistant.Services
             return null;
         }
 
-        /// <summary>Resolve an exact-name definition from one CodeGraph-schema DB → an LSP location list,
-        /// or null when the DB is missing/unopenable or the symbol isn't found. Never throws.</summary>
+        /// <summary>Resolve an exact-name definition from one CodeGraph-schema DB → an LSP location list, or
+        /// null when the DB is missing/unopenable, the symbol isn't found, or the only match is a "variable"
+        /// scoped to a PROCEDURE/ROUTINE elsewhere (see IsUnreachableLocalVariable — never a legitimate hit,
+        /// since the caller only reaches here after the upstream LSP already searched this file's own
+        /// local/routine/module scope and found nothing). Mirrors CgHoverFromDb's guard — that sibling
+        /// already filters this exact shape for hover; this path never got the same check, so a bare word
+        /// genuinely undeclared in scope (LSP correctly returns empty) could still resolve F12 to an
+        /// unrelated procedure's local via CodeGraphProvider.FindSymbolByName's unordered `LIMIT 1`. Never
+        /// throws.</summary>
         private static Dictionary<string, object> CgDefinitionFromDb(string word, string db)
         {
             try
@@ -1419,9 +1426,10 @@ namespace ClarionAssistant.Services
                 using (var p = new CodeGraphProvider())
                 {
                     if (!p.Open(db)) return null;
-                    var def = p.GetDefinition(word);
-                    if (def == null || string.IsNullOrEmpty(def.FilePath)) return null;
-                    return WrapResult(new System.Collections.ArrayList { CgLocation(def.FilePath, def.LineNumber) });
+                    var sym = p.FindSymbolByName(word);
+                    if (sym == null || string.IsNullOrEmpty(sym.FilePath)) return null;
+                    if (IsUnreachableLocalVariable(p, sym)) return null;
+                    return WrapResult(new System.Collections.ArrayList { CgLocation(sym.FilePath, sym.LineNumber) });
                 }
             }
             catch { return null; }

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -3,14 +3,14 @@
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
 the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92), the GROUP-typed CLASS-member fix
 (PR #93), the inherited-CLASS-member dotted-call resolution fix (PR #112), the
-built-in-name-collision fix (PR #118), issue #97's attrs+same-line-terminator fix, the
-overload-attribution fix (Bug P), and Bug Q (pins the DB shape behind
-`SharedLspBridge.cs`'s F12-definition local-variable-guard fix — see its own section below; unlike
-A–P this isn't a parser/indexer bug, it documents a precondition for a runtime bug in the addin's
-C#) — a single compiling Clarion solution whose procedures each exercise one historical
-parser/indexer bug (plus, for Bug Q, a DB-shape precondition for a runtime bug). This is currently
-the only regression coverage the CodeGraph parser has; run it after ANY change to
-`Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
+built-in-name-collision fix (PR #118), issue #97's attrs+same-line-terminator fix, and the
+overload-attribution fix (Bug P) — a single compiling Clarion solution whose procedures each
+exercise one historical parser/indexer bug. This is currently the only regression coverage the
+CodeGraph parser has; run it after ANY change to `Parsing/ClarionParser.cs` or
+`Graph/CodeGraphIndexer.cs` (either synced copy).
+
+**Bug Q is the one exception**: `UnreachableLocalRefTest` (bottom of `WorkerLib.clw`) does NOT
+compile — deliberately; see its own section below for why that's fine here.
 
 Includes `WorkerClass.Ask` — a method whose name collides with the Clarion built-in `ASK()`
 statement — as coverage for Bug N (PR #118). Before that fix its two call sites resolved to
@@ -25,37 +25,40 @@ indexer\bin\Debug\clarion-indexer.exe index test-fixtures\codegraph-repro\ReproS
 ```
 
 ## Expected results (verified 2026-07-17 with all #79–#90 fixes applied, plus #92, #93, #112, and
-#118, then re-verified with #97 and with Bug P (this PR); line numbers below reflect the fixture
-AFTER Bug P's `OverloadBugClass.Dispatch` addition)
+#118, then re-verified with #97, with Bug P, and with Bug Q (2026-08-07); line numbers below
+reflect the fixture AFTER Bug Q's `WorkerLib.inc`/`WorkerLib.clw` additions — Bug Q added 14 lines
+before `OverloadBugClass.Dispatch`, so every line number at or after it shifted +14 from the
+Bug-P-era numbers previously documented here, and 2 lines were added to `Worker.clw` before
+`MainHelperProc`, shifting it +2)
 
 ### Callers of `WorkerClass.Sign` — exactly 22 `calls` rows
 
 | Caller | Line | Proves issue |
 |---|---|---|
-| TestSignatureFlow | 25 | baseline (direct call) |
-| TestSignatureFlow | 31 | baseline (second call shape) |
-| ParameterTest | 43 | #87 (call through PROCEDURE parameter) |
-| ReturnTest | 52 | baseline (inline RETURN call shape) |
-| MainHelperProc | 64 | #81 (procedure in main PROGRAM file) |
-| OwnerClass.CallViaMember | 63 | #84+#86 (.inc member, cross-file type) |
-| OwnerClass.CallViaCommentedMember | 85 | #85+#86 (trailing-comment member) |
-| CommentedLocalTest | 101 | #85 (trailing-comment DATA local) |
-| GroupBugClass.CallViaAfterGroupMember | 119 | #88 (member after inline GROUP END) |
-| PeriodBugClass.CallViaAfterPeriodMember | 135 | #88 (member after inline GROUP period) |
-| OmitTest | 172 | #79 (call after OMIT block) |
-| AfterOmitProc | 181 | #79 (procedure after OMIT block) |
-| CommentEmbeddedTest | 198 | #80 (call with embedded comment) |
-| ConditionalOmitTest | 212 | #79 (conditional OMIT/COMPILE) |
-| GroupQueueLocalTest | 231 | #89 (local after GROUP(Type) two-line) |
-| InlineLocalGroupTest | 246 | #89 (local after GROUP(Type) END inline) |
-| AttrTermLocalGroupTest | 266 | #97 (local after GROUP(Type),attrs + same-line terminator) |
-| LocalDerivedClassTest | 292 | #90 (attribution after local CLASS(Parent)) |
-| LikeMemberBugClass.CallViaPlainInstanceMember | 309 | #92 (call through a reference CLASS member, unaffected control) |
-| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 327 | #93 (member after multi-line GROUP with its own extra field) |
-| DerivedWorkerClass.CallViaInheritedMember | 338 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
-| OverloadBugClass.Dispatch (LONG overload) | 349 | Bug P (own overload's call, correctly self-attributed — not misattributed to the CSTRING overload) |
+| TestSignatureFlow | 39 | baseline (direct call) |
+| TestSignatureFlow | 45 | baseline (second call shape) |
+| ParameterTest | 57 | #87 (call through PROCEDURE parameter) |
+| ReturnTest | 66 | baseline (inline RETURN call shape) |
+| MainHelperProc | 66 (`Worker.clw`) | #81 (procedure in main PROGRAM file) |
+| OwnerClass.CallViaMember | 77 | #84+#86 (.inc member, cross-file type) |
+| OwnerClass.CallViaCommentedMember | 99 | #85+#86 (trailing-comment member) |
+| CommentedLocalTest | 115 | #85 (trailing-comment DATA local) |
+| GroupBugClass.CallViaAfterGroupMember | 133 | #88 (member after inline GROUP END) |
+| PeriodBugClass.CallViaAfterPeriodMember | 149 | #88 (member after inline GROUP period) |
+| OmitTest | 186 | #79 (call after OMIT block) |
+| AfterOmitProc | 195 | #79 (procedure after OMIT block) |
+| CommentEmbeddedTest | 212 | #80 (call with embedded comment) |
+| ConditionalOmitTest | 226 | #79 (conditional OMIT/COMPILE) |
+| GroupQueueLocalTest | 245 | #89 (local after GROUP(Type) two-line) |
+| InlineLocalGroupTest | 260 | #89 (local after GROUP(Type) END inline) |
+| AttrTermLocalGroupTest | 280 | #97 (local after GROUP(Type),attrs + same-line terminator) |
+| LocalDerivedClassTest | 306 | #90 (attribution after local CLASS(Parent)) |
+| LikeMemberBugClass.CallViaPlainInstanceMember | 323 | #92 (call through a reference CLASS member, unaffected control) |
+| MultiLineGroupBugClass.CallViaAfterMultiLineGroupMember | 341 | #93 (member after multi-line GROUP with its own extra field) |
+| DerivedWorkerClass.CallViaInheritedMember | 352 | #112 (member declared on a BASE class, accessed via SELF. from a DERIVED class's own method) |
+| OverloadBugClass.Dispatch (LONG overload) | 363 | Bug P (own overload's call, correctly self-attributed — not misattributed to the CSTRING overload) |
 
-### Callers of `WorkerClass.Ask` — exactly 3 `calls` rows (Bug N fixed in #118, +1 from Bug P)
+### Callers of `WorkerClass.Ask` — exactly 5 `calls` rows (Bug N fixed in #118, +1 from Bug P, +2 from Bug Q)
 
 `Ask` is identical in shape to `Sign` (same class, same signature) — the only difference is its
 name, which happens to collide with the Clarion built-in `ASK()` window/UI statement. Both call
@@ -64,9 +67,11 @@ SAME call site, so the two can be compared line-for-line:
 
 | Caller | Line | Same-site `Sign` call (for comparison) | Path proven fixed |
 |---|---|---|---|
-| TestSignatureFlow | 30 | line 25 (`worker.Sign( 1 )`) | DATA-section local variable (baseline path) |
-| OwnerClass.CallViaMember | 69 | line 63 (`SELF.MyWorker.Sign( 10 )`) | cross-file CLASS member (#84/#86, and #112's inheritance walk when applicable) |
-| OverloadBugClass.Dispatch (CSTRING overload) | 368 | line 349 (`worker.Sign( pValue )`, LONG overload) | Bug P — sibling overload's call, correctly self-attributed to the CSTRING overload's own line (363), not the LONG overload's (346) |
+| TestSignatureFlow | 44 | line 39 (`worker.Sign( 1 )`) | DATA-section local variable (baseline path) |
+| OwnerClass.CallViaMember | 83 | line 77 (`SELF.MyWorker.Sign( 10 )`) | cross-file CLASS member (#84/#86, and #112's inheritance walk when applicable) |
+| OverloadBugClass.Dispatch (CSTRING overload) | 382 | line 363 (`worker.Sign( pValue )`, LONG overload) | Bug P — sibling overload's call, correctly self-attributed to the CSTRING overload's own line (377), not the LONG overload's (360) |
+| UnreachableLocalRefTest | 417 | n/a — calls the QUEUE,TYPE overload directly, no `Sign` call at this site | Bug Q — the call *resolves* correctly (its target, `worker`, is legitimately declared); Bug Q is about whether its bare-word ARGUMENT (`MyValue`) wrongly resolves, not about this relationship |
+| UnreachableLocalRefTest | 418 | n/a | Bug Q — same call, second argument (`TestQ`) is the one under test here |
 
 **Root cause (fixed by #118)**: `"ASK"` is in `ClarionBuiltins.cs`'s `_builtins` set (window/UI
 statement). Before #118 both the `SELF.Method` and the dotted `ObjectName.Method` call-detection
@@ -105,57 +110,75 @@ bodies' own calls can be told apart in the results:
   (inside the CSTRING overload) would be attributed as coming from the SAME one overload symbol —
   whichever loaded last — never from their own respective overloads.
 - **After the fix**: `WorkerClass.Sign` gains exactly one caller row from `OverloadBugClass.Dispatch`
-  at line 349, correctly attributed to the LONG overload's own definition line (346). `WorkerClass.Ask`
-  gains exactly one caller row from `OverloadBugClass.Dispatch` at line 368, correctly attributed to
-  the CSTRING overload's own definition line (363) — a different id than the Sign caller above, even
+  at line 363, correctly attributed to the LONG overload's own definition line (360). `WorkerClass.Ask`
+  gains exactly one caller row from `OverloadBugClass.Dispatch` at line 382, correctly attributed to
+  the CSTRING overload's own definition line (377) — a different id than the Sign caller above, even
   though both share the literal name `OverloadBugClass.Dispatch`.
 
 **Deliberately NOT fixed by this change, and not a regression if still true**: the
-`SELF.Dispatch(99)` call at line 367 (inside the CSTRING overload, intending to call the LONG
+`SELF.Dispatch(99)` call at line 381 (inside the CSTRING overload, intending to call the LONG
 overload) still resolves its call *target* to the CSTRING overload itself (i.e. `to_id`'s
-definition line is 363, not 346) — call-target resolution for an overloaded name still isn't
+definition line is 377, not 360) — call-target resolution for an overloaded name still isn't
 type-aware; it still picks whichever overload loaded last, same as before this fix. This fix only
 corrects the *caller* side (`currentProcId`/`currentProcName` — "which procedure is this line
 inside"), not the *callee* side (which overload a given call site actually invokes). Per-overload
 caller *counts* (grouping by `to_id` for an overloaded name) remain unreliable; "what does this
 specific overload call" (grouping by `from_id`) is now correct.
 
-### Bug Q: F12/go-to-definition's CodeGraph fallback resolved to an unrelated procedure's local
+### Bug Q: F12/Ctrl+Click's CodeGraph fallback resolved to an unrelated procedure's local
 
-Not a parser/indexer bug like A–P above — this documents a DB-*shape* precondition for a bug in
-`SharedLspBridge.cs` (the ClarionAssistant addin's runtime C#, a separate assembly from this
-indexer). `CgDefinitionFromDb` (F12's CodeGraph fallback, reached only once the upstream LSP's own
-scope search has already returned nothing) looked symbols up via a flat, unordered
-`WHERE LOWER(name)=LOWER(@name) LIMIT 1` with no scope filter. Its sibling `CgHoverFromDb` already
-guards this exact shape with `IsUnreachableLocalVariable` — a "variable" symbol whose
+Not a parser/indexer bug like A–P above — this reproduces the exact real-world trigger for a
+runtime bug in `SharedLspBridge.cs` (the ClarionAssistant addin's C#, a separate assembly this
+indexer never touches), discovered live: a call argument left undeclared by a typo/omission,
+whose name happened to already be a local elsewhere in the class.
+
+`CgDefinitionFromDb` (F12/Ctrl+Click's CodeGraph fallback, reached only once the upstream LSP's
+own scope search has already returned nothing) looked symbols up via a flat, unordered
+`WHERE LOWER(name)=LOWER(@name) LIMIT 1`, with no scope filter. Its sibling `CgHoverFromDb`
+already guards this exact shape with `IsUnreachableLocalVariable` — a "variable" symbol whose
 `parent_name` resolves to a `procedure`/`routine` symbol can never legitimately be referenced from
-outside that one procedure, so a match like that is always wrong. `CgDefinitionFromDb` never
-called it.
+outside that one procedure. `CgDefinitionFromDb` never called it.
 
-This repro doesn't need a *new* bug pattern — `result` is already declared as a separate local in
-20 different procedures throughout this fixture (`TestSignatureFlow`, `OmitTest`,
-`OverloadBugClass.Dispatch`, etc.), which is exactly the "many wrong candidates, arbitrary pick"
-pool the unguarded lookup drew from. `UnreachableLocalRefTest` (`WorkerLib.clw`, near the end)
-deliberately declares no local of its own named `result`, so a definition lookup on that bare word
-from inside it has nothing legitimate to resolve to. `ProbeGlobalCounter` (`WorkerLib.clw` line 5,
-module scope, no owning procedure) is the negative control — a genuine global must keep resolving
-after the fix, since `IsUnreachableLocalVariable` short-circuits to `false` on an empty
-`parent_name`.
+`MyValue` (a `LONG`) and `TestQ` (a `QUEUE(TestQtype)`) are declared ONLY as locals of
+`WorkerClass.Sign` (`WorkerLib.clw` line 10/11) — nowhere else in the solution.
+`UnreachableLocalRefTest` (bottom of `WorkerLib.clw`) references both by bare name as call
+arguments to `WorkerClass.Ask`'s new QUEUE-taking overload, without declaring either itself:
 
-**Live-IDE check** (not exercisable via the indexer alone — this only pins the DB shape the
-runtime bug depends on): open this solution in the IDE with a build of ClarionAssistant carrying
-the fix, place the caret on the commented-out `result` inside `UnreachableLocalRefTest`, press
-F12.
-- **Before the fix**: jumps to one of the 20 unrelated procedures' own `result` declaration —
-  which one is arbitrary and can change across re-indexes (SQLite's `LIMIT 1` with no `ORDER BY`).
-- **After the fix**: no definition found.
-- **Regression check**: F12 on `ProbeGlobalCounter` from the same spot must still resolve.
+```clarion
+result = worker.Ask( MyValue )                  ! MyValue undeclared here
+result = worker.Ask( 'test', result, TestQ )     ! TestQ undeclared here
+```
 
-The probe word lives in a comment rather than a live statement so this file keeps compiling —
-referencing a genuinely undeclared identifier in real code is a hard Clarion compile error, and
-`CgDefinitionFromDb` has no string/comment awareness on the definition path today (a related,
-still-open gap — see PR #166's write-up), so a commented-out word exercises the identical lookup
-as one in live code.
+This file therefore does **not** compile — deliberately, and unlike every other bug in this
+fixture. Referencing a genuinely undeclared identifier in real code is a hard Clarion compile
+error; that's the whole point (it's literally the compile error that led to this fixture addition
+— "no matching procedure", traced to this exact undeclared-argument shape). The indexer parses
+text regardless of compile state, and F12/hover/Ctrl+Click work off the live buffer regardless too
+— compiling was never a precondition for reproducing or fixing this.
+
+**Live-confirmed 2026-08-07** (`ClarionAssistant-git` = pre-fix, `ClarionAssistant-consolidated` =
+post-fix; both freshly re-indexed before each check — a stale `.codegraph.db` from a previous
+build gives misleading results, see [[gotcha_reindex_when_switching_ca_builds]]):
+- **F12 on `MyValue`**: pre-fix jumped to `WorkerClass.Sign`'s `MyValue` declaration — wrong (the
+  guard was missing). Post-fix: no definition found — correct.
+- **F12 / Ctrl+Click on `TestQ`**: post-fix, no definition found, no hover — correct. (Not
+  independently confirmed pre-fix; `MyValue`'s result already demonstrates the same code path,
+  and `TestQ` has the identical single-candidate DB shape.)
+
+**A second, independent bug was found alongside this one, upstream in Clarion-Extension**:
+hovering `MyValue` returned a *third* wrong answer — `WorkerLib.inc`'s `TestQtype` QUEUE,TYPE
+field declaration — which is neither of the two locations above and cannot have come from
+ClarionAssistant's CodeGraph fallback at all (confirmed: **no CodeGraph symbol exists for
+`TestQtype` or its `MyValue` field** — see the Symbols section below and
+[[gotcha_queue_type_invisible_to_codegraph]]). Root cause: Clarion-Extension's
+`MemberLocatorService.isVariableLookupCandidate` guards against resolving into a CLASS/INTERFACE
+member (`context.inClass || context.inInterface`, added for a prior bug — bare-word hover
+resolving to an unrelated class member) but has no equivalent check for `context.inQueueOrGroupOrRecord`,
+even though `StructureContext` already exposes that flag. A QUEUE/GROUP/RECORD field has the same
+property a CLASS member does — only reachable via qualified access (`TestQ.MyValue`), never as a
+bare word — so the same guard needs the same third condition. This is almost certainly also why
+the original "undeclared variable" diagnostic never fired: the resolver believes the name exists.
+Tracked separately; not fixed by this change.
 
 ### Symbols
 
@@ -208,22 +231,25 @@ as one in live code.
   as correctly as `WorkerClass.Sign` right next to it (proving the symbol/parsing side was always
   unaffected) — the bug was entirely in call-site resolution, not symbol capture. Compare against
   the "Callers of `WorkerClass.Ask`" table above.
-- `OverloadBugClass.Dispatch` (Bug P, this PR): two `procedure` symbols sharing the identical
-  name, at lines 346 (`( LONG pValue )`) and 363 (`( *CSTRING pValue )`) — both were ALWAYS
+- `OverloadBugClass.Dispatch` (Bug P): two `procedure` symbols sharing the identical
+  name, at lines 360 (`( LONG pValue )`) and 377 (`( *CSTRING pValue )`) — both were ALWAYS
   correctly stored as two distinct symbols (proving, like Bug N, that the bug was entirely in
   relationship resolution, not symbol capture). Compare against the "Bug P" writeup and the
   `WorkerClass.Sign`/`WorkerClass.Ask` caller tables above.
-- `ProbeGlobalCounter` (Bug Q): `type='variable'`, `scope='module'`, `parent_name=NULL` — a
-  genuine module-scope global declared at the top of `WorkerLib.clw`, outside any procedure.
-  `UnreachableLocalRefTest` (Bug Q): a `procedure` symbol like any other; the point is what it
-  does NOT have — no `result`-named local of its own (compare against the 20 procedures above
-  that each declare one).
+- `MyValue` and `TestQ` (Bug Q): both `type='variable'`, `scope='local'`, `parent_name='WorkerClass.Sign'`
+  — the ONE legitimate declaration of each, and (since `FindSymbolByName`'s lookup is unordered
+  and unscoped) also the arbitrary wrong answer the pre-fix bug returned. `TestQtype` (the
+  `QUEUE,TYPE` in `WorkerLib.inc`) and its `MyValue` field: **no symbol at all** — confirmed by
+  direct query, not merely absent from this list — see [[gotcha_queue_type_invisible_to_codegraph]].
+  `UnreachableLocalRefTest` (Bug Q): a `procedure` symbol like any other; the point is what it does
+  NOT have — no `MyValue`- or `TestQ`-named local of its own.
 
 ### Program symbol (#81)
 
 - `Worker` (`type='program'`) has `calls` rows to every procedure invoked from the global
-  CODE section (11 rows), and **zero** incoming `calls` — the local variable named `worker`
-  must never resolve to the program symbol despite the case-insensitive name collision.
+  CODE section (13 rows — 12 before Bug Q's `UnreachableLocalRefTest()` call was added), and
+  **zero** incoming `calls` — the local variable named `worker` must never resolve to the program
+  symbol despite the case-insensitive name collision.
 
 ## Verify queries
 
@@ -232,10 +258,11 @@ SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Sign' AND r.type='calls' ORDER BY r.line_number;
 
--- Bug N (fixed in #118): expect 3 rows (TestSignatureFlow line 30, OwnerClass.CallViaMember
--- line 69, OverloadBugClass.Dispatch line 368 -- the last one is Bug P's addition, not Bug N's).
--- If this drops back to 0, Bug N has regressed — the built-in-named method is being erased at
--- the dotted/SELF. call sites again.
+-- Bug N (fixed in #118): expect 5 rows (TestSignatureFlow line 44, OwnerClass.CallViaMember
+-- line 83, OverloadBugClass.Dispatch line 382 -- Bug P's addition; UnreachableLocalRefTest lines
+-- 417+418 -- Bug Q's addition, unrelated to Bug N's own collision). If the TestSignatureFlow/
+-- OwnerClass.CallViaMember/OverloadBugClass.Dispatch rows drop out, Bug N has regressed -- the
+-- built-in-named method is being erased at the dotted/SELF. call sites again.
 SELECT s2.name, r.line_number FROM relationships r
 JOIN symbols s1 ON r.to_id=s1.id JOIN symbols s2 ON r.from_id=s2.id
 WHERE s1.name='WorkerClass.Ask' AND r.type='calls' ORDER BY r.line_number;
@@ -243,8 +270,8 @@ WHERE s1.name='WorkerClass.Ask' AND r.type='calls' ORDER BY r.line_number;
 SELECT name, type, scope, parent_name, params FROM symbols WHERE type='class' OR scope='parameter'
 OR name IN ('LocalDerived','workerRef','LocalGroup','InlineLocalGroup','GenCertData','SomeHandle','InlineGroup','InlineGroupPeriod','MultiLineGroup','HiddenGroupMember','AttrTermGroup','AttrTermGroupPeriod','BaseWorker');
 
--- Bug P: expect the LONG overload (line 346) as the sole caller of WorkerClass.Sign here, and
--- the CSTRING overload (line 363) as the sole caller of WorkerClass.Ask -- never the same
+-- Bug P: expect the LONG overload (line 360) as the sole caller of WorkerClass.Sign here, and
+-- the CSTRING overload (line 377) as the sole caller of WorkerClass.Ask -- never the same
 -- overload's line for both.
 SELECT s_to.name AS callee, r.line_number, s_from.line_number AS from_overload_def_line
 FROM relationships r
@@ -252,15 +279,20 @@ JOIN symbols s_to ON r.to_id = s_to.id
 JOIN symbols s_from ON r.from_id = s_from.id
 WHERE s_to.name IN ('WorkerClass.Sign','WorkerClass.Ask') AND s_from.name = 'OverloadBugClass.Dispatch';
 
--- Bug Q: 20 unrelated "result" locals, one per owning procedure -- the wrong-candidate pool
--- FindSymbolByName's unordered LIMIT-1 draws from. UnreachableLocalRefTest must NOT be among them.
-SELECT COUNT(*) AS result_local_count FROM symbols WHERE name='result' AND type='variable';
-SELECT * FROM symbols WHERE name='result' AND parent_name='UnreachableLocalRefTest'; -- expect 0 rows
+-- Bug Q: MyValue and TestQ each have exactly ONE row -- their sole legitimate declaration in
+-- WorkerClass.Sign -- and UnreachableLocalRefTest must not be among the results (it deliberately
+-- declares neither as its own local).
+SELECT name, type, scope, parent_name FROM symbols WHERE name IN ('MyValue','TestQ');
+SELECT * FROM symbols WHERE name IN ('MyValue','TestQ') AND parent_name='UnreachableLocalRefTest'; -- expect 0 rows
 
 -- Bug Q: simulates CodeGraphProvider.FindSymbolByName's exact query shape. Whichever row this
 -- picks, its parent must resolve to type='procedure'/'routine' -- confirming
--- IsUnreachableLocalVariable would reject it. ProbeGlobalCounter (parent_name IS NULL) must
--- never be filtered this way -- that's the over-rejection/negative-control check.
-SELECT id, name, type, scope, parent_name FROM symbols WHERE LOWER(name)=LOWER('result') LIMIT 1;
-SELECT name, type, scope, parent_name FROM symbols WHERE name='ProbeGlobalCounter';
+-- IsUnreachableLocalVariable would reject it.
+SELECT id, name, type, scope, parent_name FROM symbols WHERE LOWER(name)=LOWER('MyValue') LIMIT 1;
+SELECT id, name, type, scope, parent_name FROM symbols WHERE LOWER(name)=LOWER('TestQ') LIMIT 1;
+
+-- Bug Q (related upstream finding, not this fix): TestQtype and its MyValue field produce NO
+-- CodeGraph symbol at all -- confirms a wrong hover/F12 on either cannot have come from
+-- CgHoverFromDb/CgDefinitionFromDb; it's Clarion-Extension's own resolver.
+SELECT * FROM symbols WHERE name='TestQtype'; -- expect 0 rows
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/README.md
@@ -3,11 +3,14 @@
 Contributed by [@geircodes](https://github.com/geircodes) alongside issues #79–#90, extended for
 the `LIKE(...)`/`EQUATE`-alias CLASS-member fix (PR #92), the GROUP-typed CLASS-member fix
 (PR #93), the inherited-CLASS-member dotted-call resolution fix (PR #112), the
-built-in-name-collision fix (PR #118), issue #97's attrs+same-line-terminator fix, and the
-overload-attribution fix (Bug P, this PR) — a single compiling Clarion solution whose procedures
-each exercise one historical parser/indexer bug. This is currently the only regression coverage the
-CodeGraph parser has; run it after ANY change to `Parsing/ClarionParser.cs` or
-`Graph/CodeGraphIndexer.cs` (either synced copy).
+built-in-name-collision fix (PR #118), issue #97's attrs+same-line-terminator fix, the
+overload-attribution fix (Bug P), and Bug Q (pins the DB shape behind
+`SharedLspBridge.cs`'s F12-definition local-variable-guard fix — see its own section below; unlike
+A–P this isn't a parser/indexer bug, it documents a precondition for a runtime bug in the addin's
+C#) — a single compiling Clarion solution whose procedures each exercise one historical
+parser/indexer bug (plus, for Bug Q, a DB-shape precondition for a runtime bug). This is currently
+the only regression coverage the CodeGraph parser has; run it after ANY change to
+`Parsing/ClarionParser.cs` or `Graph/CodeGraphIndexer.cs` (either synced copy).
 
 Includes `WorkerClass.Ask` — a method whose name collides with the Clarion built-in `ASK()`
 statement — as coverage for Bug N (PR #118). Before that fix its two call sites resolved to
@@ -117,6 +120,43 @@ inside"), not the *callee* side (which overload a given call site actually invok
 caller *counts* (grouping by `to_id` for an overloaded name) remain unreliable; "what does this
 specific overload call" (grouping by `from_id`) is now correct.
 
+### Bug Q: F12/go-to-definition's CodeGraph fallback resolved to an unrelated procedure's local
+
+Not a parser/indexer bug like A–P above — this documents a DB-*shape* precondition for a bug in
+`SharedLspBridge.cs` (the ClarionAssistant addin's runtime C#, a separate assembly from this
+indexer). `CgDefinitionFromDb` (F12's CodeGraph fallback, reached only once the upstream LSP's own
+scope search has already returned nothing) looked symbols up via a flat, unordered
+`WHERE LOWER(name)=LOWER(@name) LIMIT 1` with no scope filter. Its sibling `CgHoverFromDb` already
+guards this exact shape with `IsUnreachableLocalVariable` — a "variable" symbol whose
+`parent_name` resolves to a `procedure`/`routine` symbol can never legitimately be referenced from
+outside that one procedure, so a match like that is always wrong. `CgDefinitionFromDb` never
+called it.
+
+This repro doesn't need a *new* bug pattern — `result` is already declared as a separate local in
+20 different procedures throughout this fixture (`TestSignatureFlow`, `OmitTest`,
+`OverloadBugClass.Dispatch`, etc.), which is exactly the "many wrong candidates, arbitrary pick"
+pool the unguarded lookup drew from. `UnreachableLocalRefTest` (`WorkerLib.clw`, near the end)
+deliberately declares no local of its own named `result`, so a definition lookup on that bare word
+from inside it has nothing legitimate to resolve to. `ProbeGlobalCounter` (`WorkerLib.clw` line 5,
+module scope, no owning procedure) is the negative control — a genuine global must keep resolving
+after the fix, since `IsUnreachableLocalVariable` short-circuits to `false` on an empty
+`parent_name`.
+
+**Live-IDE check** (not exercisable via the indexer alone — this only pins the DB shape the
+runtime bug depends on): open this solution in the IDE with a build of ClarionAssistant carrying
+the fix, place the caret on the commented-out `result` inside `UnreachableLocalRefTest`, press
+F12.
+- **Before the fix**: jumps to one of the 20 unrelated procedures' own `result` declaration —
+  which one is arbitrary and can change across re-indexes (SQLite's `LIMIT 1` with no `ORDER BY`).
+- **After the fix**: no definition found.
+- **Regression check**: F12 on `ProbeGlobalCounter` from the same spot must still resolve.
+
+The probe word lives in a comment rather than a live statement so this file keeps compiling —
+referencing a genuinely undeclared identifier in real code is a hard Clarion compile error, and
+`CgDefinitionFromDb` has no string/comment awareness on the definition path today (a related,
+still-open gap — see PR #166's write-up), so a commented-out word exercises the identical lookup
+as one in live code.
+
 ### Symbols
 
 - 10 `class` symbols: WorkerClass, OwnerClass, DerivableClass, GroupBugClass, PeriodBugClass,
@@ -173,6 +213,11 @@ specific overload call" (grouping by `from_id`) is now correct.
   correctly stored as two distinct symbols (proving, like Bug N, that the bug was entirely in
   relationship resolution, not symbol capture). Compare against the "Bug P" writeup and the
   `WorkerClass.Sign`/`WorkerClass.Ask` caller tables above.
+- `ProbeGlobalCounter` (Bug Q): `type='variable'`, `scope='module'`, `parent_name=NULL` — a
+  genuine module-scope global declared at the top of `WorkerLib.clw`, outside any procedure.
+  `UnreachableLocalRefTest` (Bug Q): a `procedure` symbol like any other; the point is what it
+  does NOT have — no `result`-named local of its own (compare against the 20 procedures above
+  that each declare one).
 
 ### Program symbol (#81)
 
@@ -206,4 +251,16 @@ FROM relationships r
 JOIN symbols s_to ON r.to_id = s_to.id
 JOIN symbols s_from ON r.from_id = s_from.id
 WHERE s_to.name IN ('WorkerClass.Sign','WorkerClass.Ask') AND s_from.name = 'OverloadBugClass.Dispatch';
+
+-- Bug Q: 20 unrelated "result" locals, one per owning procedure -- the wrong-candidate pool
+-- FindSymbolByName's unordered LIMIT-1 draws from. UnreachableLocalRefTest must NOT be among them.
+SELECT COUNT(*) AS result_local_count FROM symbols WHERE name='result' AND type='variable';
+SELECT * FROM symbols WHERE name='result' AND parent_name='UnreachableLocalRefTest'; -- expect 0 rows
+
+-- Bug Q: simulates CodeGraphProvider.FindSymbolByName's exact query shape. Whichever row this
+-- picks, its parent must resolve to type='procedure'/'routine' -- confirming
+-- IsUnreachableLocalVariable would reject it. ProbeGlobalCounter (parent_name IS NULL) must
+-- never be filtered this way -- that's the over-rejection/negative-control check.
+SELECT id, name, type, scope, parent_name FROM symbols WHERE LOWER(name)=LOWER('result') LIMIT 1;
+SELECT name, type, scope, parent_name FROM symbols WHERE name='ProbeGlobalCounter';
 ```

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
@@ -14,6 +14,7 @@ GroupQueueLocalTest PROCEDURE, LONG
 InlineLocalGroupTest PROCEDURE, LONG
 AttrTermLocalGroupTest PROCEDURE, LONG
 LocalDerivedClassTest PROCEDURE, LONG
+UnreachableLocalRefTest PROCEDURE
     END
 MainHelperProc     PROCEDURE, LONG
   END
@@ -49,6 +50,7 @@ derivedWorker DerivedWorkerClass
     r# = likeMemberBug.CallViaPlainInstanceMember()
     r# = multiLineGroupBug.CallViaAfterMultiLineGroupMember()
     r# = derivedWorker.CallViaInheritedMember()
+    UnreachableLocalRefTest()
 
 ! Bug A repro: this procedure is implemented directly in the PROGRAM file itself,
 ! rather than in a MEMBER file. ParseMainFile only scans the file's PROGRAM marker,

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/Worker.clw
@@ -14,7 +14,7 @@ GroupQueueLocalTest PROCEDURE, LONG
 InlineLocalGroupTest PROCEDURE, LONG
 AttrTermLocalGroupTest PROCEDURE, LONG
 LocalDerivedClassTest PROCEDURE, LONG
-UnreachableLocalRefTest PROCEDURE
+UnreachableLocalRefTest PROCEDURE, LONG
     END
 MainHelperProc     PROCEDURE, LONG
   END
@@ -50,7 +50,7 @@ derivedWorker DerivedWorkerClass
     r# = likeMemberBug.CallViaPlainInstanceMember()
     r# = multiLineGroupBug.CallViaAfterMultiLineGroupMember()
     r# = derivedWorker.CallViaInheritedMember()
-    UnreachableLocalRefTest()
+    r# = UnreachableLocalRefTest()
 
 ! Bug A repro: this procedure is implemented directly in the PROGRAM file itself,
 ! rather than in a MEMBER file. ParseMainFile only scans the file's PROGRAM marker,

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -2,9 +2,13 @@
 
   INCLUDE('WorkerLib.inc'),ONCE
 
-ProbeGlobalCounter LONG
-
 WorkerClass.Sign PROCEDURE( LONG pData )
+! Bug Q repro: MyValue and TestQ are declared ONLY here, as locals of THIS procedure -- nowhere
+! else in the solution. UnreachableLocalRefTest below references both by bare name without
+! declaring its own locals of the same name, exercising CgDefinitionFromDb's
+! IsUnreachableLocalVariable guard (see README.md's Bug Q section).
+MyValue LONG
+TestQ   QUEUE(TestQType) END
   CODE
   RETURN 0
 
@@ -12,6 +16,14 @@ WorkerClass.Sign PROCEDURE( LONG pData )
 ! identical in shape to Sign above -- only its name differs, and that name happens to collide
 ! with the Clarion built-in ASK() keyword, which used to erase its calls at dotted/SELF. sites.
 WorkerClass.Ask PROCEDURE( LONG pData )
+  CODE
+  RETURN 0
+
+! Bug Q repro: the QUEUE,TYPE-taking overload declared in WorkerLib.inc. Implementation body is
+! irrelevant to Bug Q -- only the declaration (WorkerClass.Ask exists, takes a TestQtype) matters,
+! so UnreachableLocalRefTest's calls below resolve to a real method and the ONLY question is
+! whether their bare-word ARGUMENTS (MyValue, TestQ) wrongly resolve.
+WorkerClass.Ask PROCEDURE( STRING pText, LONG pValue, <TestQtype pTestQ> )
   CODE
   RETURN 0
 
@@ -370,37 +382,39 @@ worker WorkerClass
   result = worker.Ask( result )
   RETURN result
 
-! Bug Q repro: SharedLspBridge.cs's CgDefinitionFromDb (F12/go-to-definition CodeGraph
-! fallback, used whenever the upstream LSP's own scope search already returned nothing --
-! i.e. the word is genuinely undeclared here) never applied the same IsUnreachableLocalVariable
-! guard its sibling CgHoverFromDb already applies. FindSymbolByName's underlying lookup is a
-! flat, unordered "WHERE LOWER(name)=LOWER(@name) LIMIT 1" with no scope filter, so a bare word
-! that only matches OTHER procedures' local variables/parameters resolves to whichever one
-! happens to come back first -- arbitrary and index-order-dependent, never legitimate (Clarion
+! Bug Q repro: SharedLspBridge.cs's CgDefinitionFromDb (F12/Ctrl+Click's CodeGraph fallback, used
+! whenever the upstream LSP's own scope search already returned nothing -- i.e. the word is
+! genuinely undeclared here) never applied the same IsUnreachableLocalVariable guard its sibling
+! CgHoverFromDb already applies. FindSymbolByName's underlying lookup is a flat, unordered
+! "WHERE LOWER(name)=LOWER(@name) LIMIT 1" with no scope filter, so a bare word that only matches
+! ANOTHER procedure's local variable resolves to it -- arbitrary, and never legitimate (Clarion
 ! has no mechanism for one procedure to reference another's local).
 !
-! This procedure deliberately declares no local named "result" -- ~20 unrelated procedures above
-! each declare their OWN "result" local (TestSignatureFlow, OmitTest, MainHelperProc,
-! OverloadBugClass.Dispatch, etc.), which is exactly the "many wrong candidates" pool
-! FindSymbolByName's unordered LIMIT-1 picks from. (The probe word lives in this comment rather
-! than as a live statement so this file keeps compiling -- referencing a genuinely undeclared
-! identifier in real code is a hard Clarion compile error. CgDefinitionFromDb has no
-! string/comment awareness on the definition path today, so a commented-out word exercises the
-! identical lookup as one in live code.)
+! This is the real-world trigger, reproduced directly (not a synthetic stand-in): a call argument
+! left undeclared by mistake, whose name happens to already be a local elsewhere -- exactly what
+! motivated this fixture addition. MyValue and TestQ are declared ONLY in WorkerClass.Sign above
+! (line 6); this procedure references both by bare name in a real call, without declaring either
+! itself. This file therefore does NOT compile -- expected and deliberate, since the whole point
+! is a genuinely undeclared identifier; the indexer parses text regardless, and F12/hover/
+! Ctrl+Click work off the live buffer regardless of compile state.
 !
-! Live-IDE F12 check (not exercisable via the indexer alone -- see README's Bug Q section):
-!   place the caret on "result" below and press F12.
-!     result
-!   Before the fix: jumps to one of the ~20 unrelated procedures' own "result" declaration above
-!   -- which one is arbitrary and can change across re-indexes.
-!   After the fix: no definition found -- correct, since "result" is not declared anywhere
-!   reachable from this point.
+! Confirmed live 2026-08-07 (ClarionAssistant-git = pre-fix, ClarionAssistant-consolidated =
+! post-fix, both freshly re-indexed before each check):
+!   F12 on "MyValue" below:
+!     pre-fix:  jumped to WorkerClass.Sign's MyValue declaration above (line 6) -- wrong.
+!     post-fix: no definition found -- correct.
+!   F12 / Ctrl+Click on "TestQ" below:
+!     post-fix: no definition found, no hover -- correct (not independently confirmed pre-fix;
+!     MyValue's result already demonstrates the same code path).
 !
-! Negative control (over-rejection check): ProbeGlobalCounter (WorkerLib.clw's own module-scope
-! global, declared above WorkerClass.Sign) must still resolve correctly via F12 from here --
-! IsUnreachableLocalVariable's empty-ParentName exemption for genuine globals.
-!     ProbeGlobalCounter
-UnreachableLocalRefTest PROCEDURE()
+! Negative control (over-rejection check, not yet live-verified): WorkerClass.Ask itself, and the
+! "worker" local below, must keep resolving normally -- only the two undeclared arguments should
+! be affected.
+UnreachableLocalRefTest PROCEDURE, LONG
+result LONG
+worker WorkerClass
   CODE
-  RETURN
+  result = worker.Ask( MyValue )
+  result = worker.Ask( 'test', result, TestQ )
+  RETURN result
 

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.clw
@@ -2,6 +2,8 @@
 
   INCLUDE('WorkerLib.inc'),ONCE
 
+ProbeGlobalCounter LONG
+
 WorkerClass.Sign PROCEDURE( LONG pData )
   CODE
   RETURN 0
@@ -367,4 +369,38 @@ worker WorkerClass
   result = SELF.Dispatch( 99 )
   result = worker.Ask( result )
   RETURN result
+
+! Bug Q repro: SharedLspBridge.cs's CgDefinitionFromDb (F12/go-to-definition CodeGraph
+! fallback, used whenever the upstream LSP's own scope search already returned nothing --
+! i.e. the word is genuinely undeclared here) never applied the same IsUnreachableLocalVariable
+! guard its sibling CgHoverFromDb already applies. FindSymbolByName's underlying lookup is a
+! flat, unordered "WHERE LOWER(name)=LOWER(@name) LIMIT 1" with no scope filter, so a bare word
+! that only matches OTHER procedures' local variables/parameters resolves to whichever one
+! happens to come back first -- arbitrary and index-order-dependent, never legitimate (Clarion
+! has no mechanism for one procedure to reference another's local).
+!
+! This procedure deliberately declares no local named "result" -- ~20 unrelated procedures above
+! each declare their OWN "result" local (TestSignatureFlow, OmitTest, MainHelperProc,
+! OverloadBugClass.Dispatch, etc.), which is exactly the "many wrong candidates" pool
+! FindSymbolByName's unordered LIMIT-1 picks from. (The probe word lives in this comment rather
+! than as a live statement so this file keeps compiling -- referencing a genuinely undeclared
+! identifier in real code is a hard Clarion compile error. CgDefinitionFromDb has no
+! string/comment awareness on the definition path today, so a commented-out word exercises the
+! identical lookup as one in live code.)
+!
+! Live-IDE F12 check (not exercisable via the indexer alone -- see README's Bug Q section):
+!   place the caret on "result" below and press F12.
+!     result
+!   Before the fix: jumps to one of the ~20 unrelated procedures' own "result" declaration above
+!   -- which one is arbitrary and can change across re-indexes.
+!   After the fix: no definition found -- correct, since "result" is not declared anywhere
+!   reachable from this point.
+!
+! Negative control (over-rejection check): ProbeGlobalCounter (WorkerLib.clw's own module-scope
+! global, declared above WorkerClass.Sign) must still resolve correctly via F12 from here --
+! IsUnreachableLocalVariable's empty-ParentName exemption for genuine globals.
+!     ProbeGlobalCounter
+UnreachableLocalRefTest PROCEDURE()
+  CODE
+  RETURN
 

--- a/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
+++ b/ClarionAssistant/indexer/test-fixtures/codegraph-repro/WorkerLib.inc
@@ -1,3 +1,8 @@
+! Bug Q repro (see README.md): a QUEUE,TYPE used as an optional CLASS-method parameter below.
+TestQtype   QUEUE,TYPE
+MyValue       LONG
+            END
+
 WorkerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )
 
 Sign          PROCEDURE( LONG pData ), LONG
@@ -12,6 +17,10 @@ Sign          PROCEDURE( LONG pData ), LONG
 ! declaration and every call site in WorkerLib.clw, so the two can be compared side by side: both
 ! resolve now. See WorkerLib.clw for the call sites and README.md for the full writeup.
 Ask           PROCEDURE( LONG pData ), LONG
+! Bug Q repro: a second Ask overload taking a QUEUE,TYPE (TestQtype) as an optional parameter --
+! the real-world shape that motivated this fixture addition (see README.md's Bug Q section and
+! UnreachableLocalRefTest in WorkerLib.clw).
+Ask           PROCEDURE( STRING pText, LONG pValue, <TestQtype pTestQ> ), LONG
             END
 
 OwnerClass CLASS,TYPE, MODULE('WorkerLib.CLW'), LINK('WorkerLib.CLW', 1 ), DLL( 0 )


### PR DESCRIPTION
## Summary

F12/Ctrl+Click's CodeGraph fallback (`CgDefinitionFromDb` in `SharedLspBridge.cs`) could jump to
an unrelated procedure's local variable or parameter instead of correctly reporting "no
definition" — arbitrary and index-order-dependent, so the target could change across re-indexes
even though the underlying code hadn't changed.

## Root cause

`GetDefinition` asks the upstream Clarion LSP first; when it returns nothing — which mostly
happens when a word is genuinely undeclared, exactly the case where landing anywhere is wrong —
it falls back to `CgDefinitionFromDb`, a flat, unordered exact-name lookup against the indexed
CodeGraph database (`CodeGraphProvider.FindSymbolByName`, `WHERE LOWER(name)=LOWER(@name) LIMIT
1`). No `ORDER BY`, no scope filter. If the only matches anywhere in the solution are
procedure-local variables or parameters belonging to other, unrelated procedures, F12 still jumps
to one of them.

The correct guard already existed and was already used by the sibling hover path
(`CgHoverFromDb`, same file):

```csharp
private static bool IsUnreachableLocalVariable(CodeGraphProvider p, CodeGraphSymbol sym)
{
    if (!string.Equals(sym.Type, "variable", StringComparison.OrdinalIgnoreCase)) return false;
    if (string.IsNullOrEmpty(sym.ParentName)) return false;
    var parent = p.FindSymbolByName(sym.ParentName);
    return parent != null &&
        (string.Equals(parent.Type, "procedure", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(parent.Type, "routine", StringComparison.OrdinalIgnoreCase));
}
```

`CgDefinitionFromDb` never called it — a missing sibling application, not a design choice. A
genuine module/global-scope variable (empty `ParentName`) is unaffected either way, since the
guard short-circuits to `false` before it would ever be filtered.

## Fix

`CgDefinitionFromDb` now mirrors `CgHoverFromDb`: fetches the full `CodeGraphSymbol` via
`FindSymbolByName` (instead of the thinner `GetDefinition` helper it used before) and rejects the
match when `IsUnreachableLocalVariable` says so.

## Verification

- Clean build, no new warnings (`ClarionAssistant.csproj`, VS2022 MSBuild toolset).
- Live-tested against the real trigger that motivated this fix: a call argument left undeclared
  by mistake, whose name happened to already be a local variable declared in a different method
  of the same class. Before the fix, F12 on the undeclared argument jumped to that unrelated
  method's own local declaration. After the fix, it correctly finds nothing. A second undeclared
  argument of a `QUEUE` type, in the same call, also correctly finds nothing after the fix (F12
  and Ctrl+Click both) — not independently tested before the fix, but it has the identical
  single-candidate DB shape as the first case, which was.
- Added `indexer/test-fixtures/codegraph-repro`'s "Bug Q" section: the real repro (a `QUEUE,TYPE`
  used as an optional method parameter, with the undeclared arguments' names shared with locals
  declared elsewhere in the class) as permanent regression coverage, plus two SQL queries that
  simulate `FindSymbolByName`'s exact lookup shape against a freshly-indexed DB and confirm the
  picked row's parent resolves to `type='procedure'` — i.e. exactly what `IsUnreachableLocalVariable`
  needs to see to reject it.
- No live-reproducible over-rejection case exists to test against: the guard only ever rejects a
  symbol that is `type='variable'` with a parent resolving to `procedure`/`routine`, and by
  Clarion's own scoping rules that exact shape is never legitimately reachable from outside its
  own owning procedure. Two independent attempts to find a live counter-example (a bare ABC class
  name, a bare structural keyword) both turned out to resolve through the upstream Clarion LSP's
  own provider rather than this fallback at all, which is consistent with the fallback's fix
  correctly having no legitimate case in its rejection condition.

## Related, not fixed here

While testing this fix's real-world trigger, a second, independent bug was found in
Clarion-Extension's own hover/definition resolver (`MemberLocatorService.isVariableLookupCandidate`):
it guards against resolving a bare word into a CLASS/INTERFACE member
(`context.inClass || context.inInterface`) but has no equivalent check for
`context.inQueueOrGroupOrRecord`, even though `StructureContext` already exposes that flag. A
QUEUE/GROUP/RECORD field has the same property a CLASS member does — only reachable via qualified
access, never as a bare word. Filed upstream separately; unrelated codebase, out of scope here.
