### PR TITLE
fix(focus): Buttons on godegraph indexer window did not work

### DIFF
--- a/ClarionAssistant/Services/EditorFocusGuard.cs
+++ b/ClarionAssistant/Services/EditorFocusGuard.cs
@@ -43,6 +43,21 @@ namespace ClarionAssistant.Services
                 if (h == IntPtr.Zero) return false;                  // nobody focused — claim freely
                 var focused = Control.FromChildHandle(h);
                 if (focused == null) return false;                   // pure-native hwnd — cannot classify
+
+                // Focus in a different top-level window entirely (an owned modeless dialog such
+                // as IndexProgressForm, or any future one) is unambiguously foreign — stealing it
+                // back breaks that window's own controls the same way a docked pad used to go
+                // deaf (GH #140). The type-name walk below only ever recognized DockPanel pads,
+                // so a plain owned Form fell through to "unclassified — claim anyway" and lost
+                // every click to this hook re-firing on WindowSelected.
+                var oursForm = ours.FindForm();
+                var focusedForm = focused.FindForm();
+                if (oursForm != null && focusedForm != null && !ReferenceEquals(oursForm, focusedForm))
+                {
+                    MonacoSpikeLog.Write("focus-guard: stand down — focus in foreign top-level window " + focusedForm.GetType().FullName);
+                    return true;
+                }
+
                 string chain = null;
                 for (var node = focused; node != null; node = node.Parent)
                 {


### PR DESCRIPTION
## Summary

`EditorFocusGuard.FocusInForeignPad` (GH #140's focus-steal guard) only recognized DockPanel *pad* types (`PadContentWrapper` / `AutoHide` / `DockPane`) as surfaces the Monaco tab-select hook must not steal keyboard focus from. A plain **owned modeless `Form`** living entirely outside the DockPanel — for example the CodeGraph re-index results window (`IndexProgressForm`) — isn't any of those types, so it fell through the ancestor-type walk unclassified and hit the guard's "unclassified → claim anyway" default.

Symptom: after a CodeGraph re-index finished, all three buttons on the results window (Close / Copy Summary / Open Log) appeared completely unresponsive — a faint redraw flash on click, then nothing. Only the titlebar `X` actually closed the window.

## Root cause

`MonacoClarionSourceEditor.OnWorkbenchWindowSelected` re-claims Win32 focus into the Monaco editor whenever `WindowSelected` fires (the fork re-fires this event liberally — "one claim per click" per the existing doc comments on the guard). It's supposed to stand down when the user's focus is legitimately in a foreign IDE surface, but `FocusInForeignPad`'s classification only ever walked the control's ancestor chain looking for known pad-wrapper type names. `IndexProgressForm` has no such ancestor — it's a separate top-level window owned by the main IDE Form, not a docked pad — so the guard claimed focus back into Monaco on every click, before the click could reach the button underneath it.

## Fix

Added a check at the top of `FocusInForeignPad`, before the existing pad-type-name walk: compare the currently-focused control's top-level `Form` (`Control.FindForm()`) against the claiming control's own top-level `Form`. Any mismatch means focus is in a completely different top-level window — unambiguously foreign — and the guard stands down immediately.

This is a general fix rather than a one-off allowlist entry for `IndexProgressForm`: it protects any current or future owned modeless dialog the same way, with no per-type-name maintenance needed.

## Verification

Live-tested against the running IDE (Clarion 11) across the three realistic trigger paths for `WindowSelected`:
- Normal re-index completion → Close button works
- Cancel mid-run → Close button works
- Switching between source tabs while an index is running — progress window stays on top throughout, no focus steal, Close still works afterward

All three confirmed clean after the fix; before the fix, the first scenario reproduced the unresponsive-buttons symptom consistently.
