### PR TITLE
fix(deploy): skip the drive-root scan once registry/fallbacks already found a root

### DIFF
--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -116,8 +116,13 @@ function Resolve-ClarionRoots {
     foreach ($p in $Fallbacks) { Add-Root $p }
 
     if ($found.Count -eq 0) {
-        $drives = (Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
-                    Where-Object { Test-Path $_.Root }).Root
+        # Fixed local drives only. A Clarion install that's neither registered (registry) nor
+        # at a known path (Fallbacks) and lives ONLY on a network share isn't a realistic case —
+        # COM registration and templates need a local, registered install to actually work — and
+        # network shares are what makes this scan slow (SMB round-trips per drive per pattern).
+        $drives = [System.IO.DriveInfo]::GetDrives() |
+                    Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } |
+                    ForEach-Object { $_.RootDirectory.FullName }
         foreach ($drive in $drives) {
             foreach ($pattern in $GlobPatterns) {
                 Get-ChildItem -Path $drive -Directory -Filter $pattern -ErrorAction SilentlyContinue |

--- a/ClarionAssistant/deploy.ps1
+++ b/ClarionAssistant/deploy.ps1
@@ -73,6 +73,15 @@ $Versions = @{
 # addin — the developer ran the old indexer for a day while every verification pass showed
 # the new build "deployed and hash-verified" (in the four folders the script chose). A
 # machine with two installs of one version must get the addin in BOTH.
+#
+# The drive-root glob scan is the slow part — it walks every mounted filesystem drive
+# (including network shares) for every glob pattern. It only exists to catch an install at
+# a path NOT already covered by the registry or the known Fallbacks list — and the
+# 2026-08-13 incident itself was already covered by Fallbacks (C:\Clarion11-13372 is right
+# there in $Versions). So once registry+fallbacks have found at least one root, the scan is
+# redundant for the common case (an installed, registered Clarion) and was regressing every
+# `-Version all` deploy into an unconditional full-machine scan per version before any
+# output appeared. Only fall through to the scan when nothing was found yet.
 function Resolve-ClarionRoots {
     param(
         [string[]]$RegistryKeys,
@@ -106,12 +115,14 @@ function Resolve-ClarionRoots {
 
     foreach ($p in $Fallbacks) { Add-Root $p }
 
-    $drives = (Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
-                Where-Object { Test-Path $_.Root }).Root
-    foreach ($drive in $drives) {
-        foreach ($pattern in $GlobPatterns) {
-            Get-ChildItem -Path $drive -Directory -Filter $pattern -ErrorAction SilentlyContinue |
-                ForEach-Object { Add-Root $_.FullName }
+    if ($found.Count -eq 0) {
+        $drives = (Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue |
+                    Where-Object { Test-Path $_.Root }).Root
+        foreach ($drive in $drives) {
+            foreach ($pattern in $GlobPatterns) {
+                Get-ChildItem -Path $drive -Directory -Filter $pattern -ErrorAction SilentlyContinue |
+                    ForEach-Object { Add-Root $_.FullName }
+            }
         }
     }
 


### PR DESCRIPTION
6a737db (deploy to ALL live installs, not just the first hit) dropped the early return from Resolve-ClarionRoots, so it now unconditionally walks every mounted filesystem drive (network shares included) for every glob pattern of every Clarion version being deployed, even when the registry already resolved the install. On a machine with several mapped drives this turned `-Version all` into a multi-minute pause before deploy.ps1 prints anything at all — measured at ~21s per version when nothing is found, vs 11ms when a fallback already hit.

The incident 6a737db fixed (C:\Clarion11-13372 going stale) was already covered by the Fallbacks list, not the drive scan — so the scan only needs to run when registry+fallbacks found nothing, same as before that commit. This keeps the "collect every root" behavior for whatever a scan does turn up, but restores the short-circuit for the common case of a normally registered install.