### PR TITLE
feat(knowledge): let a wrong entry be retired instead of contradicted

### DIFF
--- a/ClarionAssistant/Services/KnowledgeService.cs
+++ b/ClarionAssistant/Services/KnowledgeService.cs
@@ -160,6 +160,85 @@ namespace ClarionAssistant.Services
             return results;
         }
 
+        /// <summary>
+        /// Fetch one entry by id REGARDLESS of its superseded state, or null when there is no such
+        /// row. Deliberately unfiltered: the retract/supersede tools need to name an entry they are
+        /// about to hide, and to re-point one that is already hidden.
+        /// </summary>
+        public KnowledgeEntry GetEntry(int id)
+        {
+            const string sql = @"SELECT id, category, title, content, tags, confidence, last_referenced, reference_count, created_at
+                                 FROM knowledge_entries WHERE id = @id";
+            using (var cmd = new SQLiteCommand(sql, _conn))
+            {
+                cmd.Parameters.AddWithValue("@id", id);
+                using (var reader = cmd.ExecuteReader())
+                    return reader.Read() ? ReadEntry(reader) : null;
+            }
+        }
+
+        /// <summary>
+        /// Hide an entry that turned out to be wrong, so it stops surfacing in query_knowledge and in
+        /// the startup injection, without destroying the record of what was once believed.
+        ///
+        /// Both read paths already filter <c>superseded_by IS NULL</c> (see <see cref="Search"/> and
+        /// <see cref="GetDecayRanked"/>), so writing ANY non-null value is enough to retire a row —
+        /// this method just gives that column a way to be set. <paramref name="supersededBy"/> is the
+        /// id of the entry that replaces it, or <see cref="RetractedNoReplacement"/> (0) for a plain
+        /// retraction: 0 is never a valid rowid, so it reads unambiguously as "retired, nothing took
+        /// its place".
+        ///
+        /// The FTS row is left in place — the join filters it out — so an entry can be un-retired
+        /// later by clearing the column, and the id keeps meaning what it always meant.
+        /// Returns false when there is no such entry.
+        /// </summary>
+        public bool SupersedeEntry(int id, int supersededBy)
+        {
+            const string sql = "UPDATE knowledge_entries SET superseded_by = @by, updated_at = datetime('now') WHERE id = @id";
+            using (var cmd = new SQLiteCommand(sql, _conn))
+            {
+                cmd.Parameters.AddWithValue("@by", supersededBy);
+                cmd.Parameters.AddWithValue("@id", id);
+                return cmd.ExecuteNonQuery() > 0;
+            }
+        }
+
+        /// <summary>Value written to <c>superseded_by</c> for a retraction with no replacement entry.</summary>
+        public const int RetractedNoReplacement = 0;
+
+        /// <summary>
+        /// Permanently delete an entry and its FTS row. The FTS table is standalone (no content-sync
+        /// triggers), so both halves must be removed here or the search index keeps matching a row
+        /// the join can no longer resolve. Prefer <see cref="SupersedeEntry"/> unless the entry should
+        /// leave no trace. Returns false when there is no such entry.
+        /// </summary>
+        public bool DeleteEntry(int id)
+        {
+            using (var tx = _conn.BeginTransaction())
+            {
+                try
+                {
+                    int rows;
+                    using (var cmd = new SQLiteCommand("DELETE FROM knowledge_entries WHERE id = @id", _conn))
+                    {
+                        cmd.Parameters.AddWithValue("@id", id);
+                        rows = cmd.ExecuteNonQuery();
+                    }
+
+                    using (var cmd = new SQLiteCommand("DELETE FROM knowledge_fts WHERE entry_id = @id", _conn))
+                    {
+                        // entry_id is TEXT in the FTS table (see CreateTables) — match how AddEntry wrote it.
+                        cmd.Parameters.AddWithValue("@id", id.ToString());
+                        cmd.ExecuteNonQuery();
+                    }
+
+                    tx.Commit();
+                    return rows > 0;
+                }
+                catch { tx.Rollback(); throw; }
+            }
+        }
+
         // ── Attention Decay ─────────────────────────────────
 
         public List<KnowledgeEntry> GetDecayRanked(int limit = 15)
@@ -213,6 +292,8 @@ namespace ClarionAssistant.Services
         /// <summary>
         /// Returns pre-formatted markdown for context injection.
         /// Top 10 get full content preview, next 5 get title-only.
+        /// Each line carries its entry id: this is the surface where a stale or wrong entry is
+        /// actually noticed, so it is also where the id needed to retire it has to be visible.
         /// </summary>
         public string GetInjectionMarkdown(int limit = 15)
         {
@@ -232,7 +313,7 @@ namespace ClarionAssistant.Services
                 string preview = e.Content != null && e.Content.Length > 200
                     ? e.Content.Substring(0, 200) + "..."
                     : e.Content ?? "";
-                sb.AppendLine("- **[" + e.Category + "] " + e.Title + "**: " + preview);
+                sb.AppendLine("- **#" + e.Id + " [" + e.Category + "] " + e.Title + "**: " + preview);
             }
 
             if (entries.Count > fullCount)
@@ -240,7 +321,7 @@ namespace ClarionAssistant.Services
                 sb.AppendLine();
                 sb.AppendLine("_Also available (use query_knowledge for details):_");
                 for (int i = fullCount; i < entries.Count; i++)
-                    sb.AppendLine("- [" + entries[i].Category + "] " + entries[i].Title);
+                    sb.AppendLine("- #" + entries[i].Id + " [" + entries[i].Category + "] " + entries[i].Title);
             }
 
             return sb.ToString();

--- a/ClarionAssistant/Services/McpToolRegistry.cs
+++ b/ClarionAssistant/Services/McpToolRegistry.cs
@@ -3084,7 +3084,7 @@ Rebuilds both the bundled and the personal DocGraph DBs when both exist.",
             Register(new McpTool
             {
                 Name = "add_knowledge",
-                Description = "Save a reusable insight to the Clarion Assistant's knowledge base. Categories: decision, pattern, gotcha, anti_pattern, debug_insight, preference. Knowledge persists across sessions and is auto-injected at startup ranked by usage.",
+                Description = "Save a reusable insight to the Clarion Assistant's knowledge base. Categories: decision, pattern, gotcha, anti_pattern, debug_insight, preference. Knowledge persists across sessions and is auto-injected at startup ranked by usage. Returns the new entry's id; if this entry corrects an earlier one, pass that id to supersede_knowledge so the wrong one stops being injected.",
                 InputSchema = McpJsonRpc.BuildSchema(
                     new Dictionary<string, string>
                     {
@@ -3113,7 +3113,9 @@ Rebuilds both the bundled and the personal DocGraph DBs when both exist.",
             Register(new McpTool
             {
                 Name = "query_knowledge",
-                Description = "Search the Clarion Assistant's knowledge base for decisions, patterns, gotchas, and insights. Uses full-text search. Returns matching entries ranked by relevance.",
+                Description = "Search the Clarion Assistant's knowledge base for decisions, patterns, gotchas, and insights. " +
+                              "Uses full-text search. Returns matching entries ranked by relevance, each prefixed with its " +
+                              "id — pass that id to supersede_knowledge or remove_knowledge when an entry turns out to be wrong.",
                 InputSchema = McpJsonRpc.BuildSchema(
                     new Dictionary<string, string>
                     {
@@ -3139,12 +3141,100 @@ Rebuilds both the bundled and the personal DocGraph DBs when both exist.",
                     {
                         string preview = e.Content != null && e.Content.Length > 300
                             ? e.Content.Substring(0, 300) + "..." : e.Content ?? "";
-                        sb.AppendLine(string.Format("- [{0}] {1}", e.Category, e.Title));
+                        // The id leads the line because it is the only handle the retract/supersede
+                        // tools accept — without it a caller can read that an entry is wrong and
+                        // still have no way to name it.
+                        sb.AppendLine(string.Format("- #{0} [{1}] {2}", e.Id, e.Category, e.Title));
                         sb.AppendLine("  " + preview);
                         if (e.Tags != null) sb.AppendLine("  Tags: " + e.Tags);
                         sb.AppendLine();
                     }
                     return sb.ToString().TrimEnd();
+                }
+            });
+
+            Register(new McpTool
+            {
+                Name = "supersede_knowledge",
+                Description = "Retire a knowledge entry that turned out to be WRONG so it stops surfacing in " +
+                              "query_knowledge and in the startup injection. Get the id from query_knowledge. " +
+                              "Pass superseded_by with the id of the entry that replaces it (add_knowledge returns " +
+                              "the new id) to record the correction, or omit it for a plain retraction. The row is " +
+                              "kept, not deleted, so the record of what was once believed survives — prefer this " +
+                              "over remove_knowledge. Without it a wrong entry can only be contradicted by a newer " +
+                              "one and both keep being injected, leaving the reader to work out which is current.",
+                InputSchema = McpJsonRpc.BuildSchema(
+                    new Dictionary<string, string>
+                    {
+                        { "id", "Id of the entry to retire, as shown by query_knowledge (required)" },
+                        { "superseded_by", "Id of the entry that replaces it (optional; omit for a plain retraction)" }
+                    },
+                    new[] { "id" }),
+                RequiresUiThread = false,
+                Handler = args =>
+                {
+                    if (_knowledgeService == null) return "Knowledge service not initialized.";
+                    int id = McpJsonRpc.GetInt(args, "id", 0);
+                    if (id <= 0) return "Error: id is required and must be > 0.";
+
+                    var entry = _knowledgeService.GetEntry(id);
+                    if (entry == null) return string.Format("No knowledge entry with id {0}.", id);
+
+                    int by = McpJsonRpc.GetInt(args, "superseded_by", KnowledgeService.RetractedNoReplacement);
+                    if (by == id)
+                        return "Error: an entry cannot supersede itself. Omit superseded_by to retract it outright.";
+                    if (by != KnowledgeService.RetractedNoReplacement)
+                    {
+                        // Validate the replacement exists: pointing at a missing id would hide the old
+                        // entry behind a reference that leads nowhere, which is worse than leaving it.
+                        var replacement = _knowledgeService.GetEntry(by);
+                        if (replacement == null)
+                            return string.Format(
+                                "No knowledge entry with id {0} to supersede #{1} with. Add the corrected entry " +
+                                "first, then pass its id.", by, id);
+                    }
+
+                    if (!_knowledgeService.SupersedeEntry(id, by))
+                        return string.Format("Could not retire entry #{0}.", id);
+
+                    return by == KnowledgeService.RetractedNoReplacement
+                        ? string.Format("Retired #{0} [{1}] {2} — it will no longer be returned or injected.",
+                            id, entry.Category, entry.Title)
+                        : string.Format("Retired #{0} [{1}] {2}, superseded by #{3}.",
+                            id, entry.Category, entry.Title, by);
+                }
+            });
+
+            Register(new McpTool
+            {
+                Name = "remove_knowledge",
+                Description = "PERMANENTLY delete a knowledge entry and its search-index row. Get the id from " +
+                              "query_knowledge. Use this only for entries that should leave no trace (a duplicate, " +
+                              "something saved by mistake, anything that shouldn't have been recorded); to retire an " +
+                              "entry that was simply wrong, use supersede_knowledge instead so the correction stays " +
+                              "on the record. Cannot be undone.",
+                InputSchema = McpJsonRpc.BuildSchema(
+                    new Dictionary<string, string>
+                    {
+                        { "id", "Id of the entry to delete, as shown by query_knowledge (required)" }
+                    },
+                    new[] { "id" }),
+                RequiresUiThread = false,
+                Handler = args =>
+                {
+                    if (_knowledgeService == null) return "Knowledge service not initialized.";
+                    int id = McpJsonRpc.GetInt(args, "id", 0);
+                    if (id <= 0) return "Error: id is required and must be > 0.";
+
+                    // Read it first so the response can name what was destroyed — a deletion the caller
+                    // can't see the title of is a deletion they can't tell was the wrong one.
+                    var entry = _knowledgeService.GetEntry(id);
+                    if (entry == null) return string.Format("No knowledge entry with id {0}.", id);
+
+                    if (!_knowledgeService.DeleteEntry(id))
+                        return string.Format("Could not delete entry #{0}.", id);
+
+                    return string.Format("Deleted #{0} [{1}] {2}.", id, entry.Category, entry.Title);
                 }
             });
 


### PR DESCRIPTION
### What goes wrong today

The knowledge base can only ever grow. `add_knowledge` writes an entry, the top of the
decay ranking is injected into every new session, and there is no way to say *"that one
is wrong"*. A correction can only be added as a **second** entry, so both keep being
injected and the reader has to work out which is current — and will only manage it if
they happen to read both.

The failure is not theoretical. An entry recorded as an OPEN BUG stayed in the injection
after the bug was found and fixed, asserting the opposite of the truth to every session
that started afterwards, while the correcting entry sat right next to it.

### What this changes

The schema was already most of the way there. `knowledge_entries` has had a
`superseded_by` column all along and **both read paths already filter on it** —
`Search`'s join and `GetDecayRanked`, which feeds the startup injection — so a retired
entry would have disappeared from search and injection alike. Nothing ever set the
column. The `CreateTables` comment likewise says the standalone FTS table is "populated
explicitly in AddEntry/DeleteEntry", and `DeleteEntry` was never written. This wires up
what the schema already anticipated.

**`supersede_knowledge(id, superseded_by?)`** sets that column: the replacement's id when
there is one, or `0` for a plain retraction (`0` is never a valid rowid, so it reads
unambiguously as "retired, nothing took its place"). The row survives, so the record of
what was once believed survives with it, and the column can be cleared to un-retire an
entry. The replacement id is validated first — pointing at a missing entry would hide the
old one behind a reference that leads nowhere, which is worse than leaving it alone — and
self-supersession is rejected with a pointer to the plain-retraction form.

**`remove_knowledge(id)`** is the harder tool, for entries that should leave no trace: a
duplicate, something saved by mistake. It deletes the FTS row in the same transaction,
because the FTS table is standalone with no content-sync triggers, so deleting only the
entry would leave the index matching a row the join can no longer resolve. Its
description points at `supersede_knowledge` as the default.

Both need an id the caller can actually obtain, and neither surface printed one:
`query_knowledge` listed `[category] title` and the injection markdown did the same. Both
now lead with `#id`. The injection is where a stale entry is actually noticed, which makes
it the one place the handle for retiring it has to be visible. `add_knowledge`'s
description now also points at `supersede_knowledge` for the correct-an-earlier-entry
case, since it already returns the new id.

No migration: any database old enough to lack `superseded_by` would already be throwing on
every `query_knowledge`, since `Search` has always referenced it.

### Testing

Built and deployed locally as 5.7.1127 and exercised end to end from a live session:

- `supersede_knowledge` with a replacement id — the retired entry stopped appearing in
  `query_knowledge`, the replacement kept appearing.
- `supersede_knowledge` with a **bad** `superseded_by` — fails closed, entry left alone.
- `remove_knowledge` — entry gone from both the table and FTS.
- `query_knowledge` and `add_knowledge` — ids now visible in the output.

The startup-injection path was not separately re-verified; it shares the
`GetDecayRanked` filter with search, which was.

### Relationship to the other PR

This came out of the same session as the embeditor-reachability PR — the entry that could
not be retired was the one recording that bug — but the two share no code and can be
reviewed and merged independently.
