### PR TITLE
fix(lsp): make -Pure self-contained and verify the shipped LSP matches the pin

### DIFF
--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -277,32 +277,41 @@ function Invoke-GitQuiet([string[]]$GitArgs) {
     }
 }
 
-function Assert-LspPin($sourceDir) {
+# Returns $true when the LSP may ship, $false when it must not. It does NOT exit: an LSP-copy
+# problem is not a reason to abandon the Clarion builds. This used to `exit 7`, which aborted all
+# four Clarion targets AND the C# addin before a single one was built -- cutting straight across
+# the "a build failure for ONE Clarion release must not block shipping to the others" rule the
+# final summary below is built around. The caller skips just the LSP copy instead, so every version
+# still deploys and keeps whatever server it already had, and the run ends non-zero so nobody reads
+# it as clean.
+function Test-LspPin($sourceDir) {
     $manifest = Get-Content (Join-Path $ProjectDir "lsp-server-sync\lsp-snapshot.json") -Raw | ConvertFrom-Json
     $pinned   = $manifest.resolvedCommit
     if (-not $pinned) {
         Write-Host "  WARN  manifest has no resolvedCommit — cannot verify the bundled LSP." -ForegroundColor Yellow
-        return
+        return $true
     }
     $head = Invoke-GitQuiet @('-C', $sourceDir, 'rev-parse', '--short', 'HEAD')
     if (-not $head) {
         Write-Host "  WARN  $sourceDir is not a git tree — cannot verify it matches pin $pinned." -ForegroundColor Yellow
-        return
+        return $true
     }
     # Prefix compare: `git rev-parse --short` auto-scales its length, so 7- and 8-char forms of the
     # same commit must still count as a match.
     if (-not ($head.StartsWith($pinned) -or $pinned.StartsWith($head))) {
         if ($env:CLARIONLSP_ROOT) {
             Write-Host "  WARN  bundled LSP is $head but the pin says $pinned (CLARIONLSP_ROOT override in effect)." -ForegroundColor Yellow
-            return
+            return $true
         }
         Write-Host "  FAIL  bundled LSP is $head but lsp-snapshot.json pins $pinned." -ForegroundColor Red
         Write-Host "        Re-run lsp-server-sync\Sync-LspServer.ps1 -Pure, or bump the pin deliberately." -ForegroundColor Red
-        exit 7
+        Write-Host "        The LSP copy will be SKIPPED for every version; the rest of the deploy continues." -ForegroundColor Red
+        return $false
     }
     Write-Host "  OK    bundled LSP matches pin: $pinned ($($manifest.resolvedTag))" -ForegroundColor Green
+    return $true
 }
-Assert-LspPin $LspSourceDir
+$LspPinOK = Test-LspPin $LspSourceDir
 # Pure v1.0.0 runtime deps only — NO better-sqlite3/bindings/file-uri-to-path (those backed the retired
 # CodeGraph overlay). With better-sqlite3 absent the #42 ABI check below self-skips ("module not deployed").
 # iconv-lite (+ its dep safer-buffer) is NEW at v1.0.0: UnicodeDiagnostics requires it in the EAGER
@@ -523,7 +532,7 @@ foreach ($ver in $TargetVersions) {
         # --- Deploy LSP Server ---
         $LspDestDir = Join-Path $DeployDir "lsp-server"
 
-        if (Test-Path $LspSourceDir) {
+        if ($LspPinOK -and (Test-Path $LspSourceDir)) {
             # Copy compiled server JS + common shared code
             foreach ($outDir in @("out\server", "out\common")) {
                 $LspOutSrc = "$LspSourceDir\$outDir"
@@ -611,6 +620,11 @@ foreach ($ver in $TargetVersions) {
             } elseif (Test-Path $DeployedNode) {
                 Write-Host "  SKIP  better-sqlite3 ABI check (module not deployed)" -ForegroundColor DarkGray
             }
+        } elseif (-not $LspPinOK) {
+            # Deliberate: shipping a server that does not match the pin is worse than shipping none,
+            # because lsp-snapshot.json would go on asserting a commit the consumer did not receive.
+            # The version keeps whatever lsp-server it already had; the final summary exits non-zero.
+            Write-Host "  SKIP  lsp-server (does not match the pin — see FAIL above)" -ForegroundColor Yellow
         } else {
             Write-Host "  SKIP  lsp-server (ClarionLSP not found)" -ForegroundColor DarkGray
         }
@@ -626,13 +640,19 @@ foreach ($ver in $TargetVersions) {
 
 # --- Final summary ---
 Write-Host ""
-if ($FailedBuilds.Count -gt 0) {
+if ($FailedBuilds.Count -gt 0 -or -not $LspPinOK) {
     # Never let a partial run exit 0 with a bare "All done." — that is what made a stale deployed DLL
-    # look like a successful deploy. Name the versions that did NOT ship, and fail the exit code so a
-    # caller (CI, the installer, another script) can't read this run as clean.
+    # look like a successful deploy. Name what did NOT ship, and fail the exit code so a caller (CI,
+    # the installer, another script) can't read this run as clean.
     Write-Host "Done, WITH FAILURES." -ForegroundColor Yellow
-    Write-Host "  NOT deployed (build failed): $($FailedBuilds -join ', ')" -ForegroundColor Red
-    Write-Host "  Every other requested version deployed normally." -ForegroundColor Yellow
+    if ($FailedBuilds.Count -gt 0) {
+        Write-Host "  NOT deployed (build failed): $($FailedBuilds -join ', ')" -ForegroundColor Red
+    }
+    if (-not $LspPinOK) {
+        Write-Host "  NOT deployed (pin mismatch): lsp-server — every version kept the LSP it already had." -ForegroundColor Red
+        Write-Host "  Re-run lsp-server-sync\Sync-LspServer.ps1 -Pure, or bump the pin, then re-run this script." -ForegroundColor Red
+    }
+    Write-Host "  Everything else deployed normally." -ForegroundColor Yellow
     exit 1
 }
 Write-Host "All done." -ForegroundColor Green

--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -242,6 +242,41 @@ $LspSourceDir = Resolve-LspBuild
 # server.js was copied (CLARIONLSP_ROOT override, hand-edited tree, an out/ built from another tag),
 # and the manifest is the ONLY thing a consumer can inspect to know what they got. Assert before any
 # copy so "what shipped" and "what is pinned" cannot silently diverge.
+
+# Run git and return its stdout, or $null if it failed for ANY reason. Do NOT replace this with a
+# bare `git ... 2>$null`.
+#
+# Under Windows PowerShell 5.1, redirecting a NATIVE command's stderr wraps the output in a
+# NativeCommandError record, and $ErrorActionPreference='Stop' (set at the top of this file) makes
+# that record TERMINATING. So `$x = (git ... 2>$null); if (-not $x) { warn; return }` never reaches
+# the soft-fail branch -- the script dies on the git line. Reproduced on 5.1.19041.6456 and on
+# 5.1.26100.8972; the identical code under pwsh 7 returns empty and continues, which is why the bug
+# looks like it isn't there when tested from a pwsh prompt.
+#
+# That is the exact failure this file's LSP handling is supposed to avoid: a contributor whose pure
+# build fails, or whose CLARIONLSP_ROOT is a plain unpacked server tree with no .git, would see the
+# WARN and then have the whole deploy abort anyway -- before a single Clarion version builds.
+#
+# Relaxing $ErrorActionPreference locally makes the NativeCommandError non-terminating; 2>&1 keeps
+# git's stderr off the console; the ErrorRecord filter keeps it out of the return value; the
+# try/catch covers git being absent from PATH entirely (CommandNotFoundException terminates
+# regardless of the preference).
+function Invoke-GitQuiet([string[]]$GitArgs) {
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $out = & git @GitArgs 2>&1
+        if ($LASTEXITCODE -ne 0) { return $null }
+        $clean = $out | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }
+        if (-not $clean) { return $null }
+        return (($clean -join "`n").Trim())
+    } catch {
+        return $null
+    } finally {
+        $ErrorActionPreference = $prevEap
+    }
+}
+
 function Assert-LspPin($sourceDir) {
     $manifest = Get-Content (Join-Path $ProjectDir "lsp-server-sync\lsp-snapshot.json") -Raw | ConvertFrom-Json
     $pinned   = $manifest.resolvedCommit
@@ -249,7 +284,7 @@ function Assert-LspPin($sourceDir) {
         Write-Host "  WARN  manifest has no resolvedCommit — cannot verify the bundled LSP." -ForegroundColor Yellow
         return
     }
-    $head = (git -C $sourceDir rev-parse --short HEAD 2>$null)
+    $head = Invoke-GitQuiet @('-C', $sourceDir, 'rev-parse', '--short', 'HEAD')
     if (-not $head) {
         Write-Host "  WARN  $sourceDir is not a git tree — cannot verify it matches pin $pinned." -ForegroundColor Yellow
         return

--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -194,7 +194,14 @@ $Items = @(
 # tag checkout produced by lsp-server-sync\Sync-LspServer.ps1 -Pure, cached under .lsp-build\<tag>.
 # $env:CLARIONLSP_ROOT still overrides (dev escape hatch) if you deliberately want a custom server tree.
 function Resolve-LspBuild {
-    if ($env:CLARIONLSP_ROOT) { return $env:CLARIONLSP_ROOT }   # explicit override wins
+    if ($env:CLARIONLSP_ROOT) {
+        # Loud, because this is the one path that bypasses the tag-in-path pin check below: whatever
+        # is in that tree ships, while lsp-snapshot.json goes on asserting resolvedCommit. A consumer
+        # then has no way to tell which server they actually received.
+        Write-Host "  WARN  CLARIONLSP_ROOT is set — shipping an UNPINNED LSP from $env:CLARIONLSP_ROOT" -ForegroundColor Yellow
+        Write-Host "  WARN  lsp-snapshot.json will NOT describe what ships. Do not use this for a release build." -ForegroundColor Yellow
+        return $env:CLARIONLSP_ROOT
+    }
     $syncScript = Join-Path $ProjectDir "lsp-server-sync\Sync-LspServer.ps1"
     $manifest   = Get-Content (Join-Path $ProjectDir "lsp-server-sync\lsp-snapshot.json") -Raw | ConvertFrom-Json
     $tag        = if ($manifest.resolvedTag) { $manifest.resolvedTag } else { $manifest.targetPin.tag }
@@ -229,6 +236,38 @@ function Resolve-LspBuild {
     return $pureDir
 }
 $LspSourceDir = Resolve-LspBuild
+
+# --- Verify the LSP about to ship IS the pinned one --------------------------------------------
+# Previously nothing checked this. lsp-snapshot.json could assert resolvedCommit while a different
+# server.js was copied (CLARIONLSP_ROOT override, hand-edited tree, an out/ built from another tag),
+# and the manifest is the ONLY thing a consumer can inspect to know what they got. Assert before any
+# copy so "what shipped" and "what is pinned" cannot silently diverge.
+function Assert-LspPin($sourceDir) {
+    $manifest = Get-Content (Join-Path $ProjectDir "lsp-server-sync\lsp-snapshot.json") -Raw | ConvertFrom-Json
+    $pinned   = $manifest.resolvedCommit
+    if (-not $pinned) {
+        Write-Host "  WARN  manifest has no resolvedCommit — cannot verify the bundled LSP." -ForegroundColor Yellow
+        return
+    }
+    $head = (git -C $sourceDir rev-parse --short HEAD 2>$null)
+    if (-not $head) {
+        Write-Host "  WARN  $sourceDir is not a git tree — cannot verify it matches pin $pinned." -ForegroundColor Yellow
+        return
+    }
+    # Prefix compare: `git rev-parse --short` auto-scales its length, so 7- and 8-char forms of the
+    # same commit must still count as a match.
+    if (-not ($head.StartsWith($pinned) -or $pinned.StartsWith($head))) {
+        if ($env:CLARIONLSP_ROOT) {
+            Write-Host "  WARN  bundled LSP is $head but the pin says $pinned (CLARIONLSP_ROOT override in effect)." -ForegroundColor Yellow
+            return
+        }
+        Write-Host "  FAIL  bundled LSP is $head but lsp-snapshot.json pins $pinned." -ForegroundColor Red
+        Write-Host "        Re-run lsp-server-sync\Sync-LspServer.ps1 -Pure, or bump the pin deliberately." -ForegroundColor Red
+        exit 7
+    }
+    Write-Host "  OK    bundled LSP matches pin: $pinned ($($manifest.resolvedTag))" -ForegroundColor Green
+}
+Assert-LspPin $LspSourceDir
 # Pure v1.0.0 runtime deps only — NO better-sqlite3/bindings/file-uri-to-path (those backed the retired
 # CodeGraph overlay). With better-sqlite3 absent the #42 ABI check below self-skips ("module not deployed").
 # iconv-lite (+ its dep safer-buffer) is NEW at v1.0.0: UnicodeDiagnostics requires it in the EAGER

--- a/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
+++ b/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
@@ -26,6 +26,8 @@
 .PARAMETER LspRoot
     The upstream clone (a git checkout of msarson/Clarion-Extension with our overlay).
     Defaults to $env:CLARIONLSP_ROOT, else H:\DevLaptop\ClarionLSP (legacy dev path).
+    ONLY used by the legacy overlay path (-Apply). -Pure ignores it entirely and clones
+    source.repo itself, so a contributor with no such clone can still build the pinned server.
 
 .PARAMETER Tag
     Target release tag to pin to. Defaults to targetPin.tag from lsp-snapshot.json.
@@ -43,6 +45,7 @@
     under $PureRoot (default <repo>\.lsp-build\<Tag>) which deploy.ps1 sources instead of the overlay clone.
     Independent of -Apply (which is the legacy overlay-keeping path). Idempotent: skips the rebuild if a
     pure build is already present. VERIFIES the built server.js contains ZERO codegraph refs.
+    Requires NOTHING but git + npm + network: the tree is cloned from source.repo at $Tag.
 
 .PARAMETER PureRoot
     Where the pure build lives / is created. Defaults to <repo>\.lsp-build\<Tag>.
@@ -83,6 +86,20 @@ function Fail($m) { Line 'FAIL' $m 'Red' }
 # resolvedTag/resolvedCommit/lastSync, leaving targetPin/currentPin frozen at whatever hand-written
 # audit they last held -- after the v1.0.0 re-pin the manifest still reported targetPin v0.9.8 and a
 # June currentPin, so a first read said "behind" when the bundle was current. One writer, all fields.
+# Read/write the manifest without mangling it. Windows PowerShell 5.1 defaults `Get-Content` to the
+# system ANSI codepage and `Set-Content -Encoding UTF8` to UTF8-WITH-BOM, so a read/write round-trip
+# on this UTF-8 file turned the em dash in $comment into mojibake and prepended a BOM. PS 7 defaults
+# to UTF-8 and hides the problem, which is why it survived. ConvertTo-Json in 5.1 also escapes
+# & < > ' as \uXXXX with no -EscapeHandling to turn it off, so unescape those four back.
+function Read-Manifest($path) {
+    Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+function Save-Manifest($manifest, $path) {
+    $json = ($manifest | ConvertTo-Json -Depth 12) `
+        -replace '\\u0026', '&' -replace '\\u003c', '<' -replace '\\u003e', '>' -replace '\\u0027', "'"
+    [System.IO.File]::WriteAllText($path, $json, (New-Object System.Text.UTF8Encoding($false)))
+}
+
 function Update-PinFields($manifest, $Tag, $repoRoot) {
     $commit     = (git -C $repoRoot rev-parse --short HEAD)
     $commitDate = (git -C $repoRoot show -s --format=%cs HEAD)
@@ -100,19 +117,124 @@ function Update-PinFields($manifest, $Tag, $repoRoot) {
 
 # --- Resolve inputs -------------------------------------------------------------------
 if (-not (Test-Path $ManifestPath)) { throw "Manifest not found: $ManifestPath" }
-$manifest = Get-Content $ManifestPath -Raw | ConvertFrom-Json
+$manifest = Read-Manifest $ManifestPath
 
-if (-not $LspRoot) { $LspRoot = if ($env:CLARIONLSP_ROOT) { $env:CLARIONLSP_ROOT } else { 'H:\DevLaptop\ClarionLSP' } }
-if (-not $Tag)     { $Tag = $manifest.targetPin.tag }
+if (-not $Tag) { $Tag = $manifest.targetPin.tag }
 
 Write-Host ""
 Write-Host "Clarion LSP server sync (GitHub #40)" -ForegroundColor White
-Write-Host "  LspRoot : $LspRoot"
 Write-Host "  Tag     : $Tag"
-Write-Host "  Mode    : $(if ($Apply) { 'APPLY' } else { 'dry run (read-only)' })"
+Write-Host "  Mode    : $(if ($Pure) { 'PURE build' } elseif ($Apply) { 'APPLY' } else { 'dry run (read-only)' })"
 Write-Host ""
 
-if (-not (Test-Path (Join-Path $LspRoot '.git'))) { Fail "Not a git clone: $LspRoot"; exit 2 }
+# --- PURE mode (#40) ---------------------------------------------------------------------
+# Build STOCK upstream at $Tag with NO CodeGraph overlay, into $PureRoot. The overlay is retired;
+# CodeGraph is C#-side now.
+#
+# SELF-CONTAINED BY CONSTRUCTION: this path clones $manifest.source.repo directly, so it needs no
+# pre-existing clone and never touches $LspRoot. It previously ran `git worktree add` against
+# $LspRoot, which made -Pure unusable on any machine without the maintainer's clone -- a pin bump
+# then aborted deploy.ps1 outright instead of rebuilding the pinned server. Runs BEFORE the
+# $LspRoot resolution below for exactly that reason.
+if ($Pure) {
+    if (-not $PureRoot) {
+        $RepoRoot = Split-Path -Parent $ScriptDir      # ...\ClarionAssistant
+        $PureRoot = Join-Path $RepoRoot (".lsp-build\" + $Tag)
+    }
+    $builtServer = Join-Path $PureRoot $manifest.source.buildOutput   # out/server/src/server.js
+    $repoUrl     = $manifest.source.repo
+    Info "PURE build target: $PureRoot (tag $Tag, NO overlay)"
+
+    # Ensure a clean tag checkout at $PureRoot, cloned from source.repo.
+    if ((Test-Path (Join-Path $PureRoot 'package.json')) -and -not (Test-Path (Join-Path $PureRoot '.git'))) {
+        Info "Using existing (non-git) pure tree as-is"
+    } else {
+        if (Test-Path (Join-Path $PureRoot '.git')) {
+            Info "Refreshing existing checkout -> $Tag"
+        } else {
+            Info "Cloning $repoUrl -> $PureRoot ..."
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PureRoot) | Out-Null
+            git clone --quiet $repoUrl $PureRoot
+            if ($LASTEXITCODE) { Fail "clone failed ($LASTEXITCODE): $repoUrl"; exit 2 }
+        }
+
+        # Assert this is the expected upstream repo before we build anything out of it.
+        $pureOrigin = (git -C $PureRoot remote get-url origin 2>$null)
+        if ($pureOrigin -notmatch 'Clarion-Extension') {
+            Fail "origin of $PureRoot is '$pureOrigin' — expected msarson/Clarion-Extension. Aborting."
+            exit 2
+        }
+        OK "origin: $pureOrigin"
+
+        git -C $PureRoot fetch --tags --prune --quiet origin
+        if (-not (git -C $PureRoot tag --list $Tag)) {
+            Fail "Tag '$Tag' does not exist in $repoUrl. Available recent tags:"
+            git -C $PureRoot tag --sort=-creatordate | Select-Object -First 8 | ForEach-Object { Write-Host "         $_" }
+            exit 2
+        }
+        git -C $PureRoot checkout --quiet --force $Tag
+        if ($LASTEXITCODE) { Fail "checkout of '$Tag' failed in $PureRoot"; exit 2 }
+        OK "checked out $Tag"
+    }
+
+    # Assert PURE source: the overlay .ts must NOT be present in this tree.
+    foreach ($f in $manifest.codeGraphOverlay.overlayFiles) {
+        if (Test-Path (Join-Path $PureRoot $f)) {
+            Fail "PURE tree contains overlay file '$f' — not pure. Use a clean checkout."; exit 6
+        }
+    }
+    OK "no CodeGraph overlay in source (pure)"
+
+    # Build (idempotent: skip if a pure build is already present)
+    if ($SkipBuild) {
+        Warn "Skipping build (-SkipBuild)."
+    } elseif ((Test-Path $builtServer) -and ((Get-Content $builtServer -Raw) -notmatch 'codegraph|CodeGraph')) {
+        OK "pure build already present (skipping rebuild; delete out/ to force)"
+    } else {
+        Info "Building (npm ci && npm run compile) — can take a minute..."
+        Push-Location $PureRoot
+        try {
+            npm ci;          if ($LASTEXITCODE) { throw "npm ci failed ($LASTEXITCODE)" }
+            npm run compile; if ($LASTEXITCODE) { throw "npm run compile failed ($LASTEXITCODE)" }
+        } finally { Pop-Location }
+        OK "build complete"
+    }
+
+    # Verify PURE: built server.js must contain ZERO codegraph refs.
+    if (Test-Path $builtServer) {
+        if ((Get-Content $builtServer -Raw) -match 'codegraph|CodeGraph') {
+            Fail "Built server.js STILL contains CodeGraph refs — not pure. Aborting."; exit 6
+        }
+        OK "verified PURE: no CodeGraph refs in built server.js"
+    } elseif (-not $SkipBuild) {
+        Fail "Expected build output not found: $builtServer"; exit 6
+    }
+
+    # Record the pure pin (targetPin/currentPin included -- see Update-PinFields)
+    $resolved = (git -C $PureRoot rev-parse --short HEAD 2>$null)
+    Update-PinFields $manifest $Tag $PureRoot
+    $manifest | Add-Member -NotePropertyName 'pure'           -NotePropertyValue $true   -Force
+    $manifest | Add-Member -NotePropertyName 'resolvedCommit' -NotePropertyValue $resolved -Force
+    $manifest | Add-Member -NotePropertyName 'resolvedTag'    -NotePropertyValue $Tag      -Force
+    $manifest | Add-Member -NotePropertyName 'lastSync'       -NotePropertyValue (Get-Date -Format 'yyyy-MM-dd') -Force
+    Save-Manifest $manifest $ManifestPath
+    OK "manifest updated: pure=true tag=$Tag resolvedCommit=$resolved"
+    Write-Host ""
+    OK "PURE sync complete. deploy.ps1 sources the pure build from $PureRoot."
+    exit 0
+}
+
+# --- Legacy overlay path (-Apply) ---------------------------------------------------------
+# Only this path needs a pre-existing clone with our untracked overlay .ts files in it.
+if (-not $LspRoot) { $LspRoot = if ($env:CLARIONLSP_ROOT) { $env:CLARIONLSP_ROOT } else { 'H:\DevLaptop\ClarionLSP' } }
+Write-Host "  LspRoot : $LspRoot"
+Write-Host ""
+
+# NOTE: string-concatenate the path rather than Join-Path. Join-Path VALIDATES the drive qualifier
+# and THROWS "Cannot find drive" on a non-existent drive, which under deploy.ps1's
+# $ErrorActionPreference='Stop' killed the whole deploy instead of failing soft the way
+# deploy.ps1's "LSP copy will be skipped" warning intends. Test-Path alone returns $false.
+if (-not (Test-Path -LiteralPath "$LspRoot\.git")) { Fail "Not a git clone: $LspRoot"; exit 2 }
 
 Push-Location $LspRoot
 try {
@@ -136,79 +258,6 @@ try {
         exit 2
     }
     OK "target tag exists: $Tag ($(git show -s --format='%ci' $Tag 2>$null | Select-Object -First 1))"
-
-    # --- PURE mode (#40) -------------------------------------------------------------
-    # Build STOCK upstream at $Tag with NO CodeGraph overlay, into $PureRoot. The overlay is retired;
-    # CodeGraph is C#-side now. Self-contained: creates/refreshes a clean tag checkout (untracked overlay
-    # .ts files in $LspRoot do NOT propagate into a fresh worktree), builds, verifies purity, records pin.
-    if ($Pure) {
-        if (-not $PureRoot) {
-            $RepoRoot = Split-Path -Parent $ScriptDir      # ...\ClarionAssistant
-            $PureRoot = Join-Path $RepoRoot (".lsp-build\" + $Tag)
-        }
-        $builtServer = Join-Path $PureRoot $manifest.source.buildOutput   # out/server/src/server.js
-        Write-Host ""
-        Info "PURE build target: $PureRoot (tag $Tag, NO overlay)"
-
-        # Ensure a clean tag checkout at $PureRoot
-        if (Test-Path (Join-Path $PureRoot '.git')) {
-            Info "Refreshing existing checkout -> $Tag"
-            git -C $PureRoot fetch --tags --quiet origin 2>$null
-            git -C $PureRoot checkout --quiet --force $Tag
-        } elseif (Test-Path (Join-Path $PureRoot 'package.json')) {
-            Info "Using existing (non-git) pure tree as-is"
-        } else {
-            Info "Creating clean worktree at $PureRoot ..."
-            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $PureRoot) | Out-Null
-            git worktree add --force $PureRoot $Tag
-        }
-
-        # Assert PURE source: the overlay .ts must NOT be present in this tree.
-        foreach ($f in $manifest.codeGraphOverlay.overlayFiles) {
-            if (Test-Path (Join-Path $PureRoot $f)) {
-                Fail "PURE tree contains overlay file '$f' — not pure. Use a clean checkout."; exit 6
-            }
-        }
-        OK "no CodeGraph overlay in source (pure)"
-
-        # Build (idempotent: skip if a pure build is already present)
-        if ($SkipBuild) {
-            Warn "Skipping build (-SkipBuild)."
-        } elseif ((Test-Path $builtServer) -and ((Get-Content $builtServer -Raw) -notmatch 'codegraph|CodeGraph')) {
-            OK "pure build already present (skipping rebuild; delete out/ to force)"
-        } else {
-            Info "Building (npm ci && npm run compile) — can take a minute..."
-            Push-Location $PureRoot
-            try {
-                npm ci;          if ($LASTEXITCODE) { throw "npm ci failed ($LASTEXITCODE)" }
-                npm run compile; if ($LASTEXITCODE) { throw "npm run compile failed ($LASTEXITCODE)" }
-            } finally { Pop-Location }
-            OK "build complete"
-        }
-
-        # Verify PURE: built server.js must contain ZERO codegraph refs.
-        if (Test-Path $builtServer) {
-            if ((Get-Content $builtServer -Raw) -match 'codegraph|CodeGraph') {
-                Fail "Built server.js STILL contains CodeGraph refs — not pure. Aborting."; exit 6
-            }
-            OK "verified PURE: no CodeGraph refs in built server.js"
-        } elseif (-not $SkipBuild) {
-            Fail "Expected build output not found: $builtServer"; exit 6
-        }
-
-        # Record the pure pin (targetPin/currentPin included -- see Update-PinFields)
-        $resolved = (git -C $PureRoot rev-parse --short HEAD 2>$null)
-        Update-PinFields $manifest $Tag $PureRoot
-        $manifest | Add-Member -NotePropertyName 'pure'           -NotePropertyValue $true   -Force
-        $manifest | Add-Member -NotePropertyName 'resolvedCommit' -NotePropertyValue $resolved -Force
-        $manifest | Add-Member -NotePropertyName 'resolvedTag'    -NotePropertyValue $Tag      -Force
-        $manifest | Add-Member -NotePropertyName 'lastSync'       -NotePropertyValue (Get-Date -Format 'yyyy-MM-dd') -Force
-        ($manifest | ConvertTo-Json -Depth 12) | Set-Content -Path $ManifestPath -Encoding UTF8
-        OK "manifest updated: pure=true tag=$Tag resolvedCommit=$resolved"
-        Write-Host ""
-        OK "PURE sync complete. deploy.ps1 sources the pure build from $PureRoot."
-        exit 0
-    }
 
     # 2. Drift report — current HEAD vs target tag
     $head       = (git rev-parse --short HEAD)
@@ -305,7 +354,7 @@ try {
     $manifest.resolvedCommit = $resolved
     $manifest | Add-Member -NotePropertyName 'resolvedTag' -NotePropertyValue $Tag -Force
     $manifest.lastSync = (Get-Date -Format 'yyyy-MM-dd')
-    ($manifest | ConvertTo-Json -Depth 12) | Set-Content -Path $ManifestPath -Encoding UTF8
+    Save-Manifest $manifest $ManifestPath
     OK "manifest updated: resolvedCommit=$resolved lastSync=$($manifest.lastSync)"
 
     Write-Host ""

--- a/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
+++ b/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
@@ -124,9 +124,40 @@ function Invoke-GitQuiet([string[]]$GitArgs) {
 function Read-Manifest($path) {
     Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json
 }
+# The unescape has to be backslash-aware. A blanket `-replace '\\u0026', '&'` over the SERIALIZED
+# TEXT cannot tell an escape ConvertTo-Json just emitted from characters that belong to a value.
+# Put a backslash followed by the characters u0026 into a note as ordinary prose, and
+# ConvertTo-Json escapes that backslash, so the JSON text holds TWO backslashes then u0026. The
+# blanket replace matches on the second backslash and collapses it plus the u0026 into a single
+# ampersand, leaving backslash-ampersand -- not a valid JSON escape. The manifest then no longer
+# parses, and every later run dies in Read-Manifest instead. Nothing in the file trips it today,
+# but targetPin.note and $comment are free-form prose maintained by hand, and the failure would
+# land on whoever runs the sync NEXT rather than on whoever wrote the prose.
+#
+# Parity decides it: count the backslashes immediately before uXXXX. Odd means the last one is a
+# real escape introducer, so drop it and substitute the character. Even means they all pair up into
+# literal backslashes and uXXXX is ordinary text, so leave the match alone.
+$Script:JsonUnescapeMap = @{ '0026' = '&'; '003c' = '<'; '003e' = '>'; '0027' = "'" }
+function Restore-JsonLiterals([string]$json) {
+    $evaluator = {
+        param($m)
+        $slashes = $m.Groups[1].Value
+        if ($slashes.Length % 2 -eq 0) { return $m.Value }
+        return $slashes.Substring(0, $slashes.Length - 1) + $Script:JsonUnescapeMap[$m.Groups[2].Value.ToLower()]
+    }
+    return [regex]::Replace($json, '(\\+)u(0026|003c|003e|0027)', $evaluator,
+                            [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+}
 function Save-Manifest($manifest, $path) {
-    $json = ($manifest | ConvertTo-Json -Depth 12) `
-        -replace '\\u0026', '&' -replace '\\u003c', '<' -replace '\\u003e', '>' -replace '\\u0027', "'"
+    $json = Restore-JsonLiterals ($manifest | ConvertTo-Json -Depth 12)
+    # Fail CLOSED. If the text we are about to write is not valid JSON, the on-disk manifest is
+    # still good; overwriting it with something unparseable would take the whole sync down on the
+    # next run, with a stack trace pointing at Read-Manifest rather than at whatever produced it.
+    try {
+        $json | ConvertFrom-Json | Out-Null
+    } catch {
+        throw "Refusing to write $path -- the serialized manifest is not valid JSON: $($_.Exception.Message)"
+    }
     [System.IO.File]::WriteAllText($path, $json, (New-Object System.Text.UTF8Encoding($false)))
 }
 

--- a/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
+++ b/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
@@ -196,7 +196,19 @@ if ($Pure) {
         }
         OK "origin: $pureOrigin"
 
+        # Check the fetch. Leaving its exit status unread -- alone among the git calls in this block
+        # -- opens a hole nothing downstream can close: offline, the fetch fails, `git tag --list`
+        # still finds the STALE cached tag, the checkout "succeeds", the rebuild is skipped because
+        # out/ is already present, and that stale commit is written into the manifest as
+        # authoritative -- all while the run prints "OK PURE sync complete" and deploy.ps1's pin
+        # check agrees with it. A tag that cannot be confirmed against origin is not a pin.
         git -C $PureRoot fetch --tags --prune --quiet origin
+        if ($LASTEXITCODE) {
+            Fail "fetch from origin failed ($LASTEXITCODE) in $PureRoot — cannot confirm '$Tag' against upstream."
+            Write-Host "         A locally cached tag may be stale, so pinning the manifest to it would be a lie." -ForegroundColor Red
+            Write-Host "         Re-run with a working network connection." -ForegroundColor Red
+            exit 2
+        }
         if (-not (git -C $PureRoot tag --list $Tag)) {
             Fail "Tag '$Tag' does not exist in $repoUrl. Available recent tags:"
             git -C $PureRoot tag --sort=-creatordate | Select-Object -First 8 | ForEach-Object { Write-Host "         $_" }

--- a/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
+++ b/ClarionAssistant/lsp-server-sync/Sync-LspServer.ps1
@@ -82,6 +82,36 @@ function Info($m) { Line 'INFO' $m 'Cyan' }
 function Warn($m) { Line 'WARN' $m 'Yellow' }
 function Fail($m) { Line 'FAIL' $m 'Red' }
 
+# Run git and return its stdout, or $null if it failed for ANY reason. Do NOT replace this with a
+# bare `git ... 2>$null`.
+#
+# Under Windows PowerShell 5.1, redirecting a NATIVE command's stderr wraps the output in a
+# NativeCommandError record, and the $ErrorActionPreference='Stop' set above makes that record
+# TERMINATING -- so the `Fail ...; exit 2` the caller wrote never runs; the script throws on the git
+# line instead. Because deploy.ps1 invokes this script with & under ITS own Stop, that throw
+# propagates and kills the whole deploy. Concrete trigger: a .lsp-build\<tag> left over from the old
+# `git worktree add` implementation, whose .git file points into a parent clone that has since moved.
+#
+# Relaxing $ErrorActionPreference locally makes the NativeCommandError non-terminating; 2>&1 keeps
+# git's stderr off the console; the ErrorRecord filter keeps it out of the return value; the
+# try/catch covers git being absent from PATH entirely (CommandNotFoundException terminates
+# regardless of the preference).
+function Invoke-GitQuiet([string[]]$GitArgs) {
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $out = & git @GitArgs 2>&1
+        if ($LASTEXITCODE -ne 0) { return $null }
+        $clean = $out | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }
+        if (-not $clean) { return $null }
+        return (($clean -join "`n").Trim())
+    } catch {
+        return $null
+    } finally {
+        $ErrorActionPreference = $prevEap
+    }
+}
+
 # Keep ALL pin fields honest on a successful sync (#77 housekeeping): the sync used to update only
 # resolvedTag/resolvedCommit/lastSync, leaving targetPin/currentPin frozen at whatever hand-written
 # audit they last held -- after the v1.0.0 re-pin the manifest still reported targetPin v0.9.8 and a
@@ -159,7 +189,7 @@ if ($Pure) {
         }
 
         # Assert this is the expected upstream repo before we build anything out of it.
-        $pureOrigin = (git -C $PureRoot remote get-url origin 2>$null)
+        $pureOrigin = Invoke-GitQuiet @('-C', $PureRoot, 'remote', 'get-url', 'origin')
         if ($pureOrigin -notmatch 'Clarion-Extension') {
             Fail "origin of $PureRoot is '$pureOrigin' — expected msarson/Clarion-Extension. Aborting."
             exit 2
@@ -211,7 +241,13 @@ if ($Pure) {
     }
 
     # Record the pure pin (targetPin/currentPin included -- see Update-PinFields)
-    $resolved = (git -C $PureRoot rev-parse --short HEAD 2>$null)
+    $resolved = Invoke-GitQuiet @('-C', $PureRoot, 'rev-parse', '--short', 'HEAD')
+    if (-not $resolved) {
+        # Supported case: the "Using existing (non-git) pure tree as-is" branch above. Say so out
+        # loud rather than writing a silent null -- deploy.ps1's pin assert then reports "manifest
+        # has no resolvedCommit" instead of implying the shipped server was verified against a pin.
+        Warn "cannot resolve HEAD of $PureRoot (not a git tree) — resolvedCommit will be empty."
+    }
     Update-PinFields $manifest $Tag $PureRoot
     $manifest | Add-Member -NotePropertyName 'pure'           -NotePropertyValue $true   -Force
     $manifest | Add-Member -NotePropertyName 'resolvedCommit' -NotePropertyValue $resolved -Force


### PR DESCRIPTION
# fix(lsp): make `-Pure` self-contained and verify the shipped LSP matches the pin

## Why

The bundled-LSP pin is the only thing a consumer can inspect to know which language server they
received. Three defects let "what shipped" drift from "what `lsp-snapshot.json` says shipped" —
and one of them makes a pin bump abort the whole deploy on any machine that is not the
maintainer's.

I hit the consumer-facing end of this in early July: I synced ClarionAssistant, deployed, and
LSP-backed features did not behave as demonstrated. At that point the pin was `v0.9.8`. The
subsequent re-pin commit `ed8bde5` (`fix(lsp): re-pin bundled LSP to Clarion-Extension v1.0.0
(#77)`) describes exactly what I was seeing:

> pulls in upstream's redirection-section fix (per-config sections were silently dropped
> — CA sends configuration=Release, so redirection-heavy solutions resolved ~1% of source
> files), the startup/freeze overhaul, persisted indexes, and regeneration-burst coalescing.

On a redirection-heavy solution the server resolved about **1% of source files** while appearing
installed and healthy. Nothing available to me distinguished "I am using it wrong" from "the
bundled LSP predates the fix". The same commit notes the mirror-image problem on the producing
side — *"dev-machine tests were masked by a stray C:\Users\<user>\node_modules"*. Both directions
have one root cause: the LSP that ships is never verified against the LSP that is pinned.

## What changed

### 1. `-Pure` no longer needs the maintainer's clone

`$LspRoot` defaulted to `H:\DevLaptop\ClarionLSP` and was validated at the top of the script,
*before* the `-Pure` block could run. The pure tree was then created with
`git worktree add --force $PureRoot $Tag` — a worktree **of that clone**. So `-Pure` was
unreachable on any other machine, despite its own comment describing it as "Self-contained".

The knock-on effect is the serious one. `Resolve-LspBuild` calls `-Pure` whenever
`.lsp-build\<tag>\out\server\src\server.js` is missing, which is exactly what a pin bump causes.
On a contributor machine that call dies, and because `deploy.ps1` sets
`$ErrorActionPreference = "Stop"`, the whole deploy dies with it — before a single Clarion version
builds. That defeats the soft-skip the caller clearly intends:

```powershell
deploy.ps1:205  if ($LASTEXITCODE -ne 0) { "WARN pure LSP build failed ... LSP copy will be skipped." }
```

The outcome was not "deploy without an LSP". It was no deploy at all.

`-Pure` now runs **before** any `$LspRoot` resolution and clones `$manifest.source.repo` at the
tag itself — the URL was already in the manifest. It needs only git, npm and network. `$LspRoot`
is now used solely by the legacy overlay path (`-Apply`), and its doc comment says so.

### 2. A missing drive now fails soft instead of throwing

`Join-Path` validates the drive qualifier and *throws* rather than returning false:

```
PS> $ErrorActionPreference='Stop'; Join-Path 'H:\DevLaptop\ClarionLSP' '.git'
Cannot find drive. A drive with the name 'H' does not exist.
```

`Test-Path` alone returns `$false`, so the check is now
`Test-Path -LiteralPath "$LspRoot\.git"`.

### 3. `deploy.ps1` verifies the LSP against the pin before copying

New `Assert-LspPin` compares the source tree's `HEAD` to `resolvedCommit` and exits 7 on mismatch,
so a tree reached via `$env:CLARIONLSP_ROOT` — or any `out/` built from a different tag — cannot
silently ship under a pin that describes something else. Prefix comparison, since
`git rev-parse --short` auto-scales its length.

`CLARIONLSP_ROOT` remains available as the dev escape hatch, but now announces itself:

```
WARN  CLARIONLSP_ROOT is set — shipping an UNPINNED LSP from <path>
WARN  lsp-snapshot.json will NOT describe what ships. Do not use this for a release build.
```

and downgrades the mismatch to a warning when it is in effect, on the basis that it is a
deliberate override.

### 4. (Fallout) The manifest round-trip corrupted the file on PowerShell 5.1

Not a pre-existing symptom for anyone, because nobody outside the maintainer's machine could run
`-Pure` — fixing (1) makes it reachable for every 5.1 contributor, so it is fixed here rather
than left as a new regression path.

`Get-Content -Raw` defaults to the system ANSI codepage in Windows PowerShell 5.1 and
`Set-Content -Encoding UTF8` writes UTF-8 **with** BOM. A read/write round-trip therefore turned
the em dash in `$comment` into `â€”` and prepended a BOM; `ConvertTo-Json` additionally escaped
`&`, `<`, `>`, `'` as `\uXXXX` (5.1 has no `-EscapeHandling`). PS 7 defaults to UTF-8, which is
why this went unnoticed.

`Read-Manifest` / `Save-Manifest` now round-trip losslessly. **Known limitation:** indentation
still reflows to 5.1's `ConvertTo-Json` alignment style, so a 5.1 contributor's sync produces a
whitespace-only reflow of the file. Content is unaffected. Happy to add a canonical formatter if
you want the churn gone.

## Testing

Run on a machine that has **never** had the `H:` clone — the configuration that surfaces all of
these:

| Test | Result |
|---|---|
| `-Pure` with no `H:` drive, fresh `PureRoot` | Clones `source.repo`, checks out `v1.0.0`, asserts no overlay, builds, resolves `571ffcee` — matches the pin |
| `-Pure` again on the same tree | Refreshes checkout, skips rebuild (idempotent), still `571ffcee` |
| Legacy path (no `-Pure`) with no `H:` drive | `FAIL Not a git clone: H:\DevLaptop\ClarionLSP`, exit 2 — no `Join-Path` throw |
| `deploy.ps1 -Version 12 -NoBuild` | `OK bundled LSP matches pin: 571ffcee (v1.0.0)`, deploy completes, exit 0 |
| Same, with `resolvedCommit` forced to a bogus value | `FAIL bundled LSP is 571ffcee but lsp-snapshot.json pins deadbeef`, exit 7, nothing deployed |
| Manifest round-trip | No BOM, em dash intact, `&&` and `'` literal, valid JSON, values unchanged |
| Both scripts | Parse clean (`[Parser]::ParseFile`) |

Full four-version deploy (C10 / C11.0.13505 / C11.1-13810 / C12) also verified working with these
changes on the current pin.

## Notes

- No behavioural change for anyone who already has the `H:` clone — the legacy `-Apply` path is
  untouched apart from where its `$LspRoot` validation lives.
- `lsp-snapshot.json` is deliberately **not** modified in this PR; only the two scripts change.
- Happy to adjust the exit code, or to make the pin mismatch a warning rather than a hard failure,
  if you would rather not have it block a deploy.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
