### PR TITLE
fix(editor): follow Clarion's live font, not a dead property

### DIFF
--- a/ClarionAssistant/Services/IdeEditorOptions.cs
+++ b/ClarionAssistant/Services/IdeEditorOptions.cs
@@ -132,9 +132,15 @@ namespace ClarionAssistant.Services
                 string.Equals((GetString(tes, "LineViewerStyle", "None") ?? "").Trim(), "None",
                               StringComparison.OrdinalIgnoreCase) ? "none" : "line";
 
-            // --- Font. Parse failures leave FontFamily=""/FontSize=0 so the caller falls back to the stored
-            // pref; we never substitute a font of our own choosing. ---
-            ParseFont(GetString(tes, "DefaultFont", null), v);
+            // --- Font. NOT read from the "TextEditorSettings" bundle above: "DefaultFont" there is a
+            // separate, dead property that the live Options dialog does not write to — verified directly
+            // against ClarionProperties.xml (changing font size in Options -> Text Editor updates
+            // ComponentsFont's "TextEditor" entry below, DefaultFont's Size stays wherever it started).
+            // Parse failures leave FontFamily=""/FontSize=0 so the caller falls back to the stored pref; we
+            // never substitute a font of our own choosing. ---
+            ParseComponentFont(v);
+            if (v.FontFamily.Length == 0 && v.FontSize == 0)
+                ParseFont(GetString(tes, "DefaultFont", null), v);   // older installs without the bundle below
 
             values = v;
             return true;
@@ -181,6 +187,56 @@ namespace ClarionAssistant.Services
             {
                 // Leave whatever parsed successfully; the caller falls back per-field.
                 System.Diagnostics.Debug.WriteLine("[IdeEditorOptions] font parse failed: " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// The IDE's actual live editor font: "CoreProperties.ComponentsFont" bundle, "ListOfFonts" array,
+        /// one pipe-delimited entry per IDE component, e.g.
+        ///   "TextEditor|Text Editor, Output Window (Proportional Font)|Courier New,20"
+        /// Finds the "TextEditor" entry and parses the trailing "Name,Size" pair off the last pipe segment.
+        /// Size has no explicit unit here (unlike DefaultFont's Units=N) — assumed points, same convention,
+        /// so it goes through the same pt->px conversion. Leaves the fields untouched on anything unexpected,
+        /// same fallback contract as ParseFont.
+        /// </summary>
+        private static void ParseComponentFont(IdeEditorOptionValues v)
+        {
+            try
+            {
+                Properties cf = PropertyService.Get<Properties>("CoreProperties.ComponentsFont", null);
+                if (cf == null) return;
+                string[] fonts = cf.Get<string[]>("ListOfFonts", null);
+                if (fonts == null) return;
+
+                foreach (var entry in fonts)
+                {
+                    if (string.IsNullOrEmpty(entry) || !entry.StartsWith("TextEditor|", StringComparison.Ordinal))
+                        continue;
+
+                    int lastPipe = entry.LastIndexOf('|');
+                    if (lastPipe < 0) continue;
+                    string nameSize = entry.Substring(lastPipe + 1);
+                    int lastComma = nameSize.LastIndexOf(',');
+                    if (lastComma < 0) continue;
+
+                    string fam = nameSize.Substring(0, lastComma).Trim();
+                    string sizeStr = nameSize.Substring(lastComma + 1).Trim();
+
+                    // Same shape-guard as ParseFont: no control chars/quotes that could break the CSS
+                    // font-family string this feeds into.
+                    if (fam.Length > 0 && fam.Length <= 64 && fam.IndexOfAny(new[] { '"', '\'', '{', '}', ';', '\r', '\n' }) < 0)
+                        v.FontFamily = fam;
+
+                    double pts;
+                    if (double.TryParse(sizeStr, NumberStyles.Float, CultureInfo.InvariantCulture, out pts) && pts > 0)
+                        v.FontSize = Clamp((int)Math.Round(pts * 4.0 / 3.0), 6, 48);
+
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("[IdeEditorOptions] component font read failed: " + ex.Message);
             }
         }
 

--- a/ClarionAssistant/Services/MonacoSettingsBroadcaster.cs
+++ b/ClarionAssistant/Services/MonacoSettingsBroadcaster.cs
@@ -28,9 +28,13 @@ namespace ClarionAssistant.Services
         private static readonly List<Action<string>> _sinks = new List<Action<string>>();
         private const int MaxBridgeJsonBytes = 65536;   // mirror ModernEmbeditorViewContent.MaxBridgeJsonBytes
 
-        // GH #126: when the developer OKs Options → Text Editor, re-push the stored settings to every open
-        // Monaco surface — ToDict() re-reads the IDE indentation pair live, so followers pick the new values
-        // up immediately instead of on their next open. Static ctor = hooked once, on first Monaco use.
+        // GH #126 (+ font-follow): when the developer OKs Options → Text Editor, re-push the stored settings
+        // to every open Monaco surface — ToDict() re-reads the IDE indentation/font values live, so followers
+        // pick up the new values immediately instead of on their next open (or a manual uncheck/recheck).
+        // Two bundles matter: "TextEditorSettings" (tab size, indentation, etc. — GH #126's original scope)
+        // and "CoreProperties.ComponentsFont" (the live font list; see IdeEditorOptions.ParseComponentFont —
+        // font is a separate bundle, added later, that this hook originally didn't know about). Static ctor
+        // = hooked once, on first Monaco use.
         static MonacoSettingsBroadcaster()
         {
             try
@@ -39,7 +43,7 @@ namespace ClarionAssistant.Services
                 {
                     try
                     {
-                        if (e != null && e.Key == "TextEditorSettings")
+                        if (e != null && (e.Key == "TextEditorSettings" || e.Key == "CoreProperties.ComponentsFont"))
                             Broadcast(ModernEmbeditorSettings.Load());
                     }
                     catch (Exception ex) { System.Diagnostics.Debug.WriteLine("[MonacoSettingsBroadcaster] ide-options push: " + ex.Message); }

--- a/ClarionAssistant/Terminal/monaco-embeditor.html
+++ b/ClarionAssistant/Terminal/monaco-embeditor.html
@@ -4249,6 +4249,13 @@
         if ((el = document.getElementById('setTabSize'))) el.disabled = on;
         if ((el = document.getElementById('setInsertSpaces'))) el.disabled = on;
         if ((el = document.getElementById('setCursorBehindEol'))) el.disabled = on;
+        // Font is CONDITIONAL, unlike the three above: the host omits ideFontFamily/ideFontSize when the
+        // IDE's font descriptor didn't parse, and in that case the stored pref still wins even with follow
+        // on — so only gray out the field the IDE actually has an opinion on.
+        if ((el = document.getElementById('setFontSize')))
+            el.disabled = on && !!_ideOpts && typeof _ideOpts.fontSize === 'number';
+        if ((el = document.getElementById('setFontFamily')))
+            el.disabled = on && !!_ideOpts && typeof _ideOpts.fontFamily === 'string' && _ideOpts.fontFamily !== '';
     }
 
     function populateSettingsPanel(s) {
@@ -4268,8 +4275,17 @@
         if ((el = document.getElementById('setWordWrap'))) el.checked = !!s.wordWrap;
         if ((el = document.getElementById('setMinimap'))) el.checked = !!s.minimap;
         if ((el = document.getElementById('setCompleteOnInsertKey'))) el.checked = (s.completeOnInsertKey !== false);
-        if ((el = document.getElementById('setFontSize')) && typeof s.fontSize === 'number') el.value = s.fontSize;
-        if ((el = document.getElementById('setFontFamily'))) el.value = (typeof s.fontFamily === 'string') ? s.fontFamily : '';
+        // Show the EFFECTIVE state (mirrors setCursorBehindEol above): while follow-mode owns the field via
+        // syncFollowIdeUi, display what's actually rendering rather than the stale stored pref sitting
+        // behind it.
+        if ((el = document.getElementById('setFontSize'))) {
+            var followingFontSize = (s.followIdeIndentation !== false) && _ideOpts && typeof _ideOpts.fontSize === 'number';
+            el.value = followingFontSize ? _ideOpts.fontSize : (typeof s.fontSize === 'number' ? s.fontSize : 13);
+        }
+        if ((el = document.getElementById('setFontFamily'))) {
+            var followingFontFamily = (s.followIdeIndentation !== false) && _ideOpts && typeof _ideOpts.fontFamily === 'string' && _ideOpts.fontFamily !== '';
+            el.value = followingFontFamily ? _ideOpts.fontFamily : ((typeof s.fontFamily === 'string') ? s.fontFamily : '');
+        }
         if ((el = document.getElementById('setOccurrenceHighlight'))) el.checked = (s.occurrenceHighlight !== false);   // default ON (#62)
         if ((el = document.getElementById('setHorizontalScrollbar'))) el.value = s.horizontalScrollbar || 'auto';
         populateFormatterPanel(s);
@@ -4856,7 +4872,7 @@
             // reopening later must not offer a stale "current → imported" the developer has since changed.
             if (p.classList.contains('hidden')) vscHide();
         });
-        var ids = ['setFollowIdeIndent', 'setCursorBehindEol', 'setTabSize', 'setInsertSpaces', 'setAutoIndent', 'setWordWrap', 'setMinimap', 'setCompleteOnInsertKey', 'setFontSize', 'setFontFamily', 'setOccurrenceHighlight', 'setHorizontalScrollbar',
+        var ids = ['setCursorBehindEol', 'setTabSize', 'setInsertSpaces', 'setAutoIndent', 'setWordWrap', 'setMinimap', 'setCompleteOnInsertKey', 'setFontSize', 'setFontFamily', 'setOccurrenceHighlight', 'setHorizontalScrollbar',
             // Smart Formatter controls
             'setPreferredColumn', 'setContLineMultiplier', 'setIndentComments', 'setDontIndentCol1Comments', 'setFormatLineOnEnter',
             'setAutoSpaceEquals', 'setLiveKeywordCase',
@@ -4867,9 +4883,25 @@
             var e = document.getElementById(ids[i]);
             if (e) e.addEventListener('change', onSettingChanged);
         }
-        // GH #126: toggling follow-IDE also grays/ungrays the manual pair (onSettingChanged persists it).
+        // GH #126 (+ font-follow-clobber fix): toggling follow-IDE also grays/ungrays the manual pair, then
+        // persists. When turning OFF, font size/family/cursor-behind-EOL must be restored to the STORED pref
+        // FIRST — while follow was on they were showing the EFFECTIVE (IDE) value (populateSettingsPanel's
+        // "EFFECTIVE state" rule), and onSettingChanged() below reads straight off the DOM. Without this,
+        // unchecking silently overwrites the stored pref with whatever IDE font/EOL value was on display.
+        // (setFollowIdeIndent is deliberately NOT in the generic `ids` loop above — this is its only
+        // listener, so the restore always runs before the save it triggers.)
         var fIde = document.getElementById('setFollowIdeIndent');
-        if (fIde) fIde.addEventListener('change', syncFollowIdeUi);
+        if (fIde) fIde.addEventListener('change', function () {
+            if (!fIde.checked) {
+                var s = lastSettings || {};
+                var el;
+                if ((el = document.getElementById('setFontSize')) && typeof s.fontSize === 'number') el.value = s.fontSize;
+                if ((el = document.getElementById('setFontFamily'))) el.value = (typeof s.fontFamily === 'string') ? s.fontFamily : '';
+                if ((el = document.getElementById('setCursorBehindEol'))) el.checked = !!s.cursorBehindEOL;
+            }
+            syncFollowIdeUi();
+            onSettingChanged();
+        });
         // Seed the formatter controls from DEFAULTS immediately (before host settings arrive) so a keybind
         // persist that runs first doesn't read empty/unchecked formatter controls and clobber the defaults.
         populateFormatterPanel(lastSettings);


### PR DESCRIPTION
## Summary

"Follow Clarion's editor options" in the Monaco gear panel (`Terminal/monaco-embeditor.html` + `Services/IdeEditorOptions.cs`) is supposed to mirror the IDE's own Options → Text Editor settings live. Font never actually worked: it read `TextEditorSettings.DefaultFont`, a property the current Options dialog doesn't write to — changing the font in Options never changed anything Monaco used, no matter how many times you toggled the checkbox.

## Root cause + fix

`IdeEditorOptions.ParseFont` parsed `TextEditorSettings.DefaultFont` (`[Font: Name=..., Size=..., Units=...]`). Verified directly against `ClarionProperties.xml`: changing the font size in Options → Text Editor and clicking OK rewrites the file, but `DefaultFont`'s `Size` never changes — it's dead. The value the dialog actually writes, and that the native IDE editor windows actually use, lives in a different bundle: `CoreProperties.ComponentsFont`'s `ListOfFonts` array, one pipe-delimited entry per IDE component (`"TextEditor|Text Editor, Output Window (Proportional Font)|Courier New,20"`).

Added `IdeEditorOptions.ParseComponentFont`, which finds the `TextEditor` entry and parses the trailing `Name,Size` pair (points, same pt→px conversion `DefaultFont` already used). Falls back to the old `DefaultFont` parse only if the new bundle is absent (older installs).

## Two more bugs in the same follow-mode gear panel, found while fixing the above

- **Font size/family never grayed out or showed the effective IDE value while following was on.** `syncFollowIdeUi()`/`populateSettingsPanel()` had a conditional disable + "show the effective state" branch for Cursor-behind-EOL, but nothing at all for font — it always showed/used the stored pref regardless of follow-mode. Added the missing branches, mirroring the existing Cursor-behind-EOL pattern.
- **Unchecking "follow" clobbered the stored font pref.** While following, the font fields display the *effective* (IDE) value but stay tied to the same stored-pref save path. `setFollowIdeIndent`'s `change` listener saved via `readSettingsPanel()`, which reads straight off the DOM — so unchecking, with the fields still showing the IDE's font, immediately persisted that IDE value as if it were the user's own preference, permanently overwriting whatever they'd actually set. Fixed by restoring the stored font/family/cursor-behind-EOL values into the fields *before* the save fires, only when transitioning to unchecked.

## Also fixed: live IDE font changes didn't propagate while following

`MonacoSettingsBroadcaster`'s `PropertyService.PropertyChanged` hook auto-re-broadcasts settings to every open Monaco surface when the IDE's Options dialog is OK'd — but only watched the `"TextEditorSettings"` key (GH #126's original scope, tab size/indentation). Font lives under `"CoreProperties.ComponentsFont"`, a different bundle the hook didn't know about, so an IDE font change while following required a manual uncheck/recheck to show up. Added `"CoreProperties.ComponentsFont"` to the watched keys.

## Verification

All four fixes tested live against a real Clarion 11 IDE session, iterating directly against `ClarionProperties.xml` and a temporary diagnostic build (raw `ComponentsFont` dump + on-page `_ideOpts`/disabled-state readout, both stripped before this commit) to confirm each piece independently before removing the scaffolding:
- Live IDE font size/family changes (`10pt`→`14pt`, confirmed via the raw property) correctly convert and apply while following.
- Font size/family fields correctly gray out and display the effective IDE value while checked.
- Unchecking correctly restores the stored pref (tested: stored "JetBrains Mono / 12" survives check→uncheck against a live "Courier New / 19" IDE font, in both directions, repeatedly).
- `settings.txt` persists correctly on every toggle — no clobbering in either direction.
- IDE font changes while following now propagate immediately, no manual toggle needed.

3 files changed, 104 insertions / 12 deletions on top of `upstream/master`.
check/recheck.