### PR TITLE
fix(mcp): make the embeditor round-trips reachable on large procedures

### DIFF
--- a/ClarionAssistant/Services/McpServer.cs
+++ b/ClarionAssistant/Services/McpServer.cs
@@ -28,7 +28,27 @@ namespace ClarionAssistant.Services
         // Max time a UI-thread MCP tool may run before the request is abandoned
         // with a timeout error, so a busy/wedged UI thread can't hold a worker
         // (and leak the connection as CLOSE_WAIT) indefinitely.
-        private const int UiToolTimeoutSeconds = 30;
+        //
+        // 30s is the right budget for the prompt tools (read a line, list
+        // procedures) but it was never a universal one: a single native
+        // embeditor open already waits up to 45s on its own
+        // (ModernEmbeditorLauncher.WaitForEmbedOpen, called straight from the
+        // open_procedure_embed handler), and OpenAndMirror may retry it at a
+        // slower locator speed. Those tools' internal budget therefore EXCEEDS
+        // this window by design, so on a large procedure the outer wait could
+        // never let them finish — the call always came back "UI thread did not
+        // respond within 30s" even though the work was still running correctly.
+        // Such tools now declare their own McpTool.UiTimeoutSeconds; everything
+        // else takes the default, which an install can raise with the
+        // "Mcp.UiToolTimeoutSeconds" setting.
+        private const int DefaultUiToolTimeoutSeconds = 30;
+        private const string UiToolTimeoutSettingKey = "Mcp.UiToolTimeoutSeconds";
+
+        // Clamp whatever is configured: under ~5s even a trivial tool races its
+        // own marshal onto the UI thread, and an unbounded value reintroduces
+        // the wedged-UI hang this timeout exists to prevent.
+        private const int MinUiToolTimeoutSeconds = 5;
+        private const int MaxUiToolTimeoutSeconds = 600;
 
         // Per-session auth token — regenerated on every Start(). Embedded as
         // `Authorization: Bearer <token>` in the MCP config file so the spawned
@@ -944,6 +964,37 @@ namespace ClarionAssistant.Services
         // the client for zero information gain.
         private const int ProgressThrottleMs = 1000;
 
+        /// <summary>
+        /// Timeout budget for ONE UI-thread tool call, in seconds: the larger of the
+        /// per-install "Mcp.UiToolTimeoutSeconds" setting (default 30) and the tool's
+        /// own declared <see cref="McpTool.UiTimeoutSeconds"/>, clamped to
+        /// [<see cref="MinUiToolTimeoutSeconds"/>, <see cref="MaxUiToolTimeoutSeconds"/>]
+        /// so neither a typo nor a zero can disable the guard. Taking the LARGER means
+        /// raising the global setting still lifts the slow tools, while a tool that
+        /// needs more than the default never silently loses it.
+        /// The setting is read from the in-memory settings snapshot, so a hand edit of
+        /// settings.txt takes effect on the next IDE start.
+        /// </summary>
+        private int ResolveUiToolTimeoutSeconds(string toolName)
+        {
+            int seconds = DefaultUiToolTimeoutSeconds;
+
+            if (_settings != null)
+            {
+                int configured;
+                string raw = _settings.Get(UiToolTimeoutSettingKey);
+                if (raw != null && int.TryParse(raw.Trim(), out configured) && configured > 0)
+                    seconds = configured;
+            }
+
+            int declared = _toolRegistry != null ? _toolRegistry.UiTimeoutSeconds(toolName) : 0;
+            if (declared > seconds) seconds = declared;
+
+            if (seconds < MinUiToolTimeoutSeconds) seconds = MinUiToolTimeoutSeconds;
+            if (seconds > MaxUiToolTimeoutSeconds) seconds = MaxUiToolTimeoutSeconds;
+            return seconds;
+        }
+
         private string HandleToolCall(JsonRpcRequest request)
         {
             return HandleToolCall(request, null);
@@ -1023,6 +1074,7 @@ namespace ClarionAssistant.Services
                 {
                     object uiResult = null;
                     Exception uiException = null;
+                    int timeoutSeconds = ResolveUiToolTimeoutSeconds(toolName);
 
                     // Marshal onto the UI thread WITHOUT blocking the worker forever.
                     // A synchronous Control.Invoke here deadlocks (and leaks the
@@ -1039,12 +1091,16 @@ namespace ClarionAssistant.Services
                         // Give the UI thread a bounded window to run the tool. On timeout
                         // we abandon the delegate (it will complete harmlessly later) and
                         // return an error instead of holding the worker + connection open.
-                        if (!done.Wait(TimeSpan.FromSeconds(UiToolTimeoutSeconds)))
+                        if (!done.Wait(TimeSpan.FromSeconds(timeoutSeconds)))
                         {
                             RaiseToolCall(toolName, "TIMEOUT (UI thread busy)");
                             return McpJsonRpc.SerializeResponse(request.Id, McpJsonRpc.BuildToolResult(
                                 "Error executing tool '" + toolName + "': UI thread did not respond within "
-                                + UiToolTimeoutSeconds + "s (busy or blocked).", true));
+                                + timeoutSeconds + "s (busy or blocked). If the IDE was working rather than "
+                                + "wedged, raise '" + UiToolTimeoutSettingKey + "' in "
+                                + @"%APPDATA%\ClarionAssistant\settings.txt (allowed range "
+                                + MinUiToolTimeoutSeconds + "-" + MaxUiToolTimeoutSeconds + "s) and restart the IDE.",
+                                true));
                         }
                     }
 

--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -1073,6 +1073,10 @@ Use this tool to discover IDE APIs and understand what's available for automatio
                     "Embeditor save path). 'edits' is a JSON array of {\"line_number\":N,\"code\":\"...\"}: line_number " +
                     "is the 1-based «E:N» slot start (from get_embeditor_source/search_embeditor_source), code is the " +
                     "COMPLETE replacement for that slot (end with a trailing newline). Edits are applied bottom-to-top. " +
+                    "If an embeditor is ALREADY open on the SAME procedure it is adopted rather than refused — the edits " +
+                    "go into that buffer and the save closes it (the IDE has no save-without-close), so re-open it if you " +
+                    "want to keep working there. An embeditor open on a DIFFERENT procedure is never touched: the call " +
+                    "aborts and asks you to close it. " +
                     "If ANY line_number is not a current embed-slot start, NOTHING is written. The procedure is opened, " +
                     "written, saved and closed automatically — do NOT wrap this in open_procedure_embed / " +
                     "save_and_close_embeditor.",

--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -24,6 +24,16 @@ namespace ClarionAssistant.Services
         public bool RequiresUiThread { get; set; }
 
         /// <summary>
+        /// Minimum seconds this tool needs on the UI thread before McpServer may abandon
+        /// the call as timed out. 0 (default) = take the server's configured budget.
+        /// Only set it where the handler's OWN internal waits already exceed that budget —
+        /// the embeditor round-trips, whose single native open waits up to 45s (see
+        /// <see cref="ModernEmbeditorLauncher"/>) — so the timeout stays a wedged-UI guard
+        /// everywhere else instead of becoming a blanket grace period.
+        /// </summary>
+        public int UiTimeoutSeconds { get; set; }
+
+        /// <summary>
         /// Optional long-running variant used when the MCP client supplied a
         /// progressToken (ticket 0d788f8b). Second argument is a progress callback
         /// (percent 0..100, message). ALWAYS invoked on a worker thread — even when
@@ -46,6 +56,15 @@ namespace ClarionAssistant.Services
         // Bounded relay queue: drop-when-full keeps a stalled SSE client from growing an
         // unbounded backlog while the UI thread keeps producing progress events.
         private const int StreamEventQueueCapacity = 256;
+
+        // UI-thread budget for the embeditor round-trips (McpTool.UiTimeoutSeconds). One
+        // native open alone waits up to 45s (ModernEmbeditorLauncher.WaitForEmbedOpen) and
+        // OpenAndMirror may retry it at a slower locator speed, on top of the mirror read,
+        // the slot writes and the save+close handshake — so these tools' own internal budget
+        // already exceeds the 30s server default and the old outer window could never let a
+        // large procedure (a ~3k-line generated UpdateNalog) finish. 180s covers that with
+        // headroom while still bounding a genuinely wedged UI.
+        private const int EmbedRoundTripTimeoutSeconds = 180;
 
         private readonly Dictionary<string, McpTool> _tools = new Dictionary<string, McpTool>(StringComparer.OrdinalIgnoreCase);
         private readonly EditorService _editorService;
@@ -114,6 +133,16 @@ namespace ClarionAssistant.Services
         {
             McpTool tool;
             return _tools.TryGetValue(toolName, out tool) && tool.RequiresUiThread;
+        }
+
+        /// <summary>
+        /// The tool's declared minimum UI-thread budget in seconds, or 0 when it takes the
+        /// server default. See <see cref="McpTool.UiTimeoutSeconds"/>.
+        /// </summary>
+        public int UiTimeoutSeconds(string toolName)
+        {
+            McpTool tool;
+            return _tools.TryGetValue(toolName, out tool) ? tool.UiTimeoutSeconds : 0;
         }
 
         public object ExecuteTool(string name, Dictionary<string, object> arguments)
@@ -640,6 +669,8 @@ Use this tool to discover IDE APIs and understand what's available for automatio
                     new Dictionary<string, string> { { "procedure_name", "Name of the procedure to open" } },
                     new[] { "procedure_name" }),
                 RequiresUiThread = true,
+                // Handler itself waits up to 45s for the open — see EmbedRoundTripTimeoutSeconds.
+                UiTimeoutSeconds = EmbedRoundTripTimeoutSeconds,
                 Handler = args =>
                 {
                     string name = McpJsonRpc.GetString(args, "procedure_name");
@@ -716,6 +747,9 @@ Use this tool to discover IDE APIs and understand what's available for automatio
                 Description = "Save changes and close the currently open embeditor. Use this when done editing embed code.",
                 InputSchema = McpJsonRpc.BuildSchema(new Dictionary<string, string>()),
                 RequiresUiThread = true,
+                // The native save regenerates the module; on a large procedure that outruns
+                // the 30s default — see EmbedRoundTripTimeoutSeconds.
+                UiTimeoutSeconds = EmbedRoundTripTimeoutSeconds,
                 Handler = args => _appTree.SaveAndCloseEmbeditor()
             });
 
@@ -1049,6 +1083,9 @@ Use this tool to discover IDE APIs and understand what's available for automatio
                                "line_number = 1-based «E:N» slot start; code = complete replacement for that slot." }
                 }, new[] { "procedure_name", "edits" }),
                 RequiresUiThread = true,
+                // Whole open->write->save->close round-trip on one UI-thread call — see
+                // EmbedRoundTripTimeoutSeconds.
+                UiTimeoutSeconds = EmbedRoundTripTimeoutSeconds,
                 Handler = args =>
                 {
                     string proc = McpJsonRpc.GetString(args, "procedure_name");
@@ -1164,6 +1201,9 @@ Use this tool to discover IDE APIs and understand what's available for automatio
                               "Run once with an .app open.",
                 InputSchema = McpJsonRpc.BuildSchema(new Dictionary<string, string>()),
                 RequiresUiThread = true,
+                // The cold ABC load is the slowest open of the session — see
+                // EmbedRoundTripTimeoutSeconds.
+                UiTimeoutSeconds = EmbedRoundTripTimeoutSeconds,
                 Handler = args => ModernEmbeditorLauncher.WarmupAbc()
             });
 

--- a/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorLauncher.cs
@@ -307,6 +307,63 @@ namespace ClarionAssistant.Services
         }
 
         /// <summary>
+        /// Adopt an ALREADY-OPEN embeditor when it is showing <paramref name="procName"/>, mirroring its live
+        /// buffer instead of demanding the caller close it first. A large procedure is exactly where a fresh
+        /// open is unreliable, so the developer-opened editor is often the only handle that worked — refusing
+        /// it makes the round-trip unusable in the case that needs it most.
+        ///
+        /// The identity check here is deliberately STRICTER than the post-open sanity check in
+        /// <see cref="OpenAndMirror"/>. That one only asks whether the name appears anywhere in the source,
+        /// which is sound after WE typed the name into the locator (a mis-select is the unlikely branch).
+        /// Here the editor was opened by someone else, so a bare mention could just as well be a CALL to the
+        /// target from an unrelated procedure. We therefore take the column-0 declaration via
+        /// <see cref="ProcNameFromSource"/> and require an exact name match.
+        ///
+        /// Returns true (with the mirror) only on an exact match. Returns false with <paramref name="error"/>
+        /// set when something else is open — the caller should surface that rather than open anything. Returns
+        /// false with <paramref name="error"/> null when NO embeditor is open, i.e. "carry on and open one".
+        /// Never closes, cancels or writes: a non-matching editor is left exactly as the developer left it.
+        /// UI thread only.
+        /// </summary>
+        internal static bool TryAdoptOpenEmbeditor(AppTreeService appTree, string procName,
+            out string source, out List<int[]> ranges, out string error)
+        {
+            source = null; ranges = null; error = null;
+            if (appTree == null || string.IsNullOrWhiteSpace(procName)) return false;
+
+            // Nothing open → not an error, just nothing to adopt.
+            try { if (appTree.GetEmbedInfo() == null) return false; }
+            catch { return false; }
+
+            string title, ferr, mirrored;
+            List<int[]> mirroredRanges;
+            if (!EmbeditorCompletionService.TryGetActiveEmbeditorSource(
+                    out title, out mirrored, out mirroredRanges, out ferr))
+            {
+                error = "An embeditor is open but its source could not be read (" + ferr +
+                        "); close it and try again.";
+                return false;
+            }
+
+            ICollection<string> knownProcs = null;
+            try { knownProcs = appTree.GetProcedureNames(); } catch { }
+
+            string openProc = ProcNameFromSource(mirrored, knownProcs);
+            if (string.IsNullOrEmpty(openProc) ||
+                !string.Equals(openProc, procName.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                error = "An embeditor is still open on '" +
+                        (string.IsNullOrEmpty(openProc) ? "an unidentified procedure" : openProc) +
+                        "', not '" + procName + "'; close it and try again.";
+                return false;
+            }
+
+            source = mirrored;
+            ranges = mirroredRanges;
+            return true;
+        }
+
+        /// <summary>
         /// Extract the authoritative procedure name from generated embed source (cardinal rule #7 — name from
         /// source, NEVER the temp pwee FileName/caption). MIRROR SCOPE IS SINGLE-PROC: the embeditor buffer is
         /// one procedure's assembled source (verified live — BrowseAuthors' buffer contained only its own

--- a/ClarionAssistant/Services/ModernEmbeditorSaver.cs
+++ b/ClarionAssistant/Services/ModernEmbeditorSaver.cs
@@ -228,9 +228,22 @@ namespace ClarionAssistant.Services
         /// path: OpenAndMirror -&gt; WriteEmbedContentByLine -&gt; SaveAndCloseEmbeditor -&gt; WaitForEmbedClosed).
         ///
         /// Each edit is (1-based «E:N» slot-start line, COMPLETE replacement code for that slot). Every line is
-        /// validated against the freshly-opened embed structure; if ANY line is not a current embed-slot start,
-        /// NOTHING is written (the embeditor is cancelled). Writes run bottom-to-top so earlier slots' line
-        /// numbers stay valid, verbatim (no re-indent — the caller supplies fully-indented code). UI thread only.
+        /// validated against the mirrored embed structure; if ANY line is not a current embed-slot start,
+        /// NOTHING is written. Writes run bottom-to-top so earlier slots' line numbers stay valid, verbatim
+        /// (no re-indent — the caller supplies fully-indented code). UI thread only.
+        ///
+        /// ADOPTION: when an embeditor is already open on this SAME procedure we write into it rather than
+        /// refuse (see <see cref="ModernEmbeditorLauncher.TryAdoptOpenEmbeditor"/>) — on a large procedure the
+        /// fresh open is the step that fails, so that editor is often the only working handle. Two consequences,
+        /// both deliberate:
+        /// <list type="bullet">
+        /// <item>the save still closes the tab, because <c>SaveAndCloseEmbeditor</c> is the only persist path the
+        /// IDE exposes;</item>
+        /// <item>an ADOPTED editor is never cancelled on a failure. Cancel would silently discard whatever the
+        /// developer had unsaved in that buffer, and since nothing is persisted on any failure path anyway, the
+        /// atomicity guarantee holds without it. We leave the buffer on screen and say so instead.</item>
+        /// </list>
+        /// An embeditor open on a DIFFERENT procedure is refused and left untouched.
         /// </summary>
         public static string ApplyLineEdits(string procName, IList<KeyValuePair<int, string>> edits, out bool ok)
         {
@@ -241,16 +254,49 @@ namespace ClarionAssistant.Services
                 return "Error: no edits supplied.";
 
             var appTree = new AppTreeService();
-            // Reliably re-open the correct procedure and mirror its current source + ranges; leaves the
-            // embeditor open for us to write into (same entry point the interactive save uses).
+
+            // Prefer an embeditor ALREADY open on this procedure over a fresh open. On a large procedure
+            // the fresh open is the fragile step, so the developer-opened editor is frequently the only
+            // handle that worked — refusing it (the old behaviour) made this tool unusable exactly where
+            // it is most needed, and closing their editor to satisfy the precondition throws away that
+            // handle. An editor open on a DIFFERENT procedure is still refused, and left untouched.
             string fsource, openErr;
             List<int[]> franges;
-            if (!ModernEmbeditorLauncher.OpenAndMirror(appTree, procName, out fsource, out franges, out openErr))
-                return "Apply aborted: " + openErr;
+            bool adopted = ModernEmbeditorLauncher.TryAdoptOpenEmbeditor(
+                appTree, procName, out fsource, out franges, out openErr);
+
+            if (!adopted)
+            {
+                // A non-null error means something else is open — say that, don't try to open over it.
+                if (!string.IsNullOrEmpty(openErr))
+                    return "Apply aborted: " + openErr;
+
+                // Nothing open: reliably open the correct procedure and mirror its current source +
+                // ranges; leaves the embeditor open for us to write into (same entry point the
+                // interactive save uses).
+                if (!ModernEmbeditorLauncher.OpenAndMirror(appTree, procName, out fsource, out franges, out openErr))
+                    return "Apply aborted: " + openErr;
+            }
+
+            // An editor WE opened is ours to cancel on failure; one we adopted is the developer's, and
+            // cancelling it would throw away their unsaved buffer. Nothing is persisted on any failure
+            // path either way, so skipping the cancel costs no atomicity.
+            Action cancelIfOurs = () =>
+            {
+                if (!adopted) { try { appTree.CancelEmbeditor(); } catch { } }
+            };
+            // Two adoption notes, because the two failure stages leave the buffer in different states.
+            string adoptedCleanNote = adopted
+                ? " Your open embeditor on '" + procName + "' is untouched and still open."
+                : "";
+            string adoptedDirtyNote = adopted
+                ? " NOTE: your open embeditor on '" + procName + "' now holds partially-written slots in its " +
+                  "BUFFER — nothing was saved, so undo or cancel it in the IDE rather than saving it."
+                : "";
 
             try
             {
-                // Valid write targets = the slot-START lines of the freshly-opened structure.
+                // Valid write targets = the slot-START lines of the mirrored structure.
                 var slotStarts = new HashSet<int>();
                 if (franges != null)
                     foreach (var r in franges)
@@ -261,9 +307,10 @@ namespace ClarionAssistant.Services
                 {
                     if (e.Key <= 0 || !slotStarts.Contains(e.Key))
                     {
-                        try { appTree.CancelEmbeditor(); } catch { }
+                        cancelIfOurs();
                         return "Apply aborted: line " + e.Key + " is not a current embed-slot start in '" +
-                               procName + "'. Re-read with get_embeditor_source and retry. Nothing was written.";
+                               procName + "'. Re-read with get_embeditor_source and retry. Nothing was written." +
+                               adoptedCleanNote;
                     }
                 }
 
@@ -278,8 +325,8 @@ namespace ClarionAssistant.Services
 
                 if (errors.Count > 0)
                 {
-                    try { appTree.CancelEmbeditor(); } catch { } // discard — persist nothing on partial failure
-                    return "Apply FAILED — nothing persisted:\r\n" + string.Join("\r\n", errors);
+                    cancelIfOurs(); // discard — persist nothing on partial failure
+                    return "Apply FAILED — nothing persisted:\r\n" + string.Join("\r\n", errors) + adoptedDirtyNote;
                 }
 
                 string saveRes = appTree.SaveAndCloseEmbeditor();
@@ -291,12 +338,16 @@ namespace ClarionAssistant.Services
                            "close it in the IDE before applying again.";
 
                 ok = true;
-                return "Applied " + edits.Count + " embed edit(s) to '" + procName + "'.";
+                return "Applied " + edits.Count + " embed edit(s) to '" + procName + "'." + (adopted
+                    ? " Adopted the embeditor you already had open on it; the save closed that tab (the IDE has " +
+                      "no save-without-close) — re-open it if you were still working there."
+                    : "");
             }
             catch (Exception ex)
             {
-                try { appTree.CancelEmbeditor(); } catch { }
-                return "Apply error: " + (ex.InnerException != null ? ex.InnerException.Message : ex.Message);
+                cancelIfOurs();
+                return "Apply error: " + (ex.InnerException != null ? ex.InnerException.Message : ex.Message) +
+                       adoptedDirtyNote;
             }
         }
 


### PR DESCRIPTION

### What goes wrong today

On a large procedure the MCP embeditor tools cannot complete — not because the IDE
is wedged, but because the outer timeout is smaller than the work the tools were
built to do.

Two independent causes, one symptom:

**1. The UI-thread budget was one fixed 30s const for every tool that marshals onto
the UI thread.** That is right for the prompt tools — read a line, list procedures —
but it was never a possible budget for an embeditor round-trip. A single native
embeditor open waits up to 45s on its own (`ModernEmbeditorLauncher.WaitForEmbedOpen`,
called straight from the `open_procedure_embed` handler), and `OpenAndMirror` may
retry that open at a slower locator speed after a 3s closed-wait. The inner budget
was already ~90s+ **by design**, so the outer 30s window could never let it finish.
The caller got `UI thread did not respond within 30s (busy or blocked)` while the IDE
was neither — it was doing exactly what it had been asked to do.

**2. `apply_embed_edits` refuses to run while any embeditor is open.** `ApplyLineEdits`
goes through `OpenAndMirror`, which aborts with *"An embeditor is still open; close it
and try again."* On a large procedure that is backwards. The fresh open is the fragile
step — it is the one that times out, mis-lands via the ClaList locator, or has to retry
at a slower typing speed — so a procedure the developer already has open is the one
handle known to have worked. Refusing it makes the transient round-trip unusable in
exactly the case it was written for, and closing that editor to satisfy the
precondition trades a working handle for a fragile one.

### Evidence

Observed on `UpdateNalog`, a ~3k generated-line ABC form procedure in an MPCoord app.
`open_procedure_embed` and `apply_embed_edits` each failed twice in a row with the 30s
message, and `apply_embed_edits` additionally refused to use the embeditor the developer
had opened by hand — the only handle that did work. The edits ended up being applied
manually from a markdown instruction file.

Worth stating plainly: **the atomicity guarantee held throughout.** The `.app` was
byte-identical after every failed attempt, so nothing was ever half-written. What was
broken was reachability, not safety.

### What this changes

**Two levers instead of one const** (`019e839`):

- `McpTool.UiTimeoutSeconds` — a per-tool **minimum**, `0` meaning "take the server
  default". Set to 180s on the four tools whose own internal waits exceed the default:
  `open_procedure_embed`, `apply_embed_edits`, `save_and_close_embeditor` and
  `warmup_abc` (the cold ABC load is the slowest open of the session). Everything else
  keeps 30s.
- `Mcp.UiToolTimeoutSeconds` in `settings.txt` — a per-install default for everything
  else, read through the `SettingsService` the server already holds.

`ResolveUiToolTimeoutSeconds` takes the **larger** of the two, so raising the global
setting still lifts the slow tools, while a tool that needs more than the default can
never silently lose it. The result is clamped to `[5, 600]`: below ~5s even a trivial
tool races its own marshal, and an unbounded value would reintroduce the hang the
timeout exists to prevent — so neither a typo nor a zero can disable the guard.

The blanket-grace-period alternative was deliberately not taken. The timeout's job is
to stop a wedged UI holding a worker and leaking the connection as `CLOSE_WAIT`; that
property is worth keeping for the other ~100 tools, so only the four tools that
provably need more get more. The timeout message now names the setting and its range,
because the old one told the caller the UI was "busy or blocked" when the real answer
was that the budget was too small — and gave no hint a budget existed.

**Adoption of an already-open embeditor** (`710f499`):

`TryAdoptOpenEmbeditor` mirrors the live buffer when the open procedure **is** the
target. Its identity check is deliberately **stricter** than the post-open sanity check
`OpenAndMirror` uses: `SourceMentionsProcedure` only asks whether the name appears
anywhere in the source, which is sound after *we* typed that name into the locator, but
here the editor was opened by someone else, so a bare mention could equally be a CALL to
the target from an unrelated procedure. Adoption takes the column-0 declaration through
`ProcNameFromSource` (validated against `App.ProcedureNames`) and requires an exact name
match. Anything that is not the target keeps the refusal — now naming the procedure
actually open — and is left untouched: no close, no cancel, no write.

Two consequences of adopting, both deliberate, both stated in the tool description and
the return text rather than left to be discovered:

- **The save still closes the tab.** `SaveAndCloseEmbeditor` is the only persist path
  `AppTreeService` exposes, so "save without closing" is not available to offer.
- **An adopted editor is never cancelled on failure.** Every failure path used to cancel
  to guarantee nothing is persisted, but on the developer's own buffer a cancel would
  silently discard their unsaved work. Nothing is persisted on those paths anyway —
  validation runs before the first write, and a partial write only exists in the buffer —
  so skipping the cancel costs no atomicity. The two stages leave different states and
  report differently: an aborted validation says the buffer is untouched; a partial write
  says the buffer now holds written slots and to undo rather than save.

With nothing open, behaviour is unchanged: `TryAdoptOpenEmbeditor` returns false with a
null error and `OpenAndMirror` runs as before.

### Testing

Stated plainly so the coverage is not overread:

- The failure this fixes was observed live and repeatedly on `UpdateNalog` — two
  consecutive 30s timeouts from `open_procedure_embed`, the same from
  `apply_embed_edits`, and the up-front refusal while the developer's own embeditor was
  open. The `.app` was verified byte-identical after each.
- The branch builds and was deployed locally as **5.7.1127** (that `Version.props` bump
  is a local test stamp and is *not* part of this branch).
- The knowledge tools on the companion branch were exercised against that same build.
- **The embed round-trip was not re-run against the fixed build** — the `UpdateNalog`
  edits that prompted this had already been applied by hand by then. The change is
  offered on the strength of the failure analysis, not on a green re-test, and the
  reachability path deserves a run before merge.

### Not in this PR

The knowledge-base retract/supersede work (`supersede_knowledge` / `remove_knowledge`)
is a separate branch and a separate PR — it came out of the same session because a
knowledge entry recording this bug turned out to be wrong and could not be retired, but
it shares no code with this change.
