### PR TITLE
fix(instance-coord): treat a hung-but-not-exited Clarion.exe as dead too

### DIFF
--- a/ClarionAssistant/Services/InstanceCoordinationService.cs
+++ b/ClarionAssistant/Services/InstanceCoordinationService.cs
@@ -187,7 +187,9 @@ namespace ClarionAssistant.Services
             {
                 using (var conn = OpenConnection())
                 {
-                    // Remove entries for processes that are no longer running
+                    // PASS 1 — timestamp-stale rows (no heartbeat in StaleSeconds). Existence alone is enough
+                    // here: a heartbeat that stopped this long ago means the owner either exited or is hung
+                    // badly enough that its own 10s timer no longer fires.
                     var stalePids = new List<int>();
                     using (var cmd = new SQLiteCommand(
                         "SELECT pid FROM instances WHERE heartbeat_at < datetime('now', '-' || @sec || ' seconds')", conn))
@@ -199,26 +201,54 @@ namespace ClarionAssistant.Services
                     }
 
                     foreach (int pid in stalePids)
-                    {
-                        // Double-check the process is actually dead
-                        bool alive = false;
-                        try { alive = Process.GetProcessById(pid) != null; }
-                        catch { /* process doesn't exist */ }
+                        if (!IsAliveAndResponding(pid)) DeleteInstance(conn, pid);
 
-                        if (!alive)
-                        {
-                            using (var cmd = new SQLiteCommand("DELETE FROM instances WHERE pid = @pid", conn))
-                            {
-                                cmd.Parameters.AddWithValue("@pid", pid);
-                                cmd.ExecuteNonQuery();
-                            }
-                        }
+                    // PASS 2 — GH #179 (2026-08-29 report): a Clarion.exe left hung inside a native modal can
+                    // keep pumping just enough of its own message loop for its WinForms heartbeat Timer to
+                    // keep firing, so its row NEVER goes stale by timestamp alone — it squats as a permanently
+                    // "live" peer, and every subsequent CheckProcedureConflict/GetPeers call from ANY instance
+                    // collides with a zombie that will never release anything, until the process is killed
+                    // (the user needed a full reboot). Sweep the fresh rows too: Process.Responding is cheap
+                    // for a genuinely responsive window and bounded even for a hung one (SendMessageTimeout).
+                    var freshPids = new List<int>();
+                    using (var cmd = new SQLiteCommand(
+                        "SELECT pid FROM instances WHERE pid != @pid AND heartbeat_at >= datetime('now', '-' || @sec || ' seconds')", conn))
+                    {
+                        cmd.Parameters.AddWithValue("@pid", _pid);
+                        cmd.Parameters.AddWithValue("@sec", StaleSeconds);
+                        using (var reader = cmd.ExecuteReader())
+                            while (reader.Read())
+                                freshPids.Add(reader.GetInt32(0));
                     }
+
+                    foreach (int pid in freshPids)
+                        if (!IsAliveAndResponding(pid)) DeleteInstance(conn, pid);
                 }
             }
             catch (Exception ex)
             {
                 Debug.WriteLine("[InstanceCoord] Cleanup error: " + ex.Message);
+            }
+        }
+
+        /// <summary>True only when a process with this PID exists AND its UI is answering — existence alone
+        /// (the old check) is also true for a hung-but-not-exited zombie.</summary>
+        private static bool IsAliveAndResponding(int pid)
+        {
+            try
+            {
+                using (var p = Process.GetProcessById(pid))
+                    return p.Responding;
+            }
+            catch { return false; }
+        }
+
+        private static void DeleteInstance(SQLiteConnection conn, int pid)
+        {
+            using (var cmd = new SQLiteCommand("DELETE FROM instances WHERE pid = @pid", conn))
+            {
+                cmd.Parameters.AddWithValue("@pid", pid);
+                cmd.ExecuteNonQuery();
             }
         }
 


### PR DESCRIPTION
## Summary
- `InstanceCoordinationService.CleanupStale()` only checked `Process.GetProcessById(pid) != null` to decide whether a peer instance's row should be reaped — that's true for a hung-but-not-exited (zombie) `Clarion.exe` just as much as a healthy one, so a zombie's row in the shared `instances.db` can squat forever as a "live" peer.
- Reported against #179: after a hang like the ones tracked there, the reporter found every subsequent attempt at the same operation failing — in the same or a new Clarion session — until they found a `Clarion.exe` still loaded but completely unresponsive (couldn't be closed; needed a full reboot). After the reboot, the failures stopped. See the two comments on #179 for the full writeup and a screenshot of the zombie process (64 KB working set, `N/A` CPU — a husk of a process still holding a PID).
- If the zombie's message loop still pumps enough to keep its own heartbeat `Timer` firing (e.g. stuck inside a native modal rather than a hard deadlock), its row doesn't even go stale by timestamp, so the existing timestamp-based cleanup never gets a chance to run the (already-wrong) liveness check on it at all.

## Changes
- Added `IsAliveAndResponding(pid)`: existence **and** `Process.Responding` (cheap for a healthy window, bounded even for a hung one via `SendMessageTimeout`).
- `CleanupStale()` now runs two passes: the existing timestamp-stale sweep (existence check upgraded to the new helper), plus a second sweep over heartbeat-*fresh* rows so a zombie whose timer keeps ticking still gets reaped instead of only ones that already went stale by timestamp.
- No change to the public API or the hot read paths (`GetPeers`/`CheckProcedureConflict`) — the extra check is concentrated in the periodic (10s) cleanup pass, not per-query.

## Test plan
- [x] Builds clean (Debug/ClarionVersion=11)
- [x] Deployed locally and running against a real Clarion 11 install
- [ ] Reporter will confirm over normal use whether this actually prevents the "every attempt fails until reboot" cascade the next time a hang occurs (can't force-reproduce the underlying hang on demand)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>